### PR TITLE
reintroduced the datapackage download button, and remove duplicated permissions button

### DIFF
--- a/dataedit/templates/dataedit/dataview.html
+++ b/dataedit/templates/dataedit/dataview.html
@@ -108,7 +108,7 @@
   <h4>Downloads</h4>
   <div class="btn-group btn-group-sm" role="group" aria-label="Actions">
     <a href="/api/v0/schema/{{ schema }}/tables/{{ table }}/rows?form=csv" type="button" class="btn btn-success">Download CSV</a>
-    <a href="{{ table }}/permissions" type="button" class="btn btn-danger">Permissions</a>
+    <a href="/api/v0/schema/{{ schema }}/tables/{{ table }}/rows?form=datapackage" type="button" class="btn btn-warning">Download Datapackage</a>
   </div>
   <hr>
 


### PR DESCRIPTION
The "download datapackage" button was lost or confused with the permissions button. I removed the duplicate permissions button and reintroduced the download.

Closes #711