### PR TITLE
[Tutorials] remove sidebar fom jupyter tutorials detail view

### DIFF
--- a/tutorials/templates/detail.html
+++ b/tutorials/templates/detail.html
@@ -5,21 +5,18 @@
   <h2 class="site-header">Tutorial: {{tutorial.title}}</h2>
 {% endblock site-header %}
 
-{% block main-right-sidebar-content  %}
-  {% if user.is_authenticated %}
-    <hr>
-    <h4>Actions</h4>
-     {% if not tutorial.fileName %}
-        {% if user.is_authenticated %}
-              <a type="button" class="btn btn-sm btn-success" href="{% url 'edit_tutorial' tutorial_id=tutorial.id %}">Edit</a>
-              <a type="button" class="btn btn-sm btn-danger" href="{% url 'delete_tutorial' tutorial_id=tutorial.id %}">Delete</a>
-        {% endif %}
-    {% else %}
-         <a type="button" class="btn btn-sm btn-success" href="https://github.com/OpenEnergyPlatform/examples">Edit</a>
+{% if not tutorial.fileName %}
+  {% block main-right-sidebar-content  %}
+    {% if user.is_authenticated %}
+      <hr>
+      <h4>Actions</h4>
+      {% if user.is_authenticated %}
+        <a type="button" class="btn btn-sm btn-success" href="{% url 'edit_tutorial' tutorial_id=tutorial.id %}">Edit</a>
+        <a type="button" class="btn btn-sm btn-danger" href="{% url 'delete_tutorial' tutorial_id=tutorial.id %}">Delete</a>
+      {% endif %}
     {% endif %}
-  {% endif %}
-
-{% endblock main-right-sidebar-content  %}
+  {% endblock main-right-sidebar-content  %}
+{% endif %}
 
 {% block main-content-body %}
 {% load static %}


### PR DESCRIPTION
- imported jupyter notebook tutorial overlaps the sidebar content
- sidebar is imported from base and need to be excluded from tutorials/templates/detail.hmtl