### PR TITLE
Update README for first-time installs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
   - psql -U postgres -c "CREATE EXTENSION postgis;" test
   - psql -U postgres -c "CREATE DATABASE oedb"
   - psql -U postgres -c "CREATE EXTENSION postgis;" oedb
-  - psql -U postgres -c "CREATE DATABASE django"
+  - psql -U postgres -c "CREATE DATABASE oep_django"
   - pip install -r requirements.txt
   - cp oeplatform/securitysettings.py.default oeplatform/securitysettings.py
   - python manage.py migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
-    - OEP_DB_USER="postgres" OEP_DB_PW="postgres" OEDB_USER="postgres" OEPB_PW="postgres"
+    - OEP_DB_USER="postgres" OEP_DB_PW="postgres" LOCAL_DB_USER="postgres" LOCAL_DB_PW="postgres"
   matrix:
     - TOXENV=check
     - TOXENV=docs

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Next step is to migrate the database schema from django to your django database:
 
 
     
-#### 2. Another Database
+#### 2. OEDB-like Database
 
-The second database connection should point to another postgresql database. It is used for the data input functionality implemented in dataedit/. This database corresponds to the OEDB in the live version.
+This database corresponds to the OEDB (OpenEnergyDataBase) in the live version.
+The database connection should point to another *local* postgresql database. 
+It is used for the data input functionality implemented in `dataedit/`.
 
     dbuser = ""
     dbpasswd = ""
@@ -76,25 +78,30 @@ Once logged into your psql session (for example `sudo -u postgres psql`), run th
     create user oep_db_user with password '<oep_db_password>';
     create database oep_db with owner = oep_db_user;
 
+Then enter in `oep_db` (`\c oep_db;`) and type the additional commands:
+
+    create extension postgis;
+    create extension postgis_topology;
+    create extension hstore;
+
 ##### 2.2 Django setup
 
-These are all available as environment variables
+The values of the following variables matched to environment variables' values:
 
 | variable | environment variable  | required |
-|--------|---|----|
-| dbuser | LOCAL_OEDB_USER  |yes|
-| dbpasswd | LOCAL_OEDB_PASSWORD  |yes|
-|   dbport     | LOCAL_OEDB_PORT  |no|
-|   dbhost     | LOCAL_OEDB_HOST  |no|
-|   dbname     | LOCAL_OEDB_NAME  |no|
+|---|---|---|
+| dbuser | LOCAL_DB_USER  |yes|
+| dbpasswd | LOCAL_DB_PASSWORD |yes|
+| dbport | LOCAL_DB_PORT |no|
+| dbhost | LOCAL_DB_HOST |no|
+| dbname | LOCAL_DB_NAME |no|
 
-dbuser = os.environ.get("LOCAL_OEDB_USER")
-dbpasswd = os.environ.get("LOCAL_OEDB_PASSWORD")
-dbport = os.environ.get("LOCAL_OEDB_PORT", 5432)
-dbhost = os.environ.get("LOCAL_OEDB_HOST", "localhost")
-dbname = os.environ.get("LOCAL_OEDB_NAME", "oedb")
+Make sure to set the required environment variable before performing the next step!
 
-To create all tables that are needed in the second database:
+If you kept the default name from the above example in 2.1, then the environment variables
+`LOCAL_DB_USER` and `LOCAL_DB_NAME` should have the values `oep_db_user` and `oep_db`, respectively
+
+Finally, to create all tables that are needed in the oedb-like database:
 
     python manage.py alembic upgrade head
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Create a file oeplatform/securitysettings.py by omitting the '.default' suffix o
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': 'django',
-    	'USER': 'databaseuser',
-    	'PASSWORD': 'databasepassword',
+            'NAME': 'oep_django',
+    	'USER': 'oep_django_user',
+    	'PASSWORD': '<oep_django_password>',
     	'HOST': 'localhost'                      
     	}
     }

--- a/README.md
+++ b/README.md
@@ -122,15 +122,6 @@ least one should be present if you want to use this app:
 * openstreetmap
 * reference
 
-
-
-#### (Optional) 3. Testing Database
-
-You have may to include a third database, which is used for automated testing.
-This database shouldn't include productive data. The creation of the database
-will be managed by django automatically.
-
-
   
 Finally, you can run your local copy of this platform:
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ least one should be present if you want to use this app:
 * openstreetmap
 * reference
 
+### Deploy locally
   
-Finally, you can run your local copy of this platform:
+You can run your local copy of this platform with:
 
     python manage.py runserver
     

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ contains data that will be displayed in the data visualisations on the oedb.
 
 #### 1. Django internal database
 
+##### 1.1 Posgresql command line setup
+
+Once logged into your psql session (for example `sudo -u postgres psql`), run the following lines:
+
+    create user oep_django_user with password '<oep_django_password>';
+    create database oep_django with owner = oep_django_user;
+
+##### 1.2 Django setup
+
 Create a file oeplatform/securitysettings.py by omitting the '.default' suffix on oeplatform/securitysettings.py.default and enter the connection to your above mentioned postgresql database.
 
     DATABASES = {
@@ -41,13 +50,14 @@ Create a file oeplatform/securitysettings.py by omitting the '.default' suffix o
     	}
     }
 
