### PR TITLE
Fix deprectated doc link on top of site #694

### DIFF
--- a/base/templates/base/base.html
+++ b/base/templates/base/base.html
@@ -63,7 +63,7 @@
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="https://github.com/OpenEnergyPlatform/oeplatform/wiki">Documentation</a>
+                    <a class="nav-link" href="https://oep-data-interface.readthedocs.io/en/latest/">Documentation</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="/about">About OEP</a>


### PR DESCRIPTION
Now links to api documentation like the box on the site.
Closes #694 