### PR TITLE
fix broken link to glossary #257

### DIFF
--- a/base/templates/base/discussion.html
+++ b/base/templates/base/discussion.html
@@ -6,8 +6,8 @@
 <ul>
 	<h3>Discussion</h3> <br/>
   	<li>The OpenEnergy Platform is a collaborative project and is continuously under development. The discussion about new features or improvements is carried on at <a href="https://github.com/openego/oeplatform/issues" target="_blank">GitHub</a>! (Please don’t forget to set tags if you create a new issue.)</li>
-	<li>If you want to report problems or if you have questions according to this website, please use the <a href="http://oep.iks.cs.ovgu.de/contact/" target="_blank">contact</a> form.</li>
-	<li>Transparency of energy system modelling and fruitful debates about it are very much depending on a common understanding of expressions. Therefore we started a <a href="http://href=">glossary</a>. You can watch up; debate and add expressions.</li>
+	<li>If you want to report problems or if you have questions according to this website, please use the <a href="https://openenergy-platform.org/contact/" target="_blank">contact</a> form.</li>
+	<li>Transparency of energy system modelling and fruitful debates about it are very much depending on a common understanding of expressions. Therefore we started a <a href="https://wiki.openmod-initiative.org/wiki/Category:Glossary" target="_blank">glossary</a>. You can watch up; debate and add expressions.</li>
 	<li>At the <a href="https://forum.openmod-initiative.org/" target="_blank">discussion forum</a> of the openmod initiative you can discuss about various subjects concerning open science in energy system modelling.</li>
 </ul>
 {% endblock %}


### PR DESCRIPTION
fixed broken link to glossary
corrected link to contact to include new url of platform