### PR TITLE
Update psycopg in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bibtexparser>=0.6.2
 django-colorfield>=0.1.12
 requests>=2.13.0
 geoalchemy2<=0.4.1,>=0.3.0  # because egoio
-git+https://github.com/openego/ego.io.git@dev
+egoio
 djangoajax>=2.3.7,<3.0
 webcolors>=1.7
 djangorestframework>=3.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib>=2.0
 urllib3>=1.20
 scipy>=0.18.1
 django-widget_tweaks>=1.4.1
-psycopg2>=2.8.0
+psycopg2==2.7.6
 sqlalchemy>=1.3.0
 Pillow
 bibtexparser>=0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib>=2.0
 urllib3>=1.20
 scipy>=0.18.1
 django-widget_tweaks>=1.4.1
-psycopg2-binary>=2.6.0
+psycopg2>=2.8.0
 sqlalchemy>=1.3.0
 Pillow
 bibtexparser>=0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,13 @@ matplotlib>=2.0
 urllib3>=1.20
 scipy>=0.18.1
 django-widget_tweaks>=1.4.1
-psycopg2==2.7.6
 sqlalchemy>=1.3.0
 Pillow
 bibtexparser>=0.6.2
 django-colorfield>=0.1.12
 requests>=2.13.0
-geoalchemy2<=0.4.1,>=0.3.0  # because egoio
 egoio
+psycopg2-binary==2.7.6
 djangoajax>=2.3.7,<3.0
 webcolors>=1.7
 djangorestframework>=3.5.4


### PR DESCRIPTION
Closes #421 

Install `egoio` via pip and choose `psycopg` over `psycopg-binary` (after discussion in https://github.com/OpenEnergyPlatform/oedialect/issues/15)