### PR TITLE
dataedit update tag filter UI

### DIFF
--- a/dataedit/templates/dataedit/dataedit_schemalist.html
+++ b/dataedit/templates/dataedit/dataedit_schemalist.html
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
         {% for schema, description, tables, tag_ids in schemas %}
-            <tr onclick="window.location='/dataedit/view/{{ schema }}'">
+            <tr onclick="window.location='/dataedit/view/{{ schema }}{% if request.GET %}?{% endif %}{{ request.GET.urlencode }}'">
                 <td>{{schema}}</td>
                 <td>{{description}}</td>
                 <td>{{tables}}</td>

--- a/dataedit/templates/dataedit/dataedit_schemalist.html
+++ b/dataedit/templates/dataedit/dataedit_schemalist.html
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
         {% for schema, description, tables, tag_ids in schemas %}
-            <tr onclick="window.location='/dataedit/view/{{ schema }}{% if request.GET %}?{% endif %}{{ request.GET.urlencode }}'">
+            <tr onclick="window.location='/dataedit/view/{{ schema }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}'">
                 <td>{{schema}}</td>
                 <td>{{description}}</td>
                 <td>{{tables}}</td>

--- a/dataedit/templates/dataedit/dataedit_tablelist.html
+++ b/dataedit/templates/dataedit/dataedit_tablelist.html
@@ -26,7 +26,7 @@
                 {% endif %}
                 <td>
                     {% for tag in tags %}
-                        <a class="btn tag" href="/dataedit/tags" style="background:{{tag.color}};color:{% readable_text_color tag.color %}">{{tag.name}}</a>
+                        <a class="btn tag" href="/dataedit/view/{{ schema }}?query=&tags={{ tag.id }}" style="background:{{tag.color}};color:{% readable_text_color tag.color %}">{{tag.name}}</a>
                     {% endfor %}
                 </td>
             </tr>

--- a/dataedit/templates/dataedit/filter.html
+++ b/dataedit/templates/dataedit/filter.html
@@ -40,7 +40,7 @@
         <ul class="list-group">
             <p class="font-weight-bold" style="margin-bottom: 0px;">Add Tags to a table:</p> <li class="list-group-item">Tags can be added when viewing a table.</li>
             <p class="font-weight-bold" style="margin-bottom: 0px; margin-top: 10px;">Create new Tags:</p> <li class="list-group-item">You can create <a href="/dataedit/tags">new Tags</a>.</li>
-            <p class="font-weight-bold" style="margin-bottom: 0px; margin-top: 10px;">Find data resources:</p> <li class="list-group-item"> Use the Filters on Tags or try searching for strings that occur in table names. You can combine text and Tags filters to get more precise results. If you filter for multiple Tags, only tables containing all filtered Tags will be displayed. </li>
+            <p class="font-weight-bold" style="margin-bottom: 0px; margin-top: 10px;">Find data resources:</p> <li class="list-group-item"> Use the Filters on Tags or try searching for text that may occur in table names or in metadata. You can combine text and Tags filters to get more precise results. If you filter for multiple Tags, only tables containing all filtered Tags will be displayed. </li>
         </ul>
     </div>
     </div>

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -1,3 +1,6 @@
 ### Features
+ 
 
 ### Bugs
+
+* Improve UI in dataedit tag search [PR#688](https://github.com/OpenEnergyPlatform/oeplatform/pull/688)


### PR DESCRIPTION
- When a filter is applied to tags at the dataedit/schema level, clicking on a schema now keeps the http.get parameters
- If an user clicks on a tag label (that is listed on a table) a filter for that single tag is applied as http.get
- Update the filters description text 
 
Closes #614
Closes #681
Closes #678