### PR TITLE
feature/tutorial-titles

### DIFF
--- a/base/management/commands/notebooks.py
+++ b/base/management/commands/notebooks.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
 
         if options["command"] == "build":
             # We need to generate the HTML files from the python notebooks.
-            os.system('jupyter nbconvert examples/**/*.ipynb --output-dir=examples/build --to html --template examples/templates/openenergyplatform.tpl')
+            os.system('jupyter nbconvert examples/**/*.ipynb --output-dir=examples/build --to html --template examples/template/openenergyplatform.tpl')
             # We need to parse the titles from the HTML files to be able to show them within the overview.
 
 

--- a/base/management/commands/notebooks.py
+++ b/base/management/commands/notebooks.py
@@ -1,5 +1,8 @@
 from django.core.management.base import BaseCommand, CommandError
 import os
+import glob
+import re
+import json
 
 class Command(BaseCommand):
     help = 'Closes the specified poll for voting'
@@ -18,5 +21,37 @@ class Command(BaseCommand):
             os.system('git submodule update')
 
         if options["command"] == "build":
+            # We need to generate the HTML files from the python notebooks.
             os.system('jupyter nbconvert examples/**/*.ipynb --output-dir=examples/build --to html --template examples/templates/openenergyplatform.tpl')
+            # We need to parse the titles from the HTML files to be able to show them within the overview.
 
+
+            # This is no special regex, i just looked at the HTML and figured out how they are generated
+            htmlMatchPattern = '<h[12] [^>]*>(.*?)<'
+
+            metaData = {}
+            for htmlFileName in glob.glob('./examples/build/*.html'):
+                with open(os.path.join(os.getcwd(), htmlFileName), 'r') as htmlFile:
+                    htmlFileContent = htmlFile.read()
+                    matchResults = re.findall(htmlMatchPattern, htmlFileContent, re.MULTILINE)
+
+                    validMatchForFile = None
+                    print('fileName=%s,matchResults=%i' % (htmlFileName, len(matchResults)))
+                    for matchEntry in matchResults:
+                        # If we already found a title, we do not want to find one again.
+                        # Actually we should return from this loop but python does not support gotos, I guess.
+
+                        # I also removed some matches, which are generally semantically wrong formatted titles
+                        # They are technically no titles, but h1 was used to style them,
+                        # which is viewable, but not parseable or readable for screen readers.
+
+                        if not validMatchForFile and not (matchEntry.lower().startswith('openenergy') or matchEntry.lower().startswith('rli')):
+                            validMatchForFile = matchEntry
+                    print('fileName=%s,generatedTitle=%s' % (htmlFileName, validMatchForFile))
+                    shortFileName = htmlFileName.split("/")[-1]
+                    metaData[shortFileName] = {
+                        'title': validMatchForFile,
+                    }
+
+            with open(os.path.join(os.getcwd(), './examples/build/meta.json'), 'w') as jsonFile:
+                json.dump(metaData, jsonFile, ensure_ascii=False, indent=4)

--- a/base/management/commands/notebooks.py
+++ b/base/management/commands/notebooks.py
@@ -3,6 +3,7 @@ import os
 import glob
 import re
 import json
+import uuid
 
 class Command(BaseCommand):
     help = 'Closes the specified poll for voting'
@@ -29,7 +30,7 @@ class Command(BaseCommand):
             # This is no special regex, i just looked at the HTML and figured out how they are generated
             htmlMatchPattern = '<h[12] [^>]*>(.*?)<'
 
-            metaData = {}
+            metaData = []
             for htmlFileName in glob.glob('./examples/build/*.html'):
                 with open(os.path.join(os.getcwd(), htmlFileName), 'r') as htmlFile:
                     htmlFileContent = htmlFile.read()
@@ -49,9 +50,11 @@ class Command(BaseCommand):
                             validMatchForFile = matchEntry
                     print('fileName=%s,generatedTitle=%s' % (htmlFileName, validMatchForFile))
                     shortFileName = htmlFileName.split("/")[-1]
