### PR TITLE
Reworking Factsheets View

### DIFF
--- a/base/static/css/base-style.css
+++ b/base/static/css/base-style.css
@@ -151,3 +151,35 @@ h1, h2, h3, h4, h5, h6 {
 .navbar-footer .navbar {
     height: 71px;
 }
+
+/** Styling for OEP Tags **/
+
+.tag-checkbox {
+    display: none;
+}
+
+.tag-checkbox:before {
+    display: none;
+}
+
+.tag-checkbox-container {
+    padding: 0.25em 0.5em;
+    border-radius: 0.5em;
+
+    display: flex;
+    align-items: center;
+}
+
+.tag-checkbox-container:not(:last-child) {
+    margin-right: 0.5em;
+}
+
+.tag-checkbox-icon {
+    display: none;
+
+    margin-left: 0.5em;
+}
+
+.tag-checkbox-checked .tag-checkbox-icon {
+    display: block;
+}

--- a/base/static/js/oep-tags.js
+++ b/base/static/js/oep-tags.js
@@ -1,0 +1,3 @@
+$(".tag-checkbox").on('click', (e) => {
+    $(e.target.parentElement).toggleClass("tag-checkbox-checked", e.target.checked)
+});

--- a/base/templates/base/base.html
+++ b/base/templates/base/base.html
@@ -139,6 +139,7 @@
     {% block before-body-bottom-js %}{% endblock before-body-bottom-js %}
     {% bootstrap_javascript jquery=1 %}
     <script type="text/javascript" src="{% static '/js/jsi18n' %}"></script>
+    <script type="text/javascript" src="{% static '/js/oep-tags.js' %}"></script>
     {% block after-body-bottom-js %}{% endblock after-body-bottom-js %}
 {% endblock body-bottom-js %}
 

--- a/dataedit/static/dataedit/dataedit.css
+++ b/dataedit/static/dataedit/dataedit.css
@@ -238,36 +238,6 @@ input[type="checkbox"]:checked+label{
     cursor: pointer;
 }
 
-.tag-checkbox {
-    display: none;
-}
-
-.tag-checkbox:before {
-    display: none;
-}
-
-.tag-checkbox-container {
-    padding: 0.25em 0.5em;
-    border-radius: 0.5em;
-
-    display: flex;
-    align-items: center;
-}
-
-.tag-checkbox-container:not(:last-child) {
-    margin-right: 0.5em;
-}
-
-.tag-checkbox-icon {
-    display: none;
-
-    margin-left: 0.5em;
-}
-
-.tag-checkbox-checked .tag-checkbox-icon {
-    display: block;
-}
-
 .foldable-entry {
 
     display: grid;

--- a/dataedit/static/dataedit/dataedit.js
+++ b/dataedit/static/dataedit/dataedit.js
@@ -1,3 +1,0 @@
-$(".tag-checkbox").on('click', (e) => {
-    $(e.target.parentElement).toggleClass("tag-checkbox-checked", e.target.checked)
-});

--- a/modelview/static/css/mv-style.css
+++ b/modelview/static/css/mv-style.css
@@ -60,7 +60,7 @@
     display: -webkit-flex; /* Safari */
     -webkit-flex-wrap: wrap; /* Safari 6.1+ */
     display: flex;
-    flex-wrap: wrap;
+    flex-flow: column;
 }
 
 .checkbox-item{

--- a/modelview/static/css/mv-style.css
+++ b/modelview/static/css/mv-style.css
@@ -2,11 +2,6 @@
     margin-bottom: 20px;
 }
 
-.container {
-    position: relative;
-    width:auto;
-}
-
 .mv-column-left{ float: left; width: 49.5%;overflow:auto;}
 
 .mv-column-right{ float: right; width: 49.5%; overflow:auto;}
@@ -14,8 +9,6 @@
 .mv-container{position: relative; display: inline;}
 
 .rowlabel{font-weight:bold;width:40%;vertical-align:top;}
-
-.profilebox{padding:15;overflow:auto;}
 
 .profiletable{
     border-collapse: separate;
@@ -73,4 +66,16 @@
     margin: 10 px;
 }
 
+.card-container > *:not(:first-child) {
+    margin-top: 0.5em;
+}
+
+.card-container .card-header {
+    background: unset;
+    border: unset;
+}
+
+.card-container .card-body {
+    padding-top: 0.5em;
+}
 

--- a/modelview/templates/modelview/base.html
+++ b/modelview/templates/modelview/base.html
@@ -1,10 +1,13 @@
 {% extends "base/base.html" %}
 {% load static %}
 {% block main-right-sidebar-content %}
+
+{% block main-right-sidebar-content-before %}
+{% endblock main-right-sidebar-content-before %}
 <hr>
-    <div style="overflow: hidden;">
-        <a href="/dataedit/tags"><h3>Manage Tags</h3></a>
-    </div>
+  <div style="overflow: hidden;">
+      <a href="/dataedit/tags"><h3>Manage Tags</h3></a>
+  </div>
 <hr>
 
 Fact Sheet objectives: The Fact Sheets are made to...

--- a/modelview/templates/modelview/base.html
+++ b/modelview/templates/modelview/base.html
@@ -4,27 +4,9 @@
 
 {% block main-right-sidebar-content-before %}
 {% endblock main-right-sidebar-content-before %}
-<hr>
-  <div style="overflow: hidden;">
-      <a href="/dataedit/tags"><h3>Manage Tags</h3></a>
-  </div>
-<hr>
 
-Fact Sheet objectives: The Fact Sheets are made to...
-<ul>
-    <li>Find models/frameworks for your needs or just get an overview about the existing ones</li>
-    <li>Compare a selection of models for different purposes - e.g. to develop a strategy to link them</li>
-    <li>Store your model/framework information to provide transparency</li>
-</ul>
-More info <a href="/factsheets/overview/">here</a>
-<hr>
-<b>Use case example model Fact Sheet:</b> For a European pathway simulation (EPS) we
-want to choose the models that best meet our requirements. All partners include
-their models in the Model Fact Sheets and tag them with “EPS”. To compare the
-models we filter all “EPS” models and choose different characteristics that we
-want to compare. OEP will give us tables (views) that facilitate the comparison.
-<hr>
 {% endblock %}
+
 {% block main-content-body %}
 {% block factsheets_content %}
 

--- a/modelview/templates/modelview/detail_view.html
+++ b/modelview/templates/modelview/detail_view.html
@@ -1,0 +1,36 @@
+{% extends "modelview/base.html" %}
+{% load bootstrap4 %}
+{% load static %}
+{% load modelview_extras %}
+{% load dataedit.taghandler %}
+
+{% block after-head %}
+  <link rel="stylesheet" href="{% static 'css/mv-style.css' %}">
+{% endblock after-head %}
+
+{% block site-header %}
+  <h2 class="site-header">
+    {{ displaySheetType }} Factsheet:
+    {% if model.model_name %} {{ model.model_name }} {% if  model.acronym %} ({{ model.acronym }}) {% endif %}{% endif %}
+    {% if model.name_of_scenario %} {{ model.name_of_scenario }} {% endif %}
+
+  </h2>
+{% endblock site-header %}
+
+{% block main-right-sidebar-content-before %}
+  <hr>
+
+  <h3>Actions</h3>
+
+  {% block main-right-sidebar-content-actions %}
+  {% endblock main-right-sidebar-content-actions %}
+
+  <hr>
+
+  <h3>Tags</h3>
+  {% for t in model.tags %}
+      <a href="" class="btn tag"
+         style="background:{{ t.color }};color:{% readable_text_color t.color %}; display:inline-block;">{{ t.name }}</a>
+  {% endfor %}
+
+{% endblock main-right-sidebar-content-before %}

--- a/modelview/templates/modelview/framework.html
+++ b/modelview/templates/modelview/framework.html
@@ -1,408 +1,375 @@
-{% extends "modelview/base.html" %}
+{% extends "modelview/detail_view.html" %}
 {% load bootstrap4 %}
-{% bootstrap_javascript_url %}
 {% load static %}
 {% load modelview_extras %}
 {% load dataedit.taghandler %}
+
+{% block main-right-sidebar-content-actions %}
+  <a class="btn btn-info" href="edit">Edit</a>
+{% endblock main-right-sidebar-content-actions %}
+
 {% block factsheets_content %}
-<script type="text/javascript">
-    <!--
-    $(document).ready(function(){
-    $('[data-toggle="popover"]').popover();
-    });
-    //-->
-</script>
-
-<link rel="stylesheet" href="{% static 'css/mv-style.css' %}">
-<div class="container">
-    <div style="float: left;">
-        <h1> {{ model.model_name }} {% if  model.acronym %} ({{ model.acronym }}) {% endif %} </h1>
-        {% for t in model.tags %}
-            <a href="" class="btn tag" style="background:{{t.color}};color:{% readable_text_color t.color %}; display:inline-block;">{{ t.name }}</a>
-        {% endfor %}
-    </div>
-    <div>
-        <a class="btn btn-info" style="float:right; position: absolute;bottom: 5;right: 0;" href="edit"><span name="icon"></span>Edit</a>
-    </div>
-</div>
-<div class="">
+  <div class="card-container">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a class="fill-div" data-toggle="collapse" href="#Overview">Overview</a>
-          </h4>
+      <div class="card-header">
+        <a class="fill-div" data-toggle="collapse" href="#Overview">Overview</a>
+      </div>
+      <div id="Overview" class="title= collapse in  in">
+
+        <div class="container" style="padding:0">
+
+          <table class="profiletable">
+            {% include 'modelview/model_snippet.html' with model=model field='model_name' %}
+            {% include 'modelview/model_snippet.html' with model=model field='last_updated' %}
+            {% include 'modelview/model_snippet.html' with model=model field='version' %}
+            {% include 'modelview/model_snippet.html' with model=model field='open_source' %}
+            {% include 'modelview/model_snippet.html' with model=model field='license' %}
+            {% include 'modelview/model_snippet.html' with model=model field='logo' %}
+            <tr>
+              <th>
+                Logo
+              </th>
+              <td>
+                {% if model.logo %}
+                  <img src="{% static model.logo.url %}" alt="{{ model.logo.url }}"
+                       style="max-width:30%;max-height:500px;">
+                {% endif %}
+              </td>
+            </tr>
+          </table>
         </div>
-        <div id="Overview" class="card-collapse collapse in profilebox in">
-            
-            <div class="container" style="padding:0">            
-                
-                    <table class="profiletable">
-                        {% include 'modelview/model_snippet.html' with model=model field='model_name' %}
-                        {% include 'modelview/model_snippet.html' with model=model field='last_updated' %}
-                        {% include 'modelview/model_snippet.html' with model=model field='version' %}
-                        {% include 'modelview/model_snippet.html' with model=model field='open_source' %}
-                        {% include 'modelview/model_snippet.html' with model=model field='license' %}
-                        {% include 'modelview/model_snippet.html' with model=model field='logo' %}
-                        <tr>
-                            <th> 
-                                Logo 
-                            </th>
-                            <td>
-                                {% if model.logo %}
-                                    <img src="{% static model.logo.url %}" alt="{{ model.logo.url }}" style="max-width:30%;max-height:500px;"> {# {% include 'modelview/model_snippet.html' with model=model field='logo' %} #}
-                                {% endif %}
-                            </td>
-                        </tr>               
-                    </table>
-            </div>
-        </div>
+      </div>
     </div>
-</div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a class="fill-div" data-toggle="collapse" href="#BasicInformation">Basic Information</a>
-          </h4>
-        </div>
-        <div id="BasicInformation" class="card-collapse collapse in profilebox in">
-            
-            <div class="container" style="padding:0">            
-                    
-                    <table class="profiletable">
-                       <tr>{% include 'modelview/model_snippet.html' with model=model field='model_name' %} </tr>
-                       <tr>{% include 'modelview/model_snippet.html' with model=model field='acronym' %} </tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='contact_email' %} </tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='current_contact_person' %} </tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='website' %} </tr>      
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='institutions' %} </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Geographical Scope 
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "gs_global,gs_regional,gs_national,gs_local,gs_single_project" %}
+      <div class="card-header">
+        <a class="fill-div" data-toggle="collapse" href="#BasicInformation">Basic Information</a>
+      </div>
+      <div id="BasicInformation" class="title= collapse in  in">
 
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Sectoral Scope 
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "ss_electricity,ss_heat,ss_transport,ss_other,ss_overall" %}
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                <tr>
-                <td class="sheetlabel">
-                         General Problem Scope 
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "gps_forecast,gps_explore,gps_backcast" %}
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                <tr>
-                <td class="sheetlabel">
-                       Specific Problem Scope 
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "sps_energydemand,sps_energysupply,sps_impacts,sps_environmental,sps_appraisal,sps_integrated_approach,sps_modular_buildup,sps_energy_dispatch,sps_capacity_expansion,sps_unit_commitment,sps_rule_based,sps_sector_coupling" %}
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='inital_purpose' %}</tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='inital_purpose_change' %}</tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='research_questions' %}</tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='inital_release_date' %}</tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='parent_framework' %}</tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='version' %}</tr>
-                        <tr>{% include 'modelview/model_snippet.html' with model=model field='source_of_funding' %}</tr>           
-                    </table>
-            </div>
-        </div>
-    </div>
-</div>
-<div class="">
-    <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#MathematicalDescription">Mathematical Description</a>
-          </h4>
-        </div>
-        <div id="MathematicalDescription" class="card-collapse collapse in profilebox">
-            
-            <div class="container" style="padding:0">            
-                    
-                    <table class="profiletable">
-                <tr>{% include 'modelview/model_snippet.html' with model=model field='gui' %}</tr>
-                </tr>
-                <tr>
-                <td class="sheetlabel">
-                       Programming Framework 
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "pf_Python,pf_C,pf_PHP,pf_GNU,pf_R,pf_VBA,pf_Java,pf_Fortran,pf_Modelica,pf_Matlab,pf_Ruby,pf_GAMS" %}
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                <td class="sheetlabel">
-                       External Solver 
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "es_CPLEX,es_Gurobi,es_Coin,es_GLPK,es_MOSEK" %}
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                <td class="sheetlabel">
-                       Input Data Format  
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "idf_Python_dicts,idf_XLSX,idf_Plots,idf_CSV,idf_XML,idf_txt,idf_db,idf_GAMS" %} 
-                        </table>
-                    </td>
-                </tr>
-                <tr>{% include 'modelview/model_snippet.html' with model=model field='auto_model_generator' %}</tr>
-                <tr>{% include 'modelview/model_snippet.html' with model=model field='data_preprocessing' %}</tr>
-                <td class="sheetlabel">
-                       Output Data Format  
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "odf_Python_dicts,odf_XLSX,odf_Plots,odf_CSV,odf_XML,odf_txt,odf_db,odf_GAMS" %} 
-                        </table>
-                    </td>
-                </tr>
-                <tr>{% include 'modelview/model_snippet.html' with model=model field='data_postprocessing' %}</tr>
-                <tr>{% include 'modelview/model_snippet.html' with model=model field='plotting_functionalities' %}</tr>
-                <td class="sheetlabel">
-                       The analytical approach   
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "ap_BottomUp,ap_Hybrid,ap_Other,ap_TopDown" %} 
-                        </table>
-                    </td>
-                </tr>
-                <tr>{% include 'modelview/model_snippet.html' with model=model field='additional_software' %}</tr>
-                <tr>{% include 'modelview/model_snippet.html' with model=model field='interfaces' %}</tr>
-                <tr>
-                <td class="sheetlabel">
-                       The mathematical approach  
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "ma_mip,ma_dp,ma_fl,ma_abp,ma_lp" %} 
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                <td class="sheetlabel">
-                       The underlying methodology  
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "um_econometric,um_me,um_ee,um_optimization,um_simulation,um_stochastic,um_gis,um_st,um_bc,um_mc,um_Accounting" %} 
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                <td class="sheetlabel">
-                       Objective function type  
-                    </td>
-                    <td>
-</td></tr></table>
-</div>
-<div class="">
-    <div class="card ">
-        <div class="card-header">
-            <h4 class="card-title">
-                <a href="#Openness" data-toggle="collapse">Openness</a>
-            </h4>
-        </div>
-        <div id="Openness" class="card-collapse collapse in profilebox">
+        <div class="container" style="padding:0">
 
