### PR TITLE
Various Fixes for Jupyter Notebooks in tutorials

### DIFF
--- a/tutorials/static/css/detail.css
+++ b/tutorials/static/css/detail.css
@@ -1,0 +1,38 @@
+.tutorial-container h1 > .anchor-link,
+.tutorial-container h2 > .anchor-link,
+.tutorial-container h3 > .anchor-link,
+.tutorial-container h4 > .anchor-link {
+
+    font-size: 0.4em;
+    margin-left: 1em;
+}
+
+.tutorial-container h1 {
+    font-size: 2rem;
+}
+.tutorial-container h2 {
+    font-size: 1.75rem;
+}
+.tutorial-container h3 {
+    font-size: 1.5rem;
+}
+.tutorial-container h4 {
+    font-size: 1.25rem;
+}
+.tutorial-container h5 {
+    font-size: 1rem;
+}
+.tutorial-container h6 {
+    font-size: 1rem;
+}
+
+
+.tutorial-container h1,
+.tutorial-container h2,
+.tutorial-container h3,
+.tutorial-container h4,
+.tutorial-container h5,
+.tutorial-container h6 {
+    margin-top: 1em;
+}
+

--- a/tutorials/templates/detail.html
+++ b/tutorials/templates/detail.html
@@ -1,5 +1,10 @@
 {% extends "base/base.html" %}
 {% load bootstrap4 %}
+{% load static %}
+
+{% block after-head %}
+<link rel="stylesheet" href="{% static 'css/detail.css' %}">
+{% endblock %}
 
 {% block site-header %}
   <h2 class="site-header">Tutorial: {{tutorial.title}}</h2>
@@ -30,7 +35,7 @@
 
 
     <span></span>
-    <div>
+    <div class="tutorial-container">
         {{ tutorial.html | safe }}
     </div>
     <div>

--- a/tutorials/views.py
+++ b/tutorials/views.py
@@ -37,8 +37,11 @@ def _resolveStaticTutorial(path):
                 jake_notebook = nbformat.reads(buildFileContent, as_version=4)
                 dl = DictLoader({'openenergyplatform': templateFileContent})
 
-                html_exporter = nbconvert.HTMLExporter(extra_loaders=[dl], template_file='openenergyplatform')
+                html_exporter = nbconvert.HTMLExporter(extra_loaders=[dl], template_file='openenergyplatform', anchor_link_text="Permalink" )
                 (body, resources) = html_exporter.from_notebook_node(jake_notebook)
+
+                # Adding needed bootstrap styling to table.
+                body = body.replace("<table", "<table class=\"table\" ")
 
                 return {
                     "html": body


### PR DESCRIPTION
This is a PR to several issues with jupyter notebooks and the tutorial view.

Fixes: 



- #755
  - <img src="https://user-images.githubusercontent.com/12380026/123636516-42205b00-d81d-11eb-8489-9ecf990fcbcc.png" width="300">

  

I point this to `tutorials_ui/extended-tutorial-content`, because I needed the done changes. If this is merged into develop before finishing this PR, we will merge this PR into develop and it will just work without conflict.