-                    metaData[shortFileName] = {
-                        'title': validMatchForFile,
-                    }
+                    metaData.append({
+                        'title': validMatchForFile if not None else shortFileName,
+                        'id': str(uuid.uuid4()),
+                        'fileName': shortFileName
+                    })
 
             with open(os.path.join(os.getcwd(), './examples/build/meta.json'), 'w') as jsonFile:
                 json.dump(metaData, jsonFile, ensure_ascii=False, indent=4)

--- a/tutorials/views.py
+++ b/tutorials/views.py
@@ -52,14 +52,12 @@ def _resolveStaticTutorials():
                     'html': rTut['html'],
                 })
 
-            return resolvedTutorials
+            return sorted(resolvedTutorials, key=lambda x: x.title)
     except Exception as e:
         print('Static tutorials could not be loaded, error=%s' % e)
         # If we do not have a generated meta.json or we cannot read them, we just do not return any static
         # tutorials. This is completly fine and dynamic tutorials can be used like normal.
         return []
-
-
 
 
 def _resolveDynamicTutorial(evaluatedQs):

--- a/tutorials/views.py
+++ b/tutorials/views.py
@@ -4,9 +4,8 @@ from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.urls import exceptions, reverse_lazy
 from django.contrib.auth.mixins import LoginRequiredMixin
 
-from os.path import join
-
-from uuid import uuid4
+import os
+import json
 
 from copy import deepcopy
 
@@ -22,88 +21,9 @@ import re
 
 youtubeUrlRegex = re.compile('^.*youtube\.com\/watch\?v=(?P<id>[A-z0-9]+)$')
 
-staticTutorials = [
-    {
-        "id": "e59819c7-46fd-4528-b2bd-f37e8866d1df",
-        "title": "appBBB-UML.html",
-        "fileName": "appBBB-UML.html"
-    },
-    {
-        "id": "5064610a-596a-4911-8862-e9d815d872d4",
-        "title": "df_normalize_denormalize.html",
-        "fileName": "df_normalize_denormalize.html"
-    },
-    {
-        "id": "56c675ea-93ae-43cf-886c-01f4fc98711f",
-        "title": "germany-UML.html",
-        "fileName": "germany-UML.html"
-    },
-    {
-        "id": "7e51c992-5a8a-419f-b778-31a1dd32db4a",
-        "title": "OEP-api_template.html",
-        "fileName": "OEP-api_template.html"
-    },
-    {
-        "id": "61201725-493f-4dd0-b9aa-6e0f6d6aa550",
-        "title": "OEP_API_tutorial_part1.html",
-        "fileName": "OEP_API_tutorial_part1.html"
-    },
-    {
-        "id": "c4e48c2d-626a-45ad-aa68-a6711c7af85c",
-        "title": "OEP_API_tutorial_part2.html",
-        "fileName": "OEP_API_tutorial_part2.html"
-    },
-    {
-        "id": "eab6aece-cff8-4265-989f-3dd9d7d03026",
-        "title": "OEP_API_tutorial_part3.html",
-        "fileName": "OEP_API_tutorial_part3.html"
-    },
-    {
-        "id": "a1d6fc71-6694-4704-8ab4-950be4de9561",
-        "title": "OEP_API_tutorial_part4.html",
-        "fileName": "OEP_API_tutorial_part4.html"
-    },
-    {
-        "id": "ea5e68ef-bcfb-47a1-9768-b5184797bcab",
-        "title": "OEP-oedialect_eGoDP.html",
-        "fileName": "OEP-oedialect_eGoDP.html"
-    },
-    {
-        "id": "44634b85-389f-4c26-988f-217ee9c6f768",
-        "title": "OEP-oedialect-geoquery.html",
-        "fileName": "OEP-oedialect-geoquery.html"
-    },
-    {
-        "id": "cc9e9a5e-826b-4296-a544-e057003dd22c",
-        "title": "OEP-oedialect.html",
-        "fileName": "OEP-oedialect.html"
-    },
-    {
-        "id": "99f35e78-49ca-47f4-9926-d5197c0e3ffe",
-        "title": "OEP-oedialect_template.html",
-        "fileName": "OEP-oedialect_template.html"
-    },
-    {
-        "id": "c254d5e4-479b-423f-92fb-c10411abab66",
-        "title": "OEP-oedialect_upload_from_csv.html",
-        "fileName": "OEP-oedialect_upload_from_csv.html"
-    },
-    {
-        "id": "bc6ad0f4-d9ed-4f00-84e4-f3b62f3eafca",
-        "title": "rli_tool_validate-metadata-datapackage.html",
-        "fileName": "rli_tool_validate-metadata-datapackage.html"
-    },
-    {
-        "id": "43d4da3a-4fef-4524-8c17-7214637e44ad",
-        "title": "UML Tutorial.html",
-        "fileName": "UML Tutorial.html"
-    },
-]
-
-
 def _resolveStaticTutorial(tutorial):
     try:
-        with open(join(settings.BASE_DIR, "examples", "build", tutorial["fileName"]), 'r') as buildFile:
+        with open(os.path.join(settings.BASE_DIR, "examples", "build", tutorial["fileName"]), 'r') as buildFile:
                 buildFileContent = buildFile.read()
 
         return {
@@ -114,20 +34,32 @@ def _resolveStaticTutorial(tutorial):
         return {"html": "Tutorial is missing"}
 
 
-def _resolveStaticTutorials(tutorials):
+def _resolveStaticTutorials():
     resolvedTutorials = []
 
-    # I was not able to solve this problem without an object spread operator due to my JS history.
-    # The copy does not have a specific reason but not iterating over the array which is modified in interation.
+    # Load list of static tutorials
 
-    for tutorial in tutorials:
-        paramsToAdd = _resolveStaticTutorial(tutorial)
-        copiedTutorial = deepcopy(tutorial)
-        copiedTutorial.update(paramsToAdd)
+    try:
+        with open(os.path.join(os.getcwd(), "examples", "build", 'meta.json'), 'r') as metaFile:
+            metaContent = json.load(metaFile)
 
-        resolvedTutorials.append(copiedTutorial)
+            for tutorial in metaContent:
+                rTut = _resolveStaticTutorial(tutorial)
+                resolvedTutorials.append({
+                    'id': tutorial['id'],
+                    'fileName': tutorial['fileName'],
+                    'title': tutorial['title'],
+                    'html': rTut['html'],
+                })
 
-    return resolvedTutorials
+            return resolvedTutorials
+    except Exception as e:
+        print('Static tutorials could not be loaded, error=%s' % e)
+        # If we do not have a generated meta.json or we cannot read them, we just do not return any static
+        # tutorials. This is completly fine and dynamic tutorials can be used like normal.
+        return []
+
+
 
 
 def _resolveDynamicTutorial(evaluatedQs):
@@ -184,7 +116,7 @@ def _gatherTutorials(id=None):
     # Retrieve allTutorials objects from db and cache
     dynamicTutorialsQs = Tutorial.objects.all()
 
-    tutorials = _resolveStaticTutorials(staticTutorials)
+    tutorials = _resolveStaticTutorials()
     tutorials.extend(_resolveDynamicTutorials(dynamicTutorialsQs))
 
     if id:


### PR DESCRIPTION
@MGlauer asks me to parse some human-readable titles from the html, which is generated from the Notebooks.
Therefore we introduced a `meta.json` file, which is generated at **build** time, which includes a list of files and additionally parsed titles and some meta information, which was hardcoded beforehand.

Therefore, we can now add new static tutorials without touching code.
Also, we now have human-readable titles.