-            <div class="container" style="padding:0">            
+          <table class="profiletable">
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='model_name' %} </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='acronym' %} </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='contact_email' %} </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='current_contact_person' %} </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='website' %} </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='institutions' %} </tr>
+            <tr>
+              <td class="sheetlabel">
+                Geographical Scope
+              </td>
+              <td>
+                <table>
+                  {% checklist model "gs_global,gs_regional,gs_national,gs_local,gs_single_project" %}
 
-                <table class="profiletable">
-                {% include 'modelview/model_snippet.html' with model=model field='open_source' %}
-                {% if not model.open_source %}
-                {% include 'modelview/model_snippet.html' with model=model field='open_up' %}
-                {% else %}
-                {% include 'modelview/model_snippet.html' with model=model field='license' add=model.license_other_text %}
-                {% include 'modelview/model_snippet.html' with model=model field='source_code_availability' %}
-                {% include 'modelview/model_snippet.html' with model=model field='data_code_availability'  %}
-                {% include 'modelview/model_snippet.html' with model=model field='data_provided'  %}
-                {% include 'modelview/model_snippet.html' with model=model field='open_to_developers'  %}
-                {% endif %} 
-                    <tr>
-                        <td class="sheetlabel">
-                           Support  
-                        </td>
-                    <td>
-                        <table>
-                        {% checklist model "support_forum,support_community,support_workshop,support_mail,support_modelExamples" %}        
-                        </table>
-                    </td>
-                    </tr>  
-                {% include 'modelview/model_snippet.html' with model=model field='modelling_software' %}
-                {% include 'modelview/model_snippet.html' with model=model field='interal_data_processing_software' %}
-                {% include 'modelview/model_snippet.html' with model=model field='external_optimizer' %}
-                {% include 'modelview/model_snippet.html' with model=model field='additional_software' %}
-                {% include 'modelview/model_snippet.html' with model=model field='gui' %}
                 </table>
-            
-            </div>
-        </div>
-    </div>
-</div>
-
-<div class="">
-    <div class="card ">
-        <div class="card-header">
-            <h4 class="card-title">
-                <a data-toggle="collapse" href="#ModelBuilding">Model Building</a>
-            </h4>
-        </div>
-        <div id="ModelBuilding" class="card-collapse collapse  profilebox">
-        
-            <div class="container" style="padding:0">            
-                <table class="profiletable">
-                    <tr>{% include 'modelview/model_snippet.html' with model=model field='fixed_units'  %}<tr>
-                    <tr>
-                        <td class="sheetlabel">
-                        Renewable Technology Inclusion  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "Hydro,Solar,Geothermal,Wind,Wave,Biomass,Tidal" %}        
-                            </table>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="sheetlabel">
-                        Storage Technology Inclusion  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "Hydro,Solar,Geothermal,Wind,Wave,Biomass,Tidal" %}        
-                            </table>
-                        </td>
-                    </tr> 
-                    <tr>
-                        <td class="sheetlabel">
-                        Transport Demand  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "dc_combustion,dc_battery,dc_v2grid,dc_hydrogen,dc_rail,dc_aviation" %}        
-                            </table>
-                        </td>
-                    </tr> 
-                    <tr>
-                        <td class="sheetlabel">
-                        Residential Demand  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "rd_Heating,rd_Lighting,rd_Cooking,rd_ApplianceUsage,rd_SmartAppliances" %}        
-                            </table>
-                        </td>
-                    </tr> 
-                    <tr>
-                        <td class="sheetlabel">
-                        Commercial Demand  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "cd_Offices,cd_Warehouses,cd_Retail" %}        
-                            </table>
-                        </td>
-                    </tr> 
-                    {% include 'modelview/model_snippet.html' with model=model field='agricultural_demand'  %}
-                    <tr>
-                        <td class="sheetlabel">
-                        Grid model  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "gm_singleNode,gm_TranshipmentModel,gm_LinearOptimal" %}        
-                            </table>
-                        </td>
-                    </tr> 
-                    <tr>
-                        <td class="sheetlabel">
-                        Cost Inclusion  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "ci_FuelPrices,ci_FuelHandling,ci_Investment,ci_FixedOperation,ci_VariableOperation,ci_CO2" %}        
-                            </table>
-                        </td>
-                    </tr>
-                    {% include 'modelview/model_snippet.html' with model=model field='new_components'  %}
-                    {% include 'modelview/model_snippet.html' with model=model field='variable_time_step'  %}
-                    {% include 'modelview/model_snippet.html' with model=model field='variable_rolling_horizon'  %}
-                    <tr>
-                        <td class="sheetlabel">
-                        Commonly used time step  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "ts_Minutely,ts_Hourly,ts_Monthly,ts_Yearly,ts_FiveYearly" %}        
-                            </table>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="sheetlabel">
-                        Commonly modelled time horizon  
-                        </td>
-                        <td>
-                            <table>
-                                {% checklist model "th_st,th_mt,th_lt" %}        
-                            </table>
-                        </td>
-                    </tr>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Sectoral Scope
+              </td>
+              <td>
+                <table>
+                  {% checklist model "ss_electricity,ss_heat,ss_transport,ss_other,ss_overall" %}
                 </table>
-            </div>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                General Problem Scope
+              </td>
+              <td>
+                <table>
+                  {% checklist model "gps_forecast,gps_explore,gps_backcast" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Specific Problem Scope
+              </td>
+              <td>
+                <table>
+                  {% checklist model "sps_energydemand,sps_energysupply,sps_impacts,sps_environmental,sps_appraisal,sps_integrated_approach,sps_modular_buildup,sps_energy_dispatch,sps_capacity_expansion,sps_unit_commitment,sps_rule_based,sps_sector_coupling" %}
+                </table>
+              </td>
+            </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='inital_purpose' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='inital_purpose_change' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='research_questions' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='inital_release_date' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='parent_framework' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='version' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='source_of_funding' %}</tr>
+          </table>
         </div>
