### PR TITLE
clickable links for model outputs in factsheets

### DIFF
--- a/modelview/rdf/factory.py
+++ b/modelview/rdf/factory.py
@@ -95,8 +95,8 @@ class RDFFactory(ABC):
                 fname = t["fname"]["value"]
                 d[s] = d.get(s, dict())
                 res = ''
-                if fname == 'has_input':
-                    res = context.query_one_object(o, '<https://schema.org/url>')["results"]["bindings"][0]["object"]["value"]
+                if fname == 'has_input' or fname == 'has_output':
+                    res = context.query_one_object(o, '<https://schema.org/url>')["results"]["bindings"] [0]["object"]["value"]
                 d[s][fname] = d[s].get(fname, []) + [(o, res)]
 
         cached_objects.update(


### PR DESCRIPTION
The outputs of model calculations in factsheets are now referring to the corresponding dataset in the OEP.