+By default, the environment variable `OEP_DB_USER` will provide a value for the `USER` field.
+The same holds between the environment variable `OEP_DB_PASSWORD` and `PASSWORD` field.
+
 Next step is to migrate the database schema from django to your django database:
 
     python manage.py migrate
 
-And create all tables that are needed in the second database:
 
-    python manage.py alembic upgrade head
     
 #### 2. Another Database
 
@@ -58,6 +68,35 @@ The second database connection should point to another postgresql database. It i
     dbport = 5432
     dbhost = ""
     db = ""
+
+##### 2.1 Posgresql command line setup
+
+Once logged into your psql session (for example `sudo -u postgres psql`), run the following lines:
+
+    create user oep_db_user with password '<oep_db_password>';
+    create database oep_db with owner = oep_db_user;
+
+##### 2.2 Django setup
+
+These are all available as environment variables
+
+| variable | environment variable  | required |
+|--------|---|----|
+| dbuser | LOCAL_OEDB_USER  |yes|
+| dbpasswd | LOCAL_OEDB_PASSWORD  |yes|
+|   dbport     | LOCAL_OEDB_PORT  |no|
+|   dbhost     | LOCAL_OEDB_HOST  |no|
+|   dbname     | LOCAL_OEDB_NAME  |no|
+
+dbuser = os.environ.get("LOCAL_OEDB_USER")
+dbpasswd = os.environ.get("LOCAL_OEDB_PASSWORD")
+dbport = os.environ.get("LOCAL_OEDB_PORT", 5432)
+dbhost = os.environ.get("LOCAL_OEDB_HOST", "localhost")
+dbname = os.environ.get("LOCAL_OEDB_NAME", "oedb")
+
+To create all tables that are needed in the second database:
+
+    python manage.py alembic upgrade head
 
 Only the following schemas are displayed in the dataview app of the OEP. Thus at
 least one should be present if you want to use this app:

--- a/oeplatform/securitysettings.py.default
+++ b/oeplatform/securitysettings.py.default
@@ -34,11 +34,13 @@ USER_CONNECTION_LIMIT = 4
 ANON_CONNECTION_LIMIT = 40
 
 # This database connection is used for the actual data interfaces (App: dataedit)
-dbuser = os.environ.get("OEDB_USER")
-dbpasswd = os.environ.get("OEDB_PASSWORD")
-dbport = os.environ.get("OEDB_PORT", 5432)
-dbhost = os.environ.get("OEDB_HOST", "localhost")
-dbname = os.environ.get("OEDB_NAME", "oedb")
+# This should not be linked with a potential user account of the OpenEnergyDatabase !!!
+# Please refer to the step 2.2 of the README file
+dbuser = os.environ.get("LOCAL_DB_USER")
+dbpasswd = os.environ.get("LOCAL_DB_PASSWORD")
+dbport = os.environ.get("LOCAL_DB_PORT", 5432)
+dbhost = os.environ.get("LOCAL_DB_HOST", "localhost")
+dbname = os.environ.get("LOCAL_DB_NAME", "oep_db")
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/oeplatform/securitysettings.py.default
+++ b/oeplatform/securitysettings.py.default
@@ -12,12 +12,12 @@ URL = '127.0.0.1'
 # This token is the token the test user is identified with during API-tests
 token_test_user = '0'
 
-# Database to your django database
+# Setting of your django database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'django',
+        'NAME': 'oep_django',
 	'USER': os.environ.get("OEP_DB_USER"),
 	'PASSWORD': os.environ.get("OEP_DB_PASSWORD"),
 	'HOST': 'localhost'                      

--- a/oeplatform/securitysettings.py.default
+++ b/oeplatform/securitysettings.py.default
@@ -40,7 +40,7 @@ dbuser = os.environ.get("LOCAL_DB_USER")
 dbpasswd = os.environ.get("LOCAL_DB_PASSWORD")
 dbport = os.environ.get("LOCAL_DB_PORT", 5432)
 dbhost = os.environ.get("LOCAL_DB_HOST", "localhost")
-dbname = os.environ.get("LOCAL_DB_NAME", "oep_db")
+dbname = os.environ.get("LOCAL_DB_NAME", "oedb")
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@ matplotlib>=2.0
 urllib3>=1.20
 scipy>=0.18.1
 django-widget_tweaks>=1.4.1
-psycopg2>=2.6.0
+psycopg2-binary>=2.6.0
 sqlalchemy
 Pillow
 bibtexparser>=0.6.2
 django-colorfield>=0.1.12
 requests>=2.13.0
 geoalchemy2>=0.4.0
-egoio
+git+https://github.com/openego/ego.io.git@dev
 djangoajax>=2.3.7
 webcolors>=1.7
 djangorestframework>=3.5.4


### PR DESCRIPTION
Closes #416 

Following the README step by step led to errors due to outdated requirements.txt and wrong order of command execution.

I also propose a renaming of the local OEDB-like database, as I got confused and thought it required my actual OEDB credentials. It was pointed out to me by @MGlauer that it is and OEDB-like database and should not be misinterpreted as the OEDB. The changes I propose here reflect theses clarifications.