### PR TITLE
fix oep.iks.cs.ovgu.de and http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Documentation Status](https://readthedocs.org/projects/oep-data-interface/badge/?version=latest)](http://oep-data-interface.readthedocs.io/?badge=latest)
 
-<a href="http://oep.iks.cs.ovgu.de/"><img align="right" width="200" height="200" src="https://avatars2.githubusercontent.com/u/37101913?s=400&u=9b593cfdb6048a05ea6e72d333169a65e7c922be&v=4" alt="OpenEnergyPlatform"></a>
+<a href="https://openenergy-platform.org/"><img align="right" width="200" height="200" src="https://avatars2.githubusercontent.com/u/37101913?s=400&u=9b593cfdb6048a05ea6e72d333169a65e7c922be&v=4" alt="OpenEnergyPlatform"></a>
 
 # Open Energy Family - Open Energy Platform (OEP)
 
-Repository for the code of the Open Energy Platform (OEP) website [http://openenergy-platform.org/](http://openenergy-platform.org/). This repository does not contain data, for data access please consult [this page](https://github.com/OpenEnergyPlatform/organisation/blob/master/README.md)
+Repository for the code of the Open Energy Platform (OEP) website [https://openenergy-platform.org/](https://openenergy-platform.org/). This repository does not contain data, for data access please consult [this page](https://github.com/OpenEnergyPlatform/organisation/blob/master/README.md)
 
 ## License / Copyright
 

--- a/api/tests/test_meta.py
+++ b/api/tests/test_meta.py
@@ -131,7 +131,7 @@ class TestPut(APITestCase):
         null = None
         meta = {"name": "oep_metadata_table_example_v14",
 "title": "Good example title",
-"id": "https://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
+"id": "https://openenergy-platform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
 "description": "example metadata for example data",
 "language": [ "en-GB", "en-US", "de-DE", "fr-FR" ],
 "keywords": [ "example", "template", "test" ],
@@ -201,7 +201,7 @@ class TestPut(APITestCase):
 "resources": [
     {"profile": "tabular-data-resource",
     "name": "model_draft.oep_metadata_table_example_v14",
-    "path": "https://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
+    "path": "https://openenergy-platform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
     "format": "PostgreSQL",
     "encoding" : "UTF-8",
     "schema": {

--- a/api/tests/test_meta.py
+++ b/api/tests/test_meta.py
@@ -131,7 +131,7 @@ class TestPut(APITestCase):
         null = None
         meta = {"name": "oep_metadata_table_example_v14",
 "title": "Good example title",
-"id": "http://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
+"id": "https://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
 "description": "example metadata for example data",
 "language": [ "en-GB", "en-US", "de-DE", "fr-FR" ],
 "keywords": [ "example", "template", "test" ],
@@ -201,7 +201,7 @@ class TestPut(APITestCase):
 "resources": [
     {"profile": "tabular-data-resource",
     "name": "model_draft.oep_metadata_table_example_v14",
-    "path": "http://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
+    "path": "https://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
     "format": "PostgreSQL",
     "encoding" : "UTF-8",
     "schema": {

--- a/docs/source/api/how_to.rst
+++ b/docs/source/api/how_to.rst
@@ -47,7 +47,7 @@ We want to create the following table with primary key `id`:
 
 In order to do so, we send the following PUT request::
 
-    PUT oep.iks.cs.ovgu.de/api/v0/schema/sandbox/tables/example_table/
+    PUT https://openenergy-platform.org/api/v0/schema/sandbox/tables/example_table/
     {
         "query": {
             "columns": [
@@ -111,7 +111,7 @@ tool **curl**::
                     "metadata": {"id": "sandbox.example_table"}
                 }
             }'
-        oep.iks.cs.ovgu.de/api/v0/schema/sandbox/tables/example_table/
+        https://openenergy-platform.org/api/v0/schema/sandbox/tables/example_table/
 
 
 or **python**:
@@ -177,7 +177,7 @@ In the following example, we want to add a row containing just the name
         -H "Content-Type: application/json"
         -H 'Authorization: Token <your-token>'
         -d '{"query": {"name": "John Doe"}}'
-        oep.iks.cs.ovgu.de/api/v0/schema/sandbox/tables/example_table/rows/
+        https://openenergy-platform.org//api/v0/schema/sandbox/tables/example_table/rows/
 
 **python**:
 
@@ -232,7 +232,7 @@ No authorization is required to do so.
 
     curl
         -X GET
-        oep.iks.cs.ovgu.de/api/v0/schema/sandbox/tables/example_table/rows/
+        https://openenergy-platform.org/api/v0/schema/sandbox/tables/example_table/rows/
 
 The data will be returned as list of JSON-dictionaries similar to the ones used
 when adding new rows::


### PR DESCRIPTION
* replaced `oep.iks.cs.ovgu.de` with `openenergy-platform.org`
* replaced `openenergyplatform.org` with `openenergy-platform.org`
* replaced `http://` with 'https://' for `openenergy-platform.org`