### PR TITLE
Update egoio in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,7 @@ Pillow
 bibtexparser>=0.6.2
 django-colorfield>=0.1.12
 requests>=2.13.0
-geoalchemy2<=0.4.1,>=0.3.0  # because egoio
-git+https://github.com/openego/ego.io.git@dev
+egoio
 djangoajax>=2.3.7,<3.0
 webcolors>=1.7
 djangorestframework>=3.5.4


### PR DESCRIPTION
Fixes #421 

The latest [release](https://github.com/openego/ego.io/pull/82) of egoio fixed the error preventing its pip install and added geoalchemy in its requirements. Therefore we can again simply add `egoio` in the requirements.txt