### PR TITLE
Static Tutorial Titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,10 @@ We use `alembic` to keep track of changes in those tables. To create all tables 
 
 ##### 3.1 Rendering Jupyter Notebooks
 
-Tutorials needs an additional build step to download and build the existing Jupyter notebooks in another [repository](https://github.com/OpenEnergyPlatform/examples).
+Tutorials needs an additional step to display the existing Jupyter notebooks in another [repository](https://github.com/OpenEnergyPlatform/examples).
+This basically recursivly clones the submodule, which is linked within `/examples`.
 
     python manage.py notebooks download
-    python manage.py notebooks build
 
 ### Deploy locally
 

--- a/base/management/commands/notebooks.py
+++ b/base/management/commands/notebooks.py
@@ -1,17 +1,11 @@
 from django.core.management.base import BaseCommand, CommandError
 import os
-import glob
-import re
-import json
-import uuid
 
 class Command(BaseCommand):
     help = 'Closes the specified poll for voting'
 
     def add_arguments(self, parser):
-        parser.add_argument('command', choices=['download', 'update', 'build'])
-        parser.add_argument("--update")
-        parser.add_argument("--build")
+        parser.add_argument('command', choices=['download', 'update'])
 
     def handle(self, *args, **options):
 
@@ -20,41 +14,3 @@ class Command(BaseCommand):
 
         if options["command"] == "update":
             os.system('git submodule update')
-
-        if options["command"] == "build":
-            # We need to generate the HTML files from the python notebooks.
-            os.system('jupyter nbconvert examples/**/*.ipynb --output-dir=examples/build --to html --template examples/template/openenergyplatform.tpl')
-            # We need to parse the titles from the HTML files to be able to show them within the overview.
-
-
-            # This is no special regex, i just looked at the HTML and figured out how they are generated
-            htmlMatchPattern = '<h[12] [^>]*>(.*?)<'
-
-            metaData = []
-            for htmlFileName in glob.glob('./examples/build/*.html'):
-                with open(os.path.join(os.getcwd(), htmlFileName), 'r') as htmlFile:
-                    htmlFileContent = htmlFile.read()
-                    matchResults = re.findall(htmlMatchPattern, htmlFileContent, re.MULTILINE)
-
-                    validMatchForFile = None
-                    print('fileName=%s,matchResults=%i' % (htmlFileName, len(matchResults)))
-                    for matchEntry in matchResults:
-                        # If we already found a title, we do not want to find one again.
-                        # Actually we should return from this loop but python does not support gotos, I guess.
-
-                        # I also removed some matches, which are generally semantically wrong formatted titles
-                        # They are technically no titles, but h1 was used to style them,
-                        # which is viewable, but not parseable or readable for screen readers.
-
-                        if not validMatchForFile and not (matchEntry.lower().startswith('openenergy') or matchEntry.lower().startswith('rli')):
-                            validMatchForFile = matchEntry
-                    print('fileName=%s,generatedTitle=%s' % (htmlFileName, validMatchForFile))
-                    shortFileName = htmlFileName.split("/")[-1]
-                    metaData.append({
-                        'title': validMatchForFile if not None else shortFileName,
-                        'id': str(uuid.uuid4()),
-                        'fileName': shortFileName
-                    })
-
-            with open(os.path.join(os.getcwd(), './examples/build/meta.json'), 'w') as jsonFile:
-                json.dump(metaData, jsonFile, ensure_ascii=False, indent=4)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ rdflib
 django-jquery
 zipstream-new
 Pygments
+nbconvert==5.6.1

--- a/tutorials/templates/detail.html
+++ b/tutorials/templates/detail.html
@@ -5,25 +5,24 @@
   <h2 class="site-header">Tutorial: {{tutorial.title}}</h2>
 {% endblock site-header %}
 
-{% if not tutorial.fileName %}
-  {% block main-right-sidebar-content  %}
-    {% if user.is_authenticated %}
-      <hr>
-      <h4>Actions</h4>
-      {% if user.is_authenticated %}
-        <a type="button" class="btn btn-sm btn-success" href="{% url 'edit_tutorial' tutorial_id=tutorial.id %}">Edit</a>
-        <a type="button" class="btn btn-sm btn-danger" href="{% url 'delete_tutorial' tutorial_id=tutorial.id %}">Delete</a>
-        <a type="button" class="btn btn-sm btn-danger" href="/tutorials/">Back</a>
-      {% endif %}
+{% block main-right-sidebar-content  %}
+    {% if not tutorial.isStatic %}
+        {% if user.is_authenticated %}
+          <hr>
+          <h4>Actions</h4>
+            <a type="button" class="btn btn-sm btn-success" href="{% url 'edit_tutorial' tutorial_id=tutorial.id %}">Edit</a>
+            <a type="button" class="btn btn-sm btn-danger" href="{% url 'delete_tutorial' tutorial_id=tutorial.id %}">Delete</a>
+            <a type="button" class="btn btn-sm btn-danger" href="/tutorials/">Back</a>
+        {% endif %}
     {% endif %}
-  {% endblock main-right-sidebar-content  %}
-{% endif %}
+{% endblock main-right-sidebar-content  %}
+
 
 {% block main-content-body %}
 {% load static %}
 
 
-     <span></span>
+    <span></span>
     <div>
         {{ tutorial.html | safe }}
     </div>

--- a/tutorials/templates/list.html
+++ b/tutorials/templates/list.html
@@ -27,7 +27,11 @@
       {% for tutorial in tutorials %}
         <tr>
           <td>
+            {% if tutorial.isStatic %}
+            <a href="jupyter/{{tutorial.id}}">{{ tutorial.title }}</a>
+            {% else %}
             <a href="{{tutorial.id}}">{{ tutorial.title }}</a>
+            {% endif %}
           </td>
         </tr>
       {% endfor %}

--- a/tutorials/urls.py
+++ b/tutorials/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     url(r'(?P<tutorial_id>[\w\-]+)/delete/', views.DeleteTutorial.as_view(), name='delete_tutorial'),
 
     # This must be last, otherwise it will match anything
+    url(r'jupyter/(?P<tutorial_id>[\w\-]+)/$', views.TutorialDetail.as_view(), name='detail_tutorial'),
     url(r'^(?P<tutorial_id>[\w\-]+)/$', views.TutorialDetail.as_view(), name='detail_tutorial'),
 ]

--- a/tutorials/views.py
+++ b/tutorials/views.py
@@ -4,8 +4,12 @@ from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.urls import exceptions, reverse_lazy
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import Http404
+from pathlib import Path
 import os
 import json
+import nbformat
+import nbconvert
+from jinja2 import DictLoader
 
 from copy import deepcopy
 
@@ -21,44 +25,64 @@ import re
 
 youtubeUrlRegex = re.compile('^.*youtube\.com\/watch\?v=(?P<id>[A-z0-9]+)$')
 
-def _resolveStaticTutorial(tutorial):
+def _resolveStaticTutorial(path):
     try:
-        with open(os.path.join(settings.BASE_DIR, "examples", "build", tutorial["fileName"]), 'r') as buildFile:
+        with open(path, 'r') as buildFile:
+            with open(os.path.join(settings.BASE_DIR, 'examples', 'template', 'openenergyplatform.tpl'), 'r') as templateFile:
                 buildFileContent = buildFile.read()
+                templateFileContent = templateFile.read()
 
-        return {
-            "html": buildFileContent
-        }
+                jake_notebook = nbformat.reads(buildFileContent, as_version=4)
+                dl = DictLoader({'openenergyplatform': templateFileContent})
+
+                html_exporter = nbconvert.HTMLExporter(extra_loaders=[dl], template_file='openenergyplatform')
+                (body, resources) = html_exporter.from_notebook_node(jake_notebook)
+
+                return {
+                    "html": body
+                }
 
     except:
-        return {"html": "Tutorial is missing"}
-
+        return {
+            "html": "Tutorial is missing"
+        }
 
 def _resolveStaticTutorials():
     resolvedTutorials = []
 
     # Load list of static tutorials
 
+    jsonPaths = Path().rglob('*.json')
+
     try:
-        with open(os.path.join(settings.BASE_DIR, "examples", "build", 'meta.json'), 'r') as metaFile:
-            metaContent = json.load(metaFile)
+        for jsonPath in jsonPaths:
+            neededNotebookPath = os.path.splitext(jsonPath)[0]+'.ipynb'
+            notebookPathExists = os.path.exists(neededNotebookPath)
 
-            for tutorial in metaContent:
-                rTut = _resolveStaticTutorial(tutorial)
-                resolvedTutorials.append({
-                    'id': tutorial['id'],
-                    'fileName': tutorial['fileName'],
-                    'title': tutorial['title'] or tutorial['fileName'],
-                    'html': rTut['html'],
-                })
+            if not notebookPathExists:
+                continue
 
-            return sorted(resolvedTutorials, key=lambda x: x["title"])
+            with open(jsonPath, 'r') as jsonFile:
+                jsonContent = json.load(jsonFile)
+
+            rTut = _resolveStaticTutorial(neededNotebookPath)
+
+            resolvedTutorials.append({
+                'id': jsonContent['name'],
+                'title': jsonContent['displayName'],
+                'html': rTut['html'],
+                'isStatic': True,
+            })
+
+        return sorted(resolvedTutorials, key=lambda x: x["title"])
     except Exception as e:
         print('Static tutorials could not be loaded, error=%s' % e)
         # If we do not have a generated meta.json or we cannot read them, we just do not return any static
         # tutorials. This is completly fine and dynamic tutorials can be used like normal.
         return []
 
+
+staticTutorials = _resolveStaticTutorials()
 
 def _resolveDynamicTutorial(evaluatedQs):
     """
@@ -114,7 +138,7 @@ def _gatherTutorials(id=None):
     # Retrieve allTutorials objects from db and cache
     dynamicTutorialsQs = Tutorial.objects.all()
 
-    tutorials = _resolveStaticTutorials()
+    tutorials = staticTutorials.copy()
     tutorials.extend(_resolveDynamicTutorials(dynamicTutorialsQs))
 
     if id:


### PR DESCRIPTION
This PR implements static URLs for tutorials, which are defined within a `.json` with the same file name containing tutorial metadata.

This also removes the unnecessary build step. It is just necessary to clone the submodule within /examples. This can also be done with `python manage.py notebook download` as before.
This also removes a bug, where the detail view of static tutorials showed edit buttons.

Note: Right now, I use the `openenergyplatform.tpl`, which is NOT used within the current deployment at openenergy-platform.org. How do we proceed?