### PR TITLE
Skip null in map handling

### DIFF
--- a/dataedit/static/dataedit/backend.js
+++ b/dataedit/static/dataedit/backend.js
@@ -132,36 +132,7 @@ function request_data(data, callback, settings) {
     ).done(function (count_response, select_response) {
         $("#loading-indicator").hide();
         if(map !== undefined) {
-            map.eachLayer(function (layer) {
-                if (layer !== tile_layer) {
-                    map.removeLayer(layer)
-                }
-            });
-
-            var geo_cols = get_selected_geo_columns();
-            if(geo_cols !== null) {
-                var col_idxs = select_response[0].description.reduce(function (l, r, i) {
-                    if (geo_cols.includes(r[0])) {
-                        l.push(i);
-                    }
-                    return l;
-                }, []);
-                var bounds = [];
-                for (var row_id in select_response[0].data) {
-                    var row = select_response[0].data[row_id];
-                    var geo_values = col_idxs.map(function (i) {
-                        var buf = new buffer.Buffer(row[i], "hex");
-                        var wkb = wkx.Geometry.parse(buf);
-                        var gj = L.geoJSON(wkb.toGeoJSON());
-                        gj.on("click", flash_handler(row_id));
-                        gj.addTo(map);
-                        return gj;
-                    });
-                    bounds.push(L.featureGroup(geo_values));
-                }
-                var b = L.featureGroup(bounds).getBounds();
-            }
-            map.fitBounds(b);
+            build_map(select_response[0].data, select_response[0].description)
         }
 
         if(view.type === "map") {
@@ -193,14 +164,16 @@ function build_map(data, description){
     for (var row_id in data) {
         var row = data[row_id];
         var geo_values = col_idxs.map(function (i) {
-            var buf = new buffer.Buffer(row[i], "hex");
-            var wkb = wkx.Geometry.parse(buf);
-            var gj = L.geoJSON(wkb.toGeoJSON());
-            gj.on("click", flash_handler(row_id));
-            gj.addTo(map);
-            return gj;
+            if(row[i] !== null) {
+                var buf = new buffer.Buffer(row[i], "hex");
+                var wkb = wkx.Geometry.parse(buf);
+                var gj = L.geoJSON(wkb.toGeoJSON());
+                gj.on("click", flash_handler(row_id));
+                gj.addTo(map);
+                return gj;
+            }
         });
-        bounds.push(L.featureGroup(geo_values));
+        bounds.push(L.featureGroup(geo_values.filter(x => !!x)));
     }
     var b = L.featureGroup(bounds).getBounds();
     map.fitBounds(b);


### PR DESCRIPTION
This fixes a bug that caused the map function to fail if there are null values