+      </div>
     </div>
-</div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#References">References</a>
-          </h4>
-        </div>
-        <div id="References" class="card-collapse collapse in profilebox">
-            
-            <div class="container" style="padding:0">            
-                    
-                    <table class="profiletable">
-                    {% include 'modelview/model_snippet.html' with model=model field='references_to_reports_produced_using_the_model'  %}
-                    {% include 'modelview/model_snippet.html' with model=model field='citation_reference'  %}
-                    {% include 'modelview/model_snippet.html' with model=model field='how_to_cite'  %}
-                    {% include 'modelview/model_snippet.html' with model=model field='fw_appliance'  %}
-                    {% include 'modelview/model_snippet.html' with model=model field='larger_scale_usage'  %}
-                    </table>
+      <div class="card-header">
+        <a data-toggle="collapse" href="#MathematicalDescription">Mathematical Description</a>
+      </div>
+      <div id="MathematicalDescription" class="title= collapse in ">
 
-            </div>
+        <div class="container" style="padding:0">
+
+          <table class="profiletable">
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='gui' %}</tr>
+            <tr>
+              <td class="sheetlabel">
+                Programming Framework
+              </td>
+              <td>
+                <table>
+                  {% checklist model "pf_Python,pf_C,pf_PHP,pf_GNU,pf_R,pf_VBA,pf_Java,pf_Fortran,pf_Modelica,pf_Matlab,pf_Ruby,pf_GAMS" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                External Solver
+              </td>
+              <td>
+                <table>
+                  {% checklist model "es_CPLEX,es_Gurobi,es_Coin,es_GLPK,es_MOSEK" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Input Data Format
+              </td>
+              <td>
+                <table>
+                  {% checklist model "idf_Python_dicts,idf_XLSX,idf_Plots,idf_CSV,idf_XML,idf_txt,idf_db,idf_GAMS" %}
+                </table>
+              </td>
+            </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='auto_model_generator' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='data_preprocessing' %}</tr>
+            <tr>
+              <td class="sheetlabel">
+                Output Data Format
+              </td>
+              <td>
+                <table>
+                  {% checklist model "odf_Python_dicts,odf_XLSX,odf_Plots,odf_CSV,odf_XML,odf_txt,odf_db,odf_GAMS" %}
+                </table>
+              </td>
+            </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='data_postprocessing' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='plotting_functionalities' %}</tr>
+            <tr>
+              <td class="sheetlabel">
+                The analytical approach
+              </td>
+              <td>
+                <table>
+                  {% checklist model "ap_BottomUp,ap_Hybrid,ap_Other,ap_TopDown" %}
+                </table>
+              </td>
+            </tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='additional_software' %}</tr>
+            <tr>{% include 'modelview/model_snippet.html' with model=model field='interfaces' %}</tr>
+            <tr>
+              <td class="sheetlabel">
+                The mathematical approach
+              </td>
+              <td>
+                <table>
+                  {% checklist model "ma_mip,ma_dp,ma_fl,ma_abp,ma_lp" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                The underlying methodology
+              </td>
+              <td>
+                <table>
+                  {% checklist model "um_econometric,um_me,um_ee,um_optimization,um_simulation,um_stochastic,um_gis,um_st,um_bc,um_mc,um_Accounting" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Objective function type
+              </td>
+              <td>
+              </td>
+            </tr>
+          </table>
         </div>
+      </div>
     </div>
-</div>
+    <div class="card ">
+      <div class="card-header">
+        <a href="#Openness" data-toggle="collapse">Openness</a>
+      </div>
+      <div id="Openness" class="title= collapse in ">
+
+        <div class="container" style="padding:0">
+
+          <table class="profiletable">
+            {% include 'modelview/model_snippet.html' with model=model field='open_source' %}
+            {% if not model.open_source %}
+              {% include 'modelview/model_snippet.html' with model=model field='open_up' %}
+            {% else %}
+              {% include 'modelview/model_snippet.html' with model=model field='license' add=model.license_other_text %}
+              {% include 'modelview/model_snippet.html' with model=model field='source_code_availability' %}
+              {% include 'modelview/model_snippet.html' with model=model field='data_code_availability' %}
+              {% include 'modelview/model_snippet.html' with model=model field='data_provided' %}
+              {% include 'modelview/model_snippet.html' with model=model field='open_to_developers' %}
+            {% endif %}
+            <tr>
+              <td class="sheetlabel">
+                Support
+              </td>
+              <td>
+                <table>
+                  {% checklist model "support_forum,support_community,support_workshop,support_mail,support_modelExamples" %}
+                </table>
+              </td>
+            </tr>
+            {% include 'modelview/model_snippet.html' with model=model field='modelling_software' %}
+            {% include 'modelview/model_snippet.html' with model=model field='interal_data_processing_software' %}
+            {% include 'modelview/model_snippet.html' with model=model field='external_optimizer' %}
+            {% include 'modelview/model_snippet.html' with model=model field='additional_software' %}
+            {% include 'modelview/model_snippet.html' with model=model field='gui' %}
+          </table>
+
+        </div>
+      </div>
+    </div>
+    <div class="card ">
+      <div class="card-header">
+        <a data-toggle="collapse" href="#ModelBuilding">Model Building</a>
+      </div>
+      <div id="ModelBuilding" class="card-body collapse  ">
+
+        <div class="container" style="padding:0">
+          <table class="profiletable">
+            <tr>
+              {% include 'modelview/model_snippet.html' with model=model field='fixed_units' %}
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Renewable Technology Inclusion
+              </td>
+              <td>
+                <table>
+                  {% checklist model "Hydro,Solar,Geothermal,Wind,Wave,Biomass,Tidal" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Storage Technology Inclusion
+              </td>
+              <td>
+                <table>
+                  {% checklist model "Hydro,Solar,Geothermal,Wind,Wave,Biomass,Tidal" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Transport Demand
+              </td>
+              <td>
+                <table>
+                  {% checklist model "dc_combustion,dc_battery,dc_v2grid,dc_hydrogen,dc_rail,dc_aviation" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Residential Demand
+              </td>
+              <td>
+                <table>
+                  {% checklist model "rd_Heating,rd_Lighting,rd_Cooking,rd_ApplianceUsage,rd_SmartAppliances" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Commercial Demand
+              </td>
+              <td>
+                <table>
+                  {% checklist model "cd_Offices,cd_Warehouses,cd_Retail" %}
+                </table>
+              </td>
+            </tr>
+            {% include 'modelview/model_snippet.html' with model=model field='agricultural_demand' %}
+            <tr>
+              <td class="sheetlabel">
+                Grid model
+              </td>
+              <td>
+                <table>
+                  {% checklist model "gm_singleNode,gm_TranshipmentModel,gm_LinearOptimal" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Cost Inclusion
+              </td>
+              <td>
+                <table>
+                  {% checklist model "ci_FuelPrices,ci_FuelHandling,ci_Investment,ci_FixedOperation,ci_VariableOperation,ci_CO2" %}
+                </table>
+              </td>
+            </tr>
+            {% include 'modelview/model_snippet.html' with model=model field='new_components' %}
+            {% include 'modelview/model_snippet.html' with model=model field='variable_time_step' %}
+            {% include 'modelview/model_snippet.html' with model=model field='variable_rolling_horizon' %}
+            <tr>
+              <td class="sheetlabel">
+                Commonly used time step
+              </td>
+              <td>
+                <table>
+                  {% checklist model "ts_Minutely,ts_Hourly,ts_Monthly,ts_Yearly,ts_FiveYearly" %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">
+                Commonly modelled time horizon
+              </td>
+              <td>
+                <table>
+                  {% checklist model "th_st,th_mt,th_lt" %}
+                </table>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div class="card ">
+      <div class="card-header">
+        <a data-toggle="collapse" href="#References">References</a>
+      </div>
+      <div id="References" class="card-body collapse in ">
+
+        <div class="container" style="padding:0">
+
+          <table class="profiletable">
+            {% include 'modelview/model_snippet.html' with model=model field='references_to_reports_produced_using_the_model' %}
+            {% include 'modelview/model_snippet.html' with model=model field='citation_reference' %}
+            {% include 'modelview/model_snippet.html' with model=model field='how_to_cite' %}
+            {% include 'modelview/model_snippet.html' with model=model field='fw_appliance' %}
+            {% include 'modelview/model_snippet.html' with model=model field='larger_scale_usage' %}
+          </table>
+
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/modelview/templates/modelview/model.html
+++ b/modelview/templates/modelview/model.html
@@ -1,421 +1,391 @@
-{% extends "modelview/base.html" %}
+{% extends "modelview/detail_view.html" %}
 {% load bootstrap4 %}
-{% bootstrap_javascript_url %}
 {% load static %}
 {% load modelview_extras %}
 {% load dataedit.taghandler %}
+
+{% block main-right-sidebar-content-actions %}
+  <a class="btn btn-info" href="edit">Edit</a>
+{% endblock main-right-sidebar-content-actions %}
+
+
 {% block factsheets_content %}
-<script type="text/javascript">
-    <!--
-    $(document).ready(function(){
-    $('[data-toggle="popover"]').popover();
-    });
-    //-->
-</script>
 
-<link rel="stylesheet" href="{% static 'css/mv-style.css' %}">
-<div class="container">
-    <div style="float: left;">
-        <h1> {{ model.model_name }} {% if  model.acronym %} ({{ model.acronym }}) {% endif %} </h1>
-        {% for t in model.tags %}
-            <a href="" class="btn tag" style="background:{{t.color}};color:{% readable_text_color t.color %}; display:inline-block;">{{ t.name }}</a>
-        {% endfor %}
-    </div>
-    <div>
-        <a class="btn btn-info" style="float:right; position: absolute;bottom: 5;right: 0;" href="edit"><span name="icon"></span>Edit</a>
-    </div>
-</div>
-<div class="">
+  <div class="card-container">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a class="fill-div" data-toggle="collapse" href="#BasicInformation">Basic Information</a>
-          </h4>
-        </div>
-        <div id="BasicInformation" class="card-collapse collapse in profilebox in">
-            
+      <div class="card-header">
+        <a class="fill-div" data-toggle="collapse" href="#BasicInformation">Basic Information</a>
+      </div>
+      <div id="BasicInformation" class="card-body collapse in  in">
 
-                    
-                    <table class="profiletable">
-                    <!-- <tr><td class="rowlabel"> id_name</td><td> {{ model.id_name }}</td></tr> -->
-                    {% include 'modelview/model_snippet.html' with model=model field='model_name' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='acronym' %}
-                    <tr>
-                        <td class="sheetlabel">
-                            {% get_field_attr model 'methodical_focus_1' 'verbose_name'%}
-                            <a href='javascript://' data-toggle='popover' data-trigger="focus" title="" data-content="{{ model.methodical_focus_1.help_text }}">
-                                <span class='fas fa-question'></span>
-                            </a>
-                        </td>
-                        <td>
-                            {{ model.methodical_focus_1 }}
-                            {% if model.methodical_focus_2 %}, {{ model.methodical_focus_2 }} {% endif %}
-                            {% if model.methodical_focus_3 %}, {{ model.methodical_focus_3 }} {% endif %}
-                        </td>
-                    </tr>
-                    {% include 'modelview/model_snippet.html' with model=model field='institutions' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='authors' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='current_contact_person' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='contact_email' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='website' %}
-                    <tr>
-                        <th> 
-                            Logo 
-                        </th>
-                        <td>
-                            {% if model.logo %}
-                                <img src="{% static model.logo.url %}" alt="{{ model.logo.url }}" style="max-width:30%;max-height:500px;"> {# {% include 'modelview/model_snippet.html' with model=model field='logo' %} #}
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% include 'modelview/model_snippet.html' with model=model field='primary_purpose' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='primary_outputs' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='support' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='framework' add=model.framework_yes_text%}
-                    {% include 'modelview/model_snippet.html' with model=model field='user_documentation' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='code_documentation' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='documentation_quality' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='source_of_funding' %}
-                    {% include 'modelview/model_snippet.html' with model=model field='number_of_devolopers'  %}
-                    {% include 'modelview/model_snippet.html' with model=model field='number_of_users'  %}
-                    </table>
 
-        </div>
+        <table class="profiletable">
+          {% include 'modelview/model_snippet.html' with model=model field='model_name' %}
+          {% include 'modelview/model_snippet.html' with model=model field='acronym' %}
+          <tr>
+            <td class="sheetlabel">
+              {% get_field_attr model 'methodical_focus_1' 'verbose_name' %}
+              <a href='javascript://' data-toggle='popover' data-trigger="focus" title=""
+                 data-content="{{ model.methodical_focus_1.help_text }}">
+                <span class='fas fa-question'></span>
+              </a>
+            </td>
+            <td>
+              {{ model.methodical_focus_1 }}
+              {% if model.methodical_focus_2 %}, {{ model.methodical_focus_2 }} {% endif %}
+              {% if model.methodical_focus_3 %}, {{ model.methodical_focus_3 }} {% endif %}
+            </td>
+          </tr>
+          {% include 'modelview/model_snippet.html' with model=model field='institutions' %}
+          {% include 'modelview/model_snippet.html' with model=model field='authors' %}
+          {% include 'modelview/model_snippet.html' with model=model field='current_contact_person' %}
+          {% include 'modelview/model_snippet.html' with model=model field='contact_email' %}
+          {% include 'modelview/model_snippet.html' with model=model field='website' %}
+          <tr>
+            <th>
+              Logo
+            </th>
+            <td>
+              {% if model.logo %}
+                <img src="{% static model.logo.url %}" alt="{{ model.logo.url }}"
+                     style="max-width:30%;max-height:500px;">
+                {# {% include 'modelview/model_snippet.html' with model=model field='logo' %} #}
+              {% endif %}
+            </td>
+          </tr>
+          {% include 'modelview/model_snippet.html' with model=model field='primary_purpose' %}
+          {% include 'modelview/model_snippet.html' with model=model field='primary_outputs' %}
+          {% include 'modelview/model_snippet.html' with model=model field='support' %}
+          {% include 'modelview/model_snippet.html' with model=model field='framework' add=model.framework_yes_text %}
+          {% include 'modelview/model_snippet.html' with model=model field='user_documentation' %}
+          {% include 'modelview/model_snippet.html' with model=model field='code_documentation' %}
+          {% include 'modelview/model_snippet.html' with model=model field='documentation_quality' %}
+          {% include 'modelview/model_snippet.html' with model=model field='source_of_funding' %}
+          {% include 'modelview/model_snippet.html' with model=model field='number_of_devolopers' %}
+          {% include 'modelview/model_snippet.html' with model=model field='number_of_users' %}
+        </table>
+
+      </div>
     </div>
-</div>
-        <div class="">
-            <div class="card ">
-                <div class="card-header">
-                  <h4 class="card-title">
-                    <a data-toggle="collapse" href="#Openness">Openness</a>
-                  </h4>
-                </div>
-                <div id="Openness" class="card-collapse collapse in profilebox">
-                    <table class="profiletable">
-                        {% include 'modelview/model_snippet.html' with model=model field='open_source' %}
-                        {% if not model.open_source %}
-                            {% include 'modelview/model_snippet.html' with model=model field='open_up' %}
-                            {% include 'modelview/model_snippet.html' with model=model field='costs' %}
-                        {% else %}
-                            {% include 'modelview/model_snippet.html' with model=model field='license' add=model.license_other_text %}
-                            {% include 'modelview/model_snippet.html' with model=model field='source_code_available' %}
-                            {% include 'modelview/model_snippet.html' with model=model field='gitHub' %}
-                            {% include 'modelview/model_snippet.html' with model=model field='link_to_source_code'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='data_provided'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='cooperative_programming'  %}
-                        {% endif %}
-                                                
-                    </table>
-                    {% if model.gitHub %}
-                        
-                        
-                        <table class="profiletable">
-                        <tr><td class="sheetlabel">GitHub Organisation</td><td><div data-theme="default" data-height="150" data-width="400" data-github="{{ gh_org }}/{{ gh_repo }}" class="github-card"></div><script src="//cdn.jsdelivr.net/github-cards/latest/widget.js"></script> <td></tr> 
-                         <tr><td class="sheetlabel">GitHub Contributions Graph</td><td> 
-                        <img src="/media/GitHub_{{ gh_org }}_{{ gh_repo }}_Contribution.png">
-                        </td></tr>
-                                                
-                    </table>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-        <div class="">
-            <div class="card ">
-                <div class="card-header">
-                  <h4 class="card-title">
-                    <a href="#Software" data-toggle="collapse">Software</a>
-                  </h4>
-                </div>
-                <div id="Software" class="card-collapse collapse in profilebox">
-                    <table class="profiletable">
-                        {% include 'modelview/model_snippet.html' with model=model field='modelling_software'  %}
-                        {% include 'modelview/model_snippet.html' with model=model field='interal_data_processing_software'  %}
-                        {% include 'modelview/model_snippet.html' with model=model field='external_optimizer' add=model.external_optimizer_yes_text %}
-                        {% include 'modelview/model_snippet.html' with model=model field='additional_software'  %}
-                        {% include 'modelview/model_snippet.html' with model=model field='gui'  %}
-                    </table>
-                </div>
-            </div>
-        </div>
-    
-        <div class="">
-            <div class="card ">
-                <div class="card-header">
-                  <h4 class="card-title">
-                    <a data-toggle="collapse" href="#References">References</a>
-                  </h4>
-                </div>
-                <div id="References" class="card-collapse collapse  profilebox">
-                    <div>
-                        <table class="profiletable">
-                            {% include 'modelview/model_snippet.html' with model=model field='citation_reference'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='citation_DOI'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='references_to_reports_produced_using_the_model'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='example_research_questions'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='larger_scale_usage'  %}
-                            
-                            <tr>
-			      <td class="sheetlabel">
-				  Model validation
-			      </td>
-			      <td>
-				  <table>
-				      {% checklist model "validation_models,validation_measurements,validation_others=validation_others_text" %}
-
-				  </table>
-			      </td>
-			    </tr>
-
-                            {% include 'modelview/model_snippet.html' with model=model field='example_research_questions'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='properties_missed'  %}
-                            {% include 'modelview/model_snippet.html' with model=model field='model_specific_properties'  %}
-                        </table>
-                    </div>
-                </div>
-            </div>
-        </div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#Coverage">Coverage</a>
-          </h4>
-        </div>
-        <div id="Coverage" class="card-collapse collapse  profilebox">
-            <table class="profiletable">
-                <tr>
-                    <td class="sheetlabel">
-                        Modeled energy sectors (final energy)
-                    </td>
-                    <td>
-                        <table>
-{% checklist model "energy_sectors_electricity,energy_sectors_heat,energy_sectors_others=energy_sectors_others_text" %}
+      <div class="card-header">
+        <a data-toggle="collapse" href="#Openness">Openness</a>
+      </div>
+      <div id="Openness" class="card-body collapse in ">
+        <table class="profiletable">
+          {% include 'modelview/model_snippet.html' with model=model field='open_source' %}
+          {% if not model.open_source %}
+            {% include 'modelview/model_snippet.html' with model=model field='open_up' %}
+            {% include 'modelview/model_snippet.html' with model=model field='costs' %}
+          {% else %}
+            {% include 'modelview/model_snippet.html' with model=model field='license' add=model.license_other_text %}
+            {% include 'modelview/model_snippet.html' with model=model field='source_code_available' %}
+            {% include 'modelview/model_snippet.html' with model=model field='gitHub' %}
+            {% include 'modelview/model_snippet.html' with model=model field='link_to_source_code' %}
+            {% include 'modelview/model_snippet.html' with model=model field='data_provided' %}
+            {% include 'modelview/model_snippet.html' with model=model field='cooperative_programming' %}
+          {% endif %}
 
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Modeled demand sectors
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "demand_sectors_households,demand_sectors_industry,demand_sectors_commercial_sector,demand_sectors_transport" %}
+        </table>
+        {% if model.gitHub %}
 
 
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Modeled technologies: components for power generation or conversion
-                    </td>
-                    <td>
-                        <table class="profiletable">
-                            <tr>
-                                <td class="sheetlabel">
-                                    Renewables
-                                </td>
-                                <td>
-                                    <table>
-{% checklist model "generation_renewables_PV,generation_renewables_wind,generation_renewables_hydro,generation_renewables_bio,generation_renewables_solar_thermal,generation_renewables_geothermal" %}
-                                    </table>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="sheetlabel">
-                                    Conventional
-                                </td>
-                                <td>
-                                    <table>
-{% checklist model "generation_conventional_gas,generation_conventional_lignite,generation_conventional_hard_coal,generation_conventional_oil,generation_conventional_liquid_fuels,generation_conventional_nuclear" %}
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Modeled technologies: components for transfer, infrastructure or grid
-                    </td>
-                    <td>
-                        <table class="profiletable">
-                            <tr>
-                                <td class="sheetlabel">
-                                    Electricity
-                                </td>
-                                <td>
-                                    <table>
-                                        {% checklist model "transfer_electricity_distribution,transfer_electricity_transition" %}
-                                    </table>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="sheetlabel">
-                                    Gas
-                                </td>
-                                <td>
-                                    <table>
-                                        {% checklist model "transfer_gas_distribution,transfer_gas_transition" %}
-                                    </table>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="sheetlabel">
-                                    Heat
-                                </td>
-                                <td>
-                                    <table>
-                                         {% checklist model "transfer_heat_distribution,transfer_heat_transition" %}
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Properties electrical grid
-                    </td>
-                    <td>
-                        <table>
-{% checklist model "network_coverage_AC,network_coverage_DC,network_coverage_TM,network_coverage_SN,network_coverage_other=network_coverage_other_text" %}
-                        </table>
-                    </td>
-                </tr>              
-                <tr>
-                    <td class="sheetlabel">
-                        Modeled technologies: components for storage
-                    </td>
-                    <td>
-                        <table>
-{% checklist model "storage_electricity_battery,storage_electricity_kinetic,storage_electricity_CAES,storage_electricity_PHS,storage_electricity_chemical,storage_heat,storage_gas" %}
+          <table class="profiletable">
+            <tr>
+              <td class="sheetlabel">GitHub Organisation</td>
+              <td>
+                <div data-theme="default" data-height="150" data-width="400" data-github="{{ gh_org }}/{{ gh_repo }}"
+                     class="github-card"></div>
+                <script src="//cdn.jsdelivr.net/github-cards/latest/widget.js"></script>
+              <td>
+            </tr>
+            <tr>
+              <td class="sheetlabel">GitHub Contributions Graph</td>
+              <td>
+                <img src="/media/GitHub_{{ gh_org }}_{{ gh_repo }}_Contribution.png">
+              </td>
+            </tr>
 
-                        </table>
-                    </td>
-                </tr>
-                
-                {% include 'modelview/model_snippet.html' with model=model field='user_behaviour' add=model.user_behaviour_yes_text %}
-                {% include 'modelview/model_snippet.html' with model=model field='changes_in_efficiency'  %}
-                {% include 'modelview/model_snippet.html' with model=model field='market_models'  %}
-                {% include 'modelview/model_snippet.html' with model=model field='geographical_coverage'  %}
-                <tr>
-                    <td class="sheetlabel">
-                        Geographic (spatial) resolution
-                    </td>
-                    <td>
-                        <table>
-{% checklist model "geo_resolution_global,geo_resolution_continents,geo_resolution_national_states,geo_resolution_TSO_regions,geo_resolution_federal_states,geo_resolution_regions,geo_resolution_NUTS_3,geo_resolution_municipalities,geo_resolution_districts,geo_resolution_households,geo_resolution_power_stations,geo_resolution_others=geo_resolution_others_text" %}
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Time resolution
-                    </td>
-                    <td>
-                        {% checklist model "time_resolution_anual,time_resolution_hour,time_resolution_15_min,time_resolution_1_min,time_resolution_other=time_resolution_other_text" %}
-                    </td>
-                </tr>
-                {% include 'modelview/model_snippet.html' with model=model field='comment_on_geo_resolution'  %}
-                <tr>
-                    <td class="sheetlabel">
-                        Observation period
-                    </td>
-                    <td>
-                        {% checklist model "observation_period_less_1_year,observation_period_1_year,observation_period_more_1_year,observation_period_other=observation_period_other_text" %}
-
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Additional dimensions (sector)
-                    </td>
-                    <td>
-                        <table>
-{% checklist model "additional_dimensions_sector_ecological,additional_dimensions_sector_ecological_text,additional_dimensions_sector_economic,additional_dimensions_sector_economic_text,additional_dimensions_sector_social,additional_dimensions_sector_social_text,additional_dimensions_sector_others=additional_dimensions_sector_others_text" %}
-
-                        </table>
-                    </td>
-                </tr>
-
-                
-            </table>
-        </div>
+          </table>
+        {% endif %}
+      </div>
     </div>
-</div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#MathematicalProperties">Mathematical Properties</a>
-          </h4>
-        </div>
-        <div id="MathematicalProperties" class="card-collapse collapse profilebox">
-            <table class="profiletable">
-                <tr>
-                    <td class="sheetlabel">
-                        Model class (optimisation)
-                    </td>
-                    <td>
-                        {% checklist model "model_class_optimization_LP,model_class_optimization_MILP,model_class_optimization_Nonlinear=model_class_optimization_LP_MILP_Nonlinear_text" %}
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Model class (simulation)
-                    </td>
-                    <td>
-                        {% checklist model "model_class_simulation_Agentbased,model_class_simulation_System_Dynamics,model_class_simulation_Accounting_Framework,model_class_simulation_Game_Theoretic_Model,model_class_simulation_bottom_up,model_class_simulation_top_down" %}
-
-                    </td>
-                </tr>
-                {% include 'modelview/model_snippet.html' with model=model field='model_class_other' add=model.model_class_other_text  %}
-                {% include 'modelview/model_snippet.html' with model=model field='short_description_of_mathematical_model_class'  %}
-                <tr>
-                    <td class="sheetlabel">
-                        Mathematical objective
-                    </td>
-                    <td>
-                        {% checklist model "mathematical_objective_cO2,mathematical_objective_costs,mathematical_objective_rEshare,mathematical_objective_other=mathematical_objective_other_text" %}
-                    </td>
-                </tr>                
-                <tr>
-                    <td class="sheetlabel">
-                        Approach to uncertainty
-                    </td>
-                    <td>
-                        {% checklist model "uncertainty_deterministic,uncertainty_Stochastic,uncertainty_Other=uncertainty_Other_text" %}
-                    </td>
-                </tr>
-
-                {% include 'modelview/model_snippet.html' with model=model field='montecarlo'  %}
-                {% include 'modelview/model_snippet.html' with model=model field='typical_computation_time'  %}
-                {% include 'modelview/model_snippet.html' with model=model field='typical_computation_hardware'  %}
-                {% include 'modelview/model_snippet.html' with model=model field='technical_data_anchored_in_the_model'  %}
-            </table>
-        </div>
+      <div class="card-header">
+        <a href="#Software" data-toggle="collapse">Software</a>
+      </div>
+      <div id="Software" class="card-body collapse in ">
+        <table class="profiletable">
+          {% include 'modelview/model_snippet.html' with model=model field='modelling_software' %}
+          {% include 'modelview/model_snippet.html' with model=model field='interal_data_processing_software' %}
+          {% include 'modelview/model_snippet.html' with model=model field='external_optimizer' add=model.external_optimizer_yes_text %}
+          {% include 'modelview/model_snippet.html' with model=model field='additional_software' %}
+          {% include 'modelview/model_snippet.html' with model=model field='gui' %}
+        </table>
+      </div>
     </div>
-</div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a class="fill-div" data-toggle="collapse" href="#Integration">Model Integration</a>
-          </h4>
+      <div class="card-header">
+        <a data-toggle="collapse" href="#References">References</a>
+      </div>
+      <div id="References" class="card-body collapse  ">
+        <div>
+          <table class="profiletable">
+            {% include 'modelview/model_snippet.html' with model=model field='citation_reference' %}
+            {% include 'modelview/model_snippet.html' with model=model field='citation_DOI' %}
+            {% include 'modelview/model_snippet.html' with model=model field='references_to_reports_produced_using_the_model' %}
+            {% include 'modelview/model_snippet.html' with model=model field='example_research_questions' %}
+            {% include 'modelview/model_snippet.html' with model=model field='larger_scale_usage' %}
+
+            <tr>
+              <td class="sheetlabel">
+                Model validation
+              </td>
+              <td>
+                <table>
+                  {% checklist model "validation_models,validation_measurements,validation_others=validation_others_text" %}
+
+                </table>
+              </td>
+            </tr>
+
+            {% include 'modelview/model_snippet.html' with model=model field='example_research_questions' %}
+            {% include 'modelview/model_snippet.html' with model=model field='properties_missed' %}
+            {% include 'modelview/model_snippet.html' with model=model field='model_specific_properties' %}
+          </table>
         </div>
-        <div id="Integration" class="card-collapse collapse in profilebox in">
-            <table class="profiletable">
-                {% include 'modelview/model_snippet.html' with model=model field='interfaces' %}
-                {% include 'modelview/model_snippet.html' with model=model field='model_file_format' add=model.model_file_format_other_text%}
-                {% include 'modelview/model_snippet.html' with model=model field='model_input' add=model.model_input_other_text%}
-                {% include 'modelview/model_snippet.html' with model=model field='model_output' add=model.model_output_other_text%}
-                {% include 'modelview/model_snippet.html' with model=model field='integrating_models' %}
-                {% include 'modelview/model_snippet.html' with model=model field='integrated_models' %}
-            </table>
-        </div>
+      </div>
     </div>
-</div>
+    <div class="card ">
+      <div class="card-header">
+        <a data-toggle="collapse" href="#Coverage">Coverage</a>
+      </div>
+      <div id="Coverage" class="card-body collapse  ">
+        <table class="profiletable">
+          <tr>
+            <td class="sheetlabel">
+              Modeled energy sectors (final energy)
+            </td>
+            <td>
+              <table>
+                {% checklist model "energy_sectors_electricity,energy_sectors_heat,energy_sectors_others=energy_sectors_others_text" %}
+
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Modeled demand sectors
+            </td>
+            <td>
+              <table>
+                {% checklist model "demand_sectors_households,demand_sectors_industry,demand_sectors_commercial_sector,demand_sectors_transport" %}
+
+
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Modeled technologies: components for power generation or conversion
+            </td>
+            <td>
+              <table class="profiletable">
+                <tr>
+                  <td class="sheetlabel">
+                    Renewables
+                  </td>
+                  <td>
+                    <table>
+                      {% checklist model "generation_renewables_PV,generation_renewables_wind,generation_renewables_hydro,generation_renewables_bio,generation_renewables_solar_thermal,generation_renewables_geothermal" %}
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheetlabel">
+                    Conventional
+                  </td>
+                  <td>
+                    <table>
+                      {% checklist model "generation_conventional_gas,generation_conventional_lignite,generation_conventional_hard_coal,generation_conventional_oil,generation_conventional_liquid_fuels,generation_conventional_nuclear" %}
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Modeled technologies: components for transfer, infrastructure or grid
+            </td>
+            <td>
+              <table class="profiletable">
+                <tr>
+                  <td class="sheetlabel">
+                    Electricity
+                  </td>
+                  <td>
+                    <table>
+                      {% checklist model "transfer_electricity_distribution,transfer_electricity_transition" %}
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheetlabel">
+                    Gas
+                  </td>
+                  <td>
+                    <table>
+                      {% checklist model "transfer_gas_distribution,transfer_gas_transition" %}
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="sheetlabel">
+                    Heat
+                  </td>
+                  <td>
+                    <table>
+                      {% checklist model "transfer_heat_distribution,transfer_heat_transition" %}
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Properties electrical grid
+            </td>
+            <td>
+              <table>
+                {% checklist model "network_coverage_AC,network_coverage_DC,network_coverage_TM,network_coverage_SN,network_coverage_other=network_coverage_other_text" %}
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Modeled technologies: components for storage
+            </td>
+            <td>
+              <table>
+                {% checklist model "storage_electricity_battery,storage_electricity_kinetic,storage_electricity_CAES,storage_electricity_PHS,storage_electricity_chemical,storage_heat,storage_gas" %}
+
+              </table>
+            </td>
+          </tr>
+
+          {% include 'modelview/model_snippet.html' with model=model field='user_behaviour' add=model.user_behaviour_yes_text %}
+          {% include 'modelview/model_snippet.html' with model=model field='changes_in_efficiency' %}
+          {% include 'modelview/model_snippet.html' with model=model field='market_models' %}
+          {% include 'modelview/model_snippet.html' with model=model field='geographical_coverage' %}
+          <tr>
+            <td class="sheetlabel">
+              Geographic (spatial) resolution
+            </td>
+            <td>
+              <table>
+                {% checklist model "geo_resolution_global,geo_resolution_continents,geo_resolution_national_states,geo_resolution_TSO_regions,geo_resolution_federal_states,geo_resolution_regions,geo_resolution_NUTS_3,geo_resolution_municipalities,geo_resolution_districts,geo_resolution_households,geo_resolution_power_stations,geo_resolution_others=geo_resolution_others_text" %}
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Time resolution
+            </td>
+            <td>
+              {% checklist model "time_resolution_anual,time_resolution_hour,time_resolution_15_min,time_resolution_1_min,time_resolution_other=time_resolution_other_text" %}
+            </td>
+          </tr>
+          {% include 'modelview/model_snippet.html' with model=model field='comment_on_geo_resolution' %}
+          <tr>
+            <td class="sheetlabel">
+              Observation period
+            </td>
+            <td>
+              {% checklist model "observation_period_less_1_year,observation_period_1_year,observation_period_more_1_year,observation_period_other=observation_period_other_text" %}
+
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Additional dimensions (sector)
+            </td>
+            <td>
+              <table>
+                {% checklist model "additional_dimensions_sector_ecological,additional_dimensions_sector_ecological_text,additional_dimensions_sector_economic,additional_dimensions_sector_economic_text,additional_dimensions_sector_social,additional_dimensions_sector_social_text,additional_dimensions_sector_others=additional_dimensions_sector_others_text" %}
+
+              </table>
+            </td>
+          </tr>
+
+
+        </table>
+      </div>
+    </div>
+    <div class="card ">
+      <div class="card-header">
+        <a data-toggle="collapse" href="#MathematicalProperties">Mathematical Properties</a>
+      </div>
+      <div id="MathematicalProperties" class="card-body collapse ">
+        <table class="profiletable">
+          <tr>
+            <td class="sheetlabel">
+              Model class (optimisation)
+            </td>
+            <td>
+              {% checklist model "model_class_optimization_LP,model_class_optimization_MILP,model_class_optimization_Nonlinear=model_class_optimization_LP_MILP_Nonlinear_text" %}
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Model class (simulation)
+            </td>
+            <td>
+              {% checklist model "model_class_simulation_Agentbased,model_class_simulation_System_Dynamics,model_class_simulation_Accounting_Framework,model_class_simulation_Game_Theoretic_Model,model_class_simulation_bottom_up,model_class_simulation_top_down" %}
+
+            </td>
+          </tr>
+          {% include 'modelview/model_snippet.html' with model=model field='model_class_other' add=model.model_class_other_text %}
+          {% include 'modelview/model_snippet.html' with model=model field='short_description_of_mathematical_model_class' %}
+          <tr>
+            <td class="sheetlabel">
+              Mathematical objective
+            </td>
+            <td>
+              {% checklist model "mathematical_objective_cO2,mathematical_objective_costs,mathematical_objective_rEshare,mathematical_objective_other=mathematical_objective_other_text" %}
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Approach to uncertainty
+            </td>
+            <td>
+              {% checklist model "uncertainty_deterministic,uncertainty_Stochastic,uncertainty_Other=uncertainty_Other_text" %}
+            </td>
+          </tr>
+
+          {% include 'modelview/model_snippet.html' with model=model field='montecarlo' %}
+          {% include 'modelview/model_snippet.html' with model=model field='typical_computation_time' %}
+          {% include 'modelview/model_snippet.html' with model=model field='typical_computation_hardware' %}
+          {% include 'modelview/model_snippet.html' with model=model field='technical_data_anchored_in_the_model' %}
+        </table>
+      </div>
+    </div>
+    <div class="card ">
+      <div class="card-header">
+        <a class="fill-div" data-toggle="collapse" href="#Integration">Model Integration</a>
+      </div>
+      <div id="Integration" class="card-body collapse in  in">
+        <table class="profiletable">
+          {% include 'modelview/model_snippet.html' with model=model field='interfaces' %}
+          {% include 'modelview/model_snippet.html' with model=model field='model_file_format' add=model.model_file_format_other_text %}
+          {% include 'modelview/model_snippet.html' with model=model field='model_input' add=model.model_input_other_text %}
+          {% include 'modelview/model_snippet.html' with model=model field='model_output' add=model.model_output_other_text %}
+          {% include 'modelview/model_snippet.html' with model=model field='integrating_models' %}
+          {% include 'modelview/model_snippet.html' with model=model field='integrated_models' %}
+        </table>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/modelview/templates/modelview/modellist.html
+++ b/modelview/templates/modelview/modellist.html
@@ -27,23 +27,36 @@
       <span class="fas fa-download"></span> Download CSV
     </a>
   <hr>
-  <h3>Fields</h3>
-    <div class="checkbox-container">
-    {% for heading,d in fields.items %}
-        <div class="checkbox-item">
-            <a class="fill-div" data-toggle="collapse" href="#{{heading.split|join:'_'}}">{{heading}}</a>
 
-            <div id="{{heading.split|join:'_'}}" class="card-collapse collapse">
-                {% for key,value in d.items %}
-                    <div style="display: flex;flex-flow: nowrap;align-items: center">
-                        <input type="checkbox" onchange="apply_filter(event.target)" id="{{key}}" {% if key.split|join:'_' in default %} checked="checked" {%endif %}>
-                        <label style="margin: 0" for="{{key}}">{{key}}</label>
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
-    {% endfor %}
-    </div>
+  <h3>Tags</h3>
+  <div style="display: flex; flex-flow: wrap">
+      {% for t in tags %}
+          <label class="tag-checkbox-container {% if t.id in tags %} tag-checkbox-checked {% endif %}" style="background:{{ t.color }};color:{% readable_text_color t.color %}">
+              <input {% if t.id in tags %} checked="checked" {% endif %} type="checkbox" class="tag-checkbox" name="tags" id="select_{{ t.id }}" value="{{ t.id }}" onchange="apply_tag_filter(event.target)">
+              <span>{{ t.name }}</span>
+              <span class="tag-checkbox-icon fas fa-check"></span>
+          </label>
+      {% endfor %}
+  </div>
+  <hr>
+
+  <h3>Fields</h3>
+  <div class="checkbox-container">
+  {% for heading,d in fields.items %}
+      <div class="checkbox-item">
+          <a class="fill-div" data-toggle="collapse" href="#{{heading.split|join:'_'}}">{{heading}}</a>
+
+          <div id="{{heading.split|join:'_'}}" class="card-collapse collapse">
+              {% for key,value in d.items %}
+                  <div style="display: flex;flex-flow: nowrap;align-items: center">
+                      <input type="checkbox" onchange="apply_filter(event.target)" id="{{key}}" {% if key.split|join:'_' in default %} checked="checked" {%endif %}>
+                      <label style="margin: 0" for="{{key}}">{{key}}</label>
+                  </div>
+              {% endfor %}
+          </div>
+      </div>
+  {% endfor %}
+  </div>
   <hr>
 
 {% endblock main-right-sidebar-content %}
@@ -51,23 +64,8 @@
 {% block factsheets_content %}
 
 {% if label == 'Model' or label == 'Framework' %}
-	<div>
-            <h4>Select tag filter:</h4>
-            <div>
-                You can select models by chosing one or more tags. If you want to tag models you can set tags by editing the model. You can also define a new tag and add that to the group of models that you want to compare. You can also <a href="/dataedit/tags">define a new tag</a>.
-            </div>
-            <div class="well">
-                {% for t in tags %}
-                <span>
-                    <input onchange="apply_tag_filter(event.target)" type="checkbox" class="hidden" name="select_{{t.id}}" id="select_{{t.id}}">
-                    <label style="background:{{ t.color }}; color:{% readable_text_color t.color %}" class="btn tag" for="select_{{t.id}}">{{t.name}}</label>
-                </span>
-                {% endfor %}
-            </div>
-        </div>
     <table id="overview" class="display" style="width:100%">
     </table>
-
 
 {% elif label == 'Scenario' %}
 

--- a/modelview/templates/modelview/modellist.html
+++ b/modelview/templates/modelview/modellist.html
@@ -6,29 +6,40 @@
 {% block after-head %}
 <link rel="stylesheet" href="{% static 'css/mv-style.css' %}">
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css">
-{% endblock %}
 
-{% block factsheets_content %}
-<h3>
-  {{label}} Factsheets
-  <a class="btn btn-add btn-circle" style="padding:0" href="add">
-    <span class="fas fa-plus"></span>
-  </a>
-  <a id="dlcsv" class="btn btn-info" style="float:right;bottom: 5;right: 0;" href="download">Download CSV</a>
-</h3>
-
-<br/>
 
 <style>
-    .btn-add{
+  .btn-add{
     background: transparent;
     color: green;
-}
-    input[type="checkbox"]:checked+label{
+  }
+  input[type="checkbox"]:checked+label{
     font-weight: bold;
     border: 3px solid;
-}
+  }
 </style>
+{% endblock %}
+
+
+{% block site-header %}
+  <h2 class="site-header">{{ label }} Factsheets</h2>
+{% endblock site-header %}
+
+{% block main-right-sidebar-content %}
+  <hr>
+  <h3>Actions</h3>
+    <a role="button" class="btn btn-success" href="add">
+      <span class="fas fa-plus"></span> Add {{ label }}
+    </a>
+    <a id="dlcsv" role="button"  class="btn btn-info" href="download">
+      <span class="fas fa-download"></span> Download CSV
+    </a>
+  <hr>
+
+{% endblock main-right-sidebar-content %}
+
+{% block factsheets_content %}
+
 {% if label == 'Model' or label == 'Framework' %}
 <div>
     <h4>Filter</h4>

--- a/modelview/templates/modelview/modellist.html
+++ b/modelview/templates/modelview/modellist.html
@@ -9,14 +9,6 @@
 
 
 <style>
-  .btn-add{
-    background: transparent;
-    color: green;
-  }
-  input[type="checkbox"]:checked+label{
-    font-weight: bold;
-    border: 3px solid;
-  }
 </style>
 {% endblock %}
 
@@ -35,42 +27,30 @@
       <span class="fas fa-download"></span> Download CSV
     </a>
   <hr>
+  <h3>Fields</h3>
+    <div class="checkbox-container">
+    {% for heading,d in fields.items %}
+        <div class="checkbox-item">
+            <a class="fill-div" data-toggle="collapse" href="#{{heading.split|join:'_'}}">{{heading}}</a>
+
+            <div id="{{heading.split|join:'_'}}" class="card-collapse collapse">
+                {% for key,value in d.items %}
+                    <div style="display: flex;flex-flow: nowrap;align-items: center">
+                        <input type="checkbox" onchange="apply_filter(event.target)" id="{{key}}" {% if key.split|join:'_' in default %} checked="checked" {%endif %}>
+                        <label style="margin: 0" for="{{key}}">{{key}}</label>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    {% endfor %}
+    </div>
+  <hr>
 
 {% endblock main-right-sidebar-content %}
 
 {% block factsheets_content %}
 
 {% if label == 'Model' or label == 'Framework' %}
-<div>
-    <h4>Filter</h4>
-    <div>
-    You can filter the attributes to compare the models by clicking the categories below. If you only want to compare a selection of models you can filter them by using the colored tags below.
-    </div>
-    <div class="checkbox-container">
-    {% for heading,d in fields.items %}
-        <div class="checkbox-item">
-            <div class="card-header">
-              <h4 class="card-title">
-                <a class="fill-div" data-toggle="collapse" href="#{{heading.split|join:'_'}}">{{heading}}</a>
-              </h4>
-            </div>
-
-            <div id="{{heading.split|join:'_'}}" class="card-collapse collapse">
-                <table class="table">
-                    {% for key,value in d.items %}
-                        <tr>
-                            <th><label for="{{key}}">{{key}}</label></th>
-                            <td><input type="checkbox" onchange="apply_filter(event.target)" id="{{key}}" {% if key.split|join:'_' in default %} checked="checked" {%endif %}></td>
-                        </tr>
-                    {% endfor %}
-                </table>
-            </div>
-        </div>
-    {% endfor %}
-    </div>
-</div>
-<hr>
-
 	<div>
             <h4>Select tag filter:</h4>
             <div>

--- a/modelview/templates/modelview/modellist.html
+++ b/modelview/templates/modelview/modellist.html
@@ -46,7 +46,7 @@
       <div class="checkbox-item">
           <a class="fill-div" data-toggle="collapse" href="#{{heading.split|join:'_'}}">{{heading}}</a>
 
-          <div id="{{heading.split|join:'_'}}" class="card-collapse collapse">
+          <div id="{{heading.split|join:'_'}}" class="collapse">
               {% for key,value in d.items %}
                   <div style="display: flex;flex-flow: nowrap;align-items: center">
                       <input type="checkbox" onchange="apply_filter(event.target)" id="{{key}}" {% if key.split|join:'_' in default %} checked="checked" {%endif %}>

--- a/modelview/templates/modelview/scenario.html
+++ b/modelview/templates/modelview/scenario.html
@@ -1,264 +1,238 @@
-{% extends "modelview/base.html" %}
+{% extends "modelview/detail_view.html" %}
 {% load bootstrap4 %}
-{% bootstrap_javascript_url %}
 {% load static %}
 {% load modelview_extras %}
 
+{% block main-right-sidebar-content-actions %}
+  <a class="btn btn-info" href="edit"><span class="fas fa-edit"></span>Edit Scenario</a>
+  <a class="btn btn-info" href="/factsheets/studies/{{ model.study.pk }}/edit"><span
+    class="fas fa-edit"></span>Edit Study</a>
+{% endblock main-right-sidebar-content-actions %}
+
 {% block factsheets_content %}
 
-<script type="text/javascript">
-    <!--
-    $(document).ready(function(){
-    $('[data-toggle="popover"]').popover();
-    });
-    //-->
-</script>
+  <div class="card-container">
+    <div class="card">
+      <div class="card-header">
+        <a data-toggle="collapse" href="#BasicInformation">Study</a>
+      </div>
+      <div id="BasicInformation" class="title= collapse in card-body">
 
-<link rel="stylesheet" href="{% static 'css/mv-style.css' %}">
-<div class="container">
-    <div style="float: left;">
-        <h1> {{ model.name_of_scenario }} </h1>
+        <table class="profiletable">
+          {% include 'modelview/model_snippet.html' with model=model_study field='name_of_the_study' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='author_Institution' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='contact_email' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='client' %}
+          <tr>
+            <td class="sheetlabel">
+              Source of funding
+            </td>
+            <td>
+              <table>
+                {% checklist model_study "funding_private,funding_public,funding_no_funding" %}
+
+              </table>
+            </td>
+          </tr>
+
+          {% include 'modelview/model_snippet.html' with model=model_study field='citation_reference' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='citation_doi' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='aim' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='new_aspects' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='spatial_Geographical_coverage' %}
+          <tr>
+            <td class="sheetlabel">
+              Time frame
+            </td>
+            <td>
+              {% checklist model_study "time_frame_2020,time_frame_2030,time_frame_2050,time_frame_other=time_frame_other_text" %}
+
+            </td>
+          </tr>
+          {% include 'modelview/model_snippet.html' with model=model_study field='time_frame_2_target_year' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='time_frame_2_transformation_path' %}
+          <tr>
+            <td class="sheetlabel">
+              Modeled energy sectors
+            </td>
+            <td>
+              {% checklist model_study "modeled_energy_sectors_electricity,modeled_energy_sectors_heat,modeled_energy_sectors_liquid_fuels,modeled_energy_sectors_gas,modeled_energy_sectors_others=modeled_energy_sectors_others_text" %}
+
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Modeled demand sectors
+            </td>
+            <td>
+              {% checklist model_study "modeled_demand_sectors_households,modeled_demand_sectors_industry,modeled_demand_sectors_commercial_sector,modeled_demand_sectors_transport" %}
+
+            </td>
+          </tr>
+
+          <tr>
+            <td class="sheetlabel">
+              Economic (behavioural) rationale
+            </td>
+            <td>
+              {% checklist model_study "economic_behavioral_perfect,economic_behavioral_myopic,economic_behavioral_qualitative,economic_behavioral_agentbased,economic_behavioral_other=economic_behavioral_other_text" %}
+
+            </td>
+          </tr>
+
+          <tr>
+            <td class="sheetlabel">
+              Technologies included
+            </td>
+            <td>
+              {% checklist model_study "renewables_PV,renewables_wind,renewables_hydro,renewables_biomass,renewables_biogas,renewables_solar,renewables_others=renewables_others_text,conventional_generation_gas,conventional_generation_coal,conventional_generation_oil,conventional_generation_liquid,conventional_generation_nuclear,CHP,networks_electricity_gas_electricity,networks_electricity_gas_gas,networks_electricity_gas_heat,storages_battery,storages_kinetic,storages_CAES,storages_PHS,storages_chemical" %}
+
+            </td>
+          </tr>
+
+          {% include 'modelview/model_snippet.html' with model=model_study field='economic_focuses_included' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='social_focuses_included' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='endogenous_variables' %}
+          {% include 'modelview/model_snippet.html' with model=model_study field='sensitivities' %}
+          <tr>
+            <td class="sheetlabel">
+              Technologies included
+            </td>
+            <td>
+              <table>
+                {% checklist model_study "time_steps_anual,time_steps_hour,time_steps_15_min,time_steps_1_min,time_steps_sec,time_steps_other=time_steps_other_text" %}
+
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
     </div>
-    <div style="float:right; position: absolute;right: 0;">
-        <a class="btn btn-info" style="bottom: 40;" href="edit"><span name="icon"></span>Edit Scenario</a>
-        <a class="btn btn-info" style="bottom: 5;" href="/factsheets/studies/{{ model.study.pk }}/edit"><span name="icon"></span>Edit Study</a>
-    </div>
-</div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#BasicInformation">Study</a>
-          </h4>
-        </div>
-        <div id="BasicInformation" class="card-collapse collapse in profilebox in">
-                    
-                    <table class="profiletable">
-                        {% include 'modelview/model_snippet.html' with model=model_study field='name_of_the_study' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='author_Institution' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='contact_email' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='client' %}
-                        <tr>
-                            <td class="sheetlabel">
-                                Source of funding
-                            </td>
-                            <td>
-                                <table>
-				  {% checklist model_study "funding_private,funding_public,funding_no_funding" %}
+      <div class="card-header">
+        <a data-toggle="collapse" href="#MathematicalProperties">Empirical Data</a>
+      </div>
+      <div id="MathematicalProperties" class="title= collapse card-body">
+        <table class="profiletable">
+          <tr>
+            <td class="sheetlabel">
+              Exogenous time series used
+            </td>
+            <td>
+              {% checklist model "exogenous_time_series_used_climate,exogenous_time_series_used_feedin,exogenous_time_series_used_loadcurves,exogenous_time_series_used_others=exogenous_time_series_used_others_text" %}
+            </td>
+          </tr>
 
-                                </table>
-                            </td>
-                        </tr>
-                        
-                        {% include 'modelview/model_snippet.html' with model=model_study field='citation_reference' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='citation_doi' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='aim' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='new_aspects' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='spatial_Geographical_coverage' %}
-                        <tr>
-                            <td class="sheetlabel">
-                                Time frame
-                            </td>
-                            <td>
-                                {% checklist model_study "time_frame_2020,time_frame_2030,time_frame_2050,time_frame_other=time_frame_other_text" %}
+          {% include 'modelview/model_snippet.html' with model=model field='technical_data' %}
+          {% include 'modelview/model_snippet.html' with model=model field='social_data' %}
+          {% include 'modelview/model_snippet.html' with model=model field='economical_data' %}
+          {% include 'modelview/model_snippet.html' with model=model field='ecological_data' %}
+          {% include 'modelview/model_snippet.html' with model=model field='preProcessing' %}
+          {% include 'modelview/model_snippet.html' with model=model field='name_of_scenario' %}
 
-                            </td>
-                        </tr>
-                        {% include 'modelview/model_snippet.html' with model=model_study field='time_frame_2_target_year' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='time_frame_2_transformation_path' %}
-                        <tr>
-                            <td class="sheetlabel">
-                                Modeled energy sectors
-                            </td>
-                            <td>
-				{% checklist model_study "modeled_energy_sectors_electricity,modeled_energy_sectors_heat,modeled_energy_sectors_liquid_fuels,modeled_energy_sectors_gas,modeled_energy_sectors_others=modeled_energy_sectors_others_text" %}
-
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="sheetlabel">
-                                Modeled demand sectors
-                            </td>
-                            <td>
-                                {% checklist model_study "modeled_demand_sectors_households,modeled_demand_sectors_industry,modeled_demand_sectors_commercial_sector,modeled_demand_sectors_transport" %}
-
-                            </td>
-                        </tr>
-
-                        <tr>
-                            <td class="sheetlabel">
-                                Economic (behavioural) rationale
-                            </td>
-                            <td>
-                                {% checklist model_study "economic_behavioral_perfect,economic_behavioral_myopic,economic_behavioral_qualitative,economic_behavioral_agentbased,economic_behavioral_other=economic_behavioral_other_text" %}
-
-                            </td>
-                        </tr>
-                        
-                        <tr>
-                            <td class="sheetlabel">
-                                Technologies included
-                            </td>
-                            <td>
-				{% checklist model_study "renewables_PV,renewables_wind,renewables_hydro,renewables_biomass,renewables_biogas,renewables_solar,renewables_others=renewables_others_text,conventional_generation_gas,conventional_generation_coal,conventional_generation_oil,conventional_generation_liquid,conventional_generation_nuclear,CHP,networks_electricity_gas_electricity,networks_electricity_gas_gas,networks_electricity_gas_heat,storages_battery,storages_kinetic,storages_CAES,storages_PHS,storages_chemical" %}
-
-                            </td>
-                        </tr>                        
-                       
-                        {% include 'modelview/model_snippet.html' with model=model_study field='economic_focuses_included' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='social_focuses_included' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='endogenous_variables' %}
-                        {% include 'modelview/model_snippet.html' with model=model_study field='sensitivities' %}
-                        <tr>
-                            <td class="sheetlabel">
-                                Technologies included
-                            </td>
-                            <td>
-                                <table>
-				     {% checklist model_study "time_steps_anual,time_steps_hour,time_steps_15_min,time_steps_1_min,time_steps_sec,time_steps_other=time_steps_other_text" %}
-
-                                </table>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-    </div>     
-<div class="">
-    <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#MathematicalProperties">Empirical Data</a>
-          </h4>
-        </div>
-        <div id="MathematicalProperties" class="card-collapse collapse profilebox">
-            <table class="profiletable">
-                <tr>
-                    <td class="sheetlabel">
-                        Exogenous time series used
-                    </td>
-                    <td>
-                        {% checklist model "exogenous_time_series_used_climate,exogenous_time_series_used_feedin,exogenous_time_series_used_loadcurves,exogenous_time_series_used_others=exogenous_time_series_used_others_text" %}
-                    </td>
-                </tr>
-                
-                {% include 'modelview/model_snippet.html' with model=model field='technical_data' %}
-                {% include 'modelview/model_snippet.html' with model=model field='social_data' %}
-                {% include 'modelview/model_snippet.html' with model=model field='economical_data' %}
-                {% include 'modelview/model_snippet.html' with model=model field='ecological_data' %}
-                {% include 'modelview/model_snippet.html' with model=model field='preProcessing' %}
-                {% include 'modelview/model_snippet.html' with model=model field='name_of_scenario' %}
-                
-            </table>
-        </div>
+        </table>
+      </div>
     </div>
-</div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#Coverage">Assumptions</a>
-          </h4>
-        </div>
-        <div id="Coverage" class="card-collapse collapse  profilebox">
-            <table class="profiletable">
-                {% develop_year model 'energy_saving' %}
-                {% develop_year model 'potential_energy_savings' %}
-                {% develop_year model 'emission_reductions' %}
-                {% develop_year model 'share_RE_heat' %}
-                {% develop_year model 'share_RE_mobility' %}
-                {% develop_year model 'share_RE_power' %}
-                {% develop_year model 'share_RE_total' %}                
-                <tr>
-                    <td class="sheetlabel">
-                        Cost development
-                    </td>
-                    <td>
-                        <table>
-                            {% checklist model "cost_development_capex,cost_development_opex,cost_development_learning_curves,cost_development_constant,cost_development_rediscount" %}
+      <div class="card-header">
+        <a data-toggle="collapse" href="#Coverage">Assumptions</a>
+      </div>
+      <div id="Coverage" class="title= collapse  card-body">
+        <table class="profiletable">
+          {% develop_year model 'energy_saving' %}
+          {% develop_year model 'potential_energy_savings' %}
+          {% develop_year model 'emission_reductions' %}
+          {% develop_year model 'share_RE_heat' %}
+          {% develop_year model 'share_RE_mobility' %}
+          {% develop_year model 'share_RE_power' %}
+          {% develop_year model 'share_RE_total' %}
+          <tr>
+            <td class="sheetlabel">
+              Cost development
+            </td>
+            <td>
+              <table>
+                {% checklist model "cost_development_capex,cost_development_opex,cost_development_learning_curves,cost_development_constant,cost_development_rediscount" %}
 
-                        </table>
-                    </td>
-                </tr>
-                {% include 'modelview/model_snippet.html' with model=model field='technological_innovations' %}
-                <tr>
-                    <td class="sheetlabel">
-                        Potential wind
-                    </td>
-                    <td>
-                        {% checklist model "potential_wind_whole,potential_wind_technical,potential_wind_economical,potential_wind_ecological,potential_wind_other,potential_wind_other_text" %}
-                    </td>
-                </tr>
-                
-                
-                <tr>
-                    <td class="sheetlabel">
-                        Potential solar electric
-                    </td>
-                    <td>
-                        {% checklist model "potential_solar_electric_whole,potential_solar_electric_technical,potential_solar_electric_economical,potential_solar_electric_ecological,potential_solar_electric_other=potential_solar_electric_other_text" %}
-                    </td>
-                </tr>
-                <tr>
-                    <td class="sheetlabel">
-                        Potential solar thermal
-                    </td>
-                    <td>
-                        {% checklist model "potential_solar_thermal_whole,potential_solar_thermal_technical,potential_solar_thermal_economical,potential_solar_thermal_ecological,potential_solar_thermal_other=potential_solar_thermal_other_text" %}
-                    </td>
-                </tr>
-                
-                <tr>
-                    <td class="sheetlabel">
-                        Potential biomass
-                    </td>
-                    <td>
-                        {% checklist model "potential_biomass_whole,potential_biomass_technical,potential_biomass_economical,potential_biomass_ecological,potential_biomass_other=potential_biomass_other_text" %}
-                    </td>
-                </tr>
-                
-                <tr>
-                    <td class="sheetlabel">
-                        Potential geothermal
-                    </td>
-                    <td>
-                        {% checklist model "potential_geothermal_whole,potential_geothermal_technical,potential_geothermal_economical,potential_geothermal_ecological,potential_geothermal_other,potential_geothermal_othertext" %}
-                    </td>
-                </tr>
-                
-                <tr>
-                    <td class="sheetlabel">
-                        Potential hydro power
-                    </td>
-                    <td>
-                        {% checklist model "potential_hydro_power_whole,potential_hydro_power_technical,potential_hydro_power_economical,potential_hydro_power_ecological,potential_hydro_power_other,potential_hydro_power_other_text" %}
-                    </td>
-                </tr>
-                
-                {% include 'modelview/model_snippet.html' with model=model field='social_developement' %}
-                {% include 'modelview/model_snippet.html' with model=model field='economic_development' %}
-                {% include 'modelview/model_snippet.html' with model=model field='development_of_environmental_aspects' %}
-                {% include 'modelview/model_snippet.html' with model=model field='postprocessing' %}
-                {% include 'modelview/model_snippet.html' with model=model field='further_assumptions_for_postprocessing' %}
-            </table>
-        </div>
+              </table>
+            </td>
+          </tr>
+          {% include 'modelview/model_snippet.html' with model=model field='technological_innovations' %}
+          <tr>
+            <td class="sheetlabel">
+              Potential wind
+            </td>
+            <td>
+              {% checklist model "potential_wind_whole,potential_wind_technical,potential_wind_economical,potential_wind_ecological,potential_wind_other,potential_wind_other_text" %}
+            </td>
+          </tr>
+
+
+          <tr>
+            <td class="sheetlabel">
+              Potential solar electric
+            </td>
+            <td>
+              {% checklist model "potential_solar_electric_whole,potential_solar_electric_technical,potential_solar_electric_economical,potential_solar_electric_ecological,potential_solar_electric_other=potential_solar_electric_other_text" %}
+            </td>
+          </tr>
+          <tr>
+            <td class="sheetlabel">
+              Potential solar thermal
+            </td>
+            <td>
+              {% checklist model "potential_solar_thermal_whole,potential_solar_thermal_technical,potential_solar_thermal_economical,potential_solar_thermal_ecological,potential_solar_thermal_other=potential_solar_thermal_other_text" %}
+            </td>
+          </tr>
+
+          <tr>
+            <td class="sheetlabel">
+              Potential biomass
+            </td>
+            <td>
+              {% checklist model "potential_biomass_whole,potential_biomass_technical,potential_biomass_economical,potential_biomass_ecological,potential_biomass_other=potential_biomass_other_text" %}
+            </td>
+          </tr>
+
+          <tr>
+            <td class="sheetlabel">
+              Potential geothermal
+            </td>
+            <td>
+              {% checklist model "potential_geothermal_whole,potential_geothermal_technical,potential_geothermal_economical,potential_geothermal_ecological,potential_geothermal_other,potential_geothermal_othertext" %}
+            </td>
+          </tr>
+
+          <tr>
+            <td class="sheetlabel">
+              Potential hydro power
+            </td>
+            <td>
+              {% checklist model "potential_hydro_power_whole,potential_hydro_power_technical,potential_hydro_power_economical,potential_hydro_power_ecological,potential_hydro_power_other,potential_hydro_power_other_text" %}
+            </td>
+          </tr>
+
+          {% include 'modelview/model_snippet.html' with model=model field='social_developement' %}
+          {% include 'modelview/model_snippet.html' with model=model field='economic_development' %}
+          {% include 'modelview/model_snippet.html' with model=model field='development_of_environmental_aspects' %}
+          {% include 'modelview/model_snippet.html' with model=model field='postprocessing' %}
+          {% include 'modelview/model_snippet.html' with model=model field='further_assumptions_for_postprocessing' %}
+        </table>
+      </div>
     </div>
-</div>
-<div class="">
     <div class="card ">
-        <div class="card-header">
-          <h4 class="card-title">
-            <a data-toggle="collapse" href="#Results">Results</a>
-          </h4>
-        </div>
-        <div id="Results" class="card-collapse collapse profilebox">
-            <table class="profiletable">
-                {% include 'modelview/model_snippet.html' with model=model field='uncertainty_assessment' %}
-                {% include 'modelview/model_snippet.html' with model=model field='robustness' %}
-                {% include 'modelview/model_snippet.html' with model=model field='comparability_Validation' %}
-                {% include 'modelview/model_snippet.html' with model=model field='conclusions' %}
-            </table>
-        </div>
+      <div class="card-header">
+        <a data-toggle="collapse" href="#Results">Results</a>
+      </div>
+      <div id="Results" class="title= collapse card-body">
+        <table class="profiletable">
+          {% include 'modelview/model_snippet.html' with model=model field='uncertainty_assessment' %}
+          {% include 'modelview/model_snippet.html' with model=model field='robustness' %}
+          {% include 'modelview/model_snippet.html' with model=model field='comparability_Validation' %}
+          {% include 'modelview/model_snippet.html' with model=model field='conclusions' %}
+        </table>
+      </div>
     </div>
-</div>
+  </div>
 
 {% endblock %}

--- a/modelview/views.py
+++ b/modelview/views.py
@@ -156,7 +156,7 @@ def show(request, sheettype, model_name):
     return render(
         request,
         ("modelview/{0}.html".format(sheettype)),
-        {"model": model, "model_study": model_study, "gh_org": org, "gh_repo": repo},
+        {"model": model, "model_study": model_study, "gh_org": org, "gh_repo": repo, "displaySheetType": sheettype.capitalize()},
     )
 
 


### PR DESCRIPTION
I reworked the view for the factsheets for Models and Frameworks.
I moved the filter methods within the sidebar to prioritise the data view by reusing some elements from the data view.

Two Concerns: 

- Not sure, what to do with the column filters. They are less bulky now, but I did not find a good element within bootstrap to implement them.
- I could not test scenarios, because I was not able to create one.