### PR TITLE
Feature/add project subpages to about overview#971

### DIFF
--- a/base/templates/base/about.html
+++ b/base/templates/base/about.html
@@ -77,36 +77,6 @@
             border="0" />
     </a>
     {% endfor %}
-    <!-- <a class="logo" href="https://github.com/open-fred" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/open_FRED_Header.png' %}"
-                 alt="open_FRED" width="275"
-                 border="0"/>
-        </a>
-        <a class="logo" href="https://reiner-lemoine-institut.de/en/szenariendb/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/SzenarienDB_Header.png' %}"
-                 alt="SzenarienDB" width="275"
-                 border="0"/>
-        </a>
-        <a class="logo" href="https://reiner-lemoine-institut.de/open_modex/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/open_MODEX_Header.jpg' %}"
-                 alt="open_MODEX" width="275"
-                 border="0"/>
-        </a>
-        <a class="logo" href="https://reiner-lemoine-institut.de/lod-geoss/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/LOD-GEOSS_Header.png' %}"
-                 alt="LOD-GEOSS" width="275"
-                 border="0"/>
-        </a>
-        <a class="logo" href="https://reiner-lemoine-institut.de/automatisiertes-vergleichen-energieszenarien-sirop/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/SIROP_logo.png' %}"
-                 alt="SIROP" width="275"
-                 border="0"/>
-        </a> -->
 </div>
 
 <h4 id="who-partners">Partners</h4>

--- a/base/templates/base/about.html
+++ b/base/templates/base/about.html
@@ -7,8 +7,9 @@
 <h2>Open Energy Family and Open Energy Platform</h2> <br>
 
 <a href="{% static 'img/about/OpenEnergyFamily_GroupPhoto.png' %}">
-        <img style="width:50%" class="mx-auto d-block" src="{% static 'img/about/OpenEnergyFamily_GroupPhoto.png' %}" alt="Open Energy Family"/>
-    </a>
+    <img style="width:50%" class="mx-auto d-block" src="{% static 'img/about/OpenEnergyFamily_GroupPhoto.png' %}"
+        alt="Open Energy Family" />
+</a>
 
 <h3 id="general-introduction">General Introduction</h3>
 <p>The Open Energy Family aims to ensure quality, transparency and reproducibility in energy
@@ -23,9 +24,10 @@
 
 <h3 id="what-energy-system-modelling">What? Energy System Modelling</h3>
 
-    <a href="{% static 'img/about/OpenEnergyFamily_modeling-cycle.png' %}">
-        <img style="width:50%" class="mx-auto d-block" src="{% static 'img/about/OpenEnergyFamily_modeling-cycle.png' %}" alt="OEP circle simple"/>
-    </a>
+<a href="{% static 'img/about/OpenEnergyFamily_modeling-cycle.png' %}">
+    <img style="width:50%" class="mx-auto d-block" src="{% static 'img/about/OpenEnergyFamily_modeling-cycle.png' %}"
+        alt="OEP circle simple" />
+</a>
 
 <p>Energy system models are used to explore the current and future energy
     systems and are often applied to questions involving the expansion of
@@ -37,13 +39,15 @@
     of the OEP is the underlying
     <a href="https://openenergy-platform.org/dataedit/schemas/">open energy database</a>,
     which can be used by everyone and is maintained by a team of developers from different
-    institutes.</p>
+    institutes.
+</p>
 
 <h3 id="how-open-science">How? Open Science</h3>
 
-    <a href="{% static 'img/about/OpenEnergyFamily_modeling-open-science.png' %}">
-        <img style="width:50%" class="mx-auto d-block" src="{% static 'img/about/OpenEnergyFamily_modeling-open-science.png' %}" alt="OEP circle simple"/>
-    </a>
+<a href="{% static 'img/about/OpenEnergyFamily_modeling-open-science.png' %}">
+    <img style="width:50%" class="mx-auto d-block"
+        src="{% static 'img/about/OpenEnergyFamily_modeling-open-science.png' %}" alt="OEP circle simple" />
+</a>
 <p>We follow and promote the principles of
     <a href="https://en.wikipedia.org/wiki/Open_science/">Open Science</a>
     and offer an open infrastructure for energy system research.
@@ -55,7 +59,8 @@
     specifications and the
     <a href="https://www.go-fair.org/fair-principles/">FAIR principles</a>
     to improve the findability, accessibility, interoperability, and reuse of
-    digital assets.</p>
+    digital assets.
+</p>
 
 <h3 id="who-oep-community">Who? OEP-Community</h3>
 <p>The OEP is a cross-project research project that is continuously being developed by
@@ -66,13 +71,12 @@
 
 <h4 id="who-projects">Research Projects</h4>
 <div class="d-flex justify-content-between flex-md-wrap">
-        <a class="logo" href="https://github.com/openego" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/open_eGo_Header.png' %}"
-                 alt="open_eGo" width="275"
-                 border="0"/>
-        </a>
-        <a class="logo" href="https://github.com/open-fred" target="_blank">
+    {% for project in projects %}
+    <a class="logo" href="https://github.com/openego" target="_blank">
+        <img class="flex-item" src="{% static 'logos/' %}{{project.logo}}" alt="open_eGo" width="275" border="0" />
+    </a>
+    {% endfor %}
+    <!-- <a class="logo" href="https://github.com/open-fred" target="_blank">
             <img class="flex-item"
                  src="{% static 'logos/open_FRED_Header.png' %}"
                  alt="open_FRED" width="275"
@@ -101,76 +105,54 @@
                  src="{% static 'logos/SIROP_logo.png' %}"
                  alt="SIROP" width="275"
                  border="0"/>
-        </a>
+        </a> -->
 </div>
 
 <h4 id="who-partners">Partners</h4>
 <div class="d-flex justify-content-between flex-md-wrap">
-        <a class="logo" href="http://iks.cs.ovgu.de/IKS.html" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/OvGU.png' %}"
-                 alt="Otto von Guericke Universität Magdeburg - IKS" width="245" height="85"
-                 border="0"/>
-        </a>
-        <a class="logo" href="http://reiner-lemoine-institut.de/en/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/RLI.png' %}"
-                 alt="Reiner Lemoine Institut" width="140" height="102" border="0"/>
-        </a>
-        <a class="logo" href="https://www.uni-flensburg.de/en/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/EUF.png' %}"
-                 alt="Europa-Universität Flensburg" width="250px"/>
-        </a>
-        <a class="logo" href="http://www.znes-flensburg.de/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/ZNES.png' %}"
-                 alt="Zentrum für nachhaltige Energiesysteme" width="250px"/>
-        </a>
-        <a class="logo" href="https://www.dlr.de/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/DLR-VE.png' %}"
-                 alt="DLR-VE (NEXT Energy)" width="268" height="109" border="0"/>
-        </a>
-        <a class="logo" href="https://www.hereon.de/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/partner_logo_hereon.png' %}"
-                 alt="HZG-Hereon" width="268" height="109" border="0"/>
-        </a>
-        <a class="logo" href="https://www.iee.fraunhofer.de/en.html" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/IEE.png' %}"
-                 alt="Fraunhofer IEE" width="250px"/>
-        </a>
-        <a class="logo" href="https://www.oeko.de/en/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/OEI.png' %}"
-                 alt="Öko Institut" width="250px"/>
-        </a>
-        <a class="logo" href="https://www.fz-juelich.de" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/FZJuelich-1.jpg' %}"
-                 alt="FZJ" width="250px"/>
-        </a>
-        <a class="logo" href="https://infai.org/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/InfAI-Logo.png' %}"
-                 alt="InfAI" width="250px"/>
-        </a>
-        <a class="logo" href="https://www.pik-potsdam.de/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/pik_logo.png' %}"
-                 alt="PIK" width="250px"/>
-        </a>
-        <a class="logo" href="https://www.ier.uni-stuttgart.de/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/Logo_IER_UniStuttgart-1200x386.png' %}"
-                 alt="IER" width="250px"/>
-        </a>
-        <a class="logo" href="https://www.fortiss.org/" target="_blank">
-            <img class="flex-item"
-                 src="{% static 'logos/partner_logo_fortiss.png' %}"
-                 alt="fortiss" width="250px"/>
-        </a>
+    <a class="logo" href="http://iks.cs.ovgu.de/IKS.html" target="_blank">
+        <img class="flex-item" src="{% static 'logos/OvGU.png' %}" alt="Otto von Guericke Universität Magdeburg - IKS"
+            width="245" height="85" border="0" />
+    </a>
+    <a class="logo" href="http://reiner-lemoine-institut.de/en/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/RLI.png' %}" alt="Reiner Lemoine Institut" width="140" height="102"
+            border="0" />
+    </a>
+    <a class="logo" href="https://www.uni-flensburg.de/en/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/EUF.png' %}" alt="Europa-Universität Flensburg" width="250px" />
+    </a>
+    <a class="logo" href="http://www.znes-flensburg.de/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/ZNES.png' %}" alt="Zentrum für nachhaltige Energiesysteme"
+            width="250px" />
+    </a>
+    <a class="logo" href="https://www.dlr.de/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/DLR-VE.png' %}" alt="DLR-VE (NEXT Energy)" width="268" height="109"
+            border="0" />
+    </a>
+    <a class="logo" href="https://www.hereon.de/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/partner_logo_hereon.png' %}" alt="HZG-Hereon" width="268"
+            height="109" border="0" />
+    </a>
+    <a class="logo" href="https://www.iee.fraunhofer.de/en.html" target="_blank">
+        <img class="flex-item" src="{% static 'logos/IEE.png' %}" alt="Fraunhofer IEE" width="250px" />
+    </a>
+    <a class="logo" href="https://www.oeko.de/en/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/OEI.png' %}" alt="Öko Institut" width="250px" />
+    </a>
+    <a class="logo" href="https://www.fz-juelich.de" target="_blank">
+        <img class="flex-item" src="{% static 'logos/FZJuelich-1.jpg' %}" alt="FZJ" width="250px" />
+    </a>
+    <a class="logo" href="https://infai.org/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/InfAI-Logo.png' %}" alt="InfAI" width="250px" />
+    </a>
+    <a class="logo" href="https://www.pik-potsdam.de/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/pik_logo.png' %}" alt="PIK" width="250px" />
+    </a>
+    <a class="logo" href="https://www.ier.uni-stuttgart.de/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/Logo_IER_UniStuttgart-1200x386.png' %}" alt="IER" width="250px" />
+    </a>
+    <a class="logo" href="https://www.fortiss.org/" target="_blank">
+        <img class="flex-item" src="{% static 'logos/partner_logo_fortiss.png' %}" alt="fortiss" width="250px" />
+    </a>
 </div>
 {% endblock %}

--- a/base/templates/base/about.html
+++ b/base/templates/base/about.html
@@ -72,8 +72,9 @@
 <h4 id="who-projects">Research Projects</h4>
 <div class="d-flex justify-content-between flex-md-wrap">
     {% for project in projects %}
-    <a class="logo" href="https://github.com/openego" target="_blank">
-        <img class="flex-item" src="{% static 'logos/' %}{{project.logo}}" alt="open_eGo" width="275" border="0" />
+    <a class="logo" href="{% url 'project_detail'  project_id=project.id %}">
+        <img class="flex-item" src="{% static 'logos/' %}{{project.logo}}" alt="{{project.id}}" width="275"
+            border="0" />
     </a>
     {% endfor %}
     <!-- <a class="logo" href="https://github.com/open-fred" target="_blank">

--- a/base/templates/base/project-detail.html
+++ b/base/templates/base/project-detail.html
@@ -1,0 +1,29 @@
+{% extends "base/base.html" %}
+{% load bootstrap4 %}
+
+
+{% block main-content-body %}
+{% load static %}
+<div>
+    <!-- logo -->
+    <img class="flex-item" src="{% static 'logos/' %}{{project.logo}}" alt="{{ project.fullTitle }}" width="275"
+        border="0" />
+
+    <!-- full title and acronym -->
+    {{ project.fullTitle }}
+    {{ project.acronym }}
+
+    <!-- general -->
+    {{ project.general }}
+    <!-- tasks -->
+    {% for task in project.tasks %}
+    <li>{{ task }}</li>
+    {% endfor %}
+    <!-- Partners -->
+    {{ project.partners }}
+    <!-- Funding -->
+    {{ project.funding }}
+    <!-- Meta -->
+    {{ project.meta.lastUpdated }}
+</div>
+{% endblock main-content-body %}

--- a/base/urls.py
+++ b/base/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     url(r"^robots.txt$", views.robot),
     url(r"^$", views.Welcome.as_view(), name="index"),
     url(r"^about/$", views.AboutPage.as_view(), name="index"),
-    url(r"^project-detail/(?P<id>[\w\-]+)/$", views.AboutProjectDetail.as_view(), name="p"),
+    url(r"^about/project-detail/(?P<project_id>[\w\-]+)/$", views.AboutProjectDetail.as_view(), name="project_detail"),
     url(r"^faq/$", views.redir, {"target": "faq"}, name="index"),
     url(r"^discussion/$", views.redir, {"target": "discussion"}, name="index"),
     url(r"^contact/$", views.ContactView.as_view(), name="index"),

--- a/base/urls.py
+++ b/base/urls.py
@@ -5,7 +5,8 @@ from base import views
 urlpatterns = [
     url(r"^robots.txt$", views.robot),
     url(r"^$", views.Welcome.as_view(), name="index"),
-    url(r"^about/$", views.redir, {"target": "about"}, name="index"),
+    url(r"^about/$", views.AboutPage.as_view(), name="index"),
+    url(r"^project-detail/(?P<id>[\w\-]+)/$", views.AboutProjectDetail.as_view(), name="p"),
     url(r"^faq/$", views.redir, {"target": "faq"}, name="index"),
     url(r"^discussion/$", views.redir, {"target": "discussion"}, name="index"),
     url(r"^contact/$", views.ContactView.as_view(), name="index"),

--- a/base/views.py
+++ b/base/views.py
@@ -126,6 +126,7 @@ def get_json_content(path, json_id=None):
         or
         object: single json python object
     """
+    
     if path is not None:
         all_jsons=[]
         for _json in os.listdir(path=path):
@@ -136,21 +137,19 @@ def get_json_content(path, json_id=None):
         if json_id is None:
             return all_jsons
         else:
-            content_by_id = [i for i in all_jsons if i[id] is json_id]
-            return content_by_id
+            content_by_id = [i for i in all_jsons if json_id == i["id"] and "template" != i["id"]]
+            return content_by_id[0]
+    # TODO: catch the exception if path is none 
     else:
-        return {"error": "The path cant be None. Please create a new Project"}
+        return {"error": "Path cant be None. Please provide the path to '/static/project_detail_pages_content/' . You can create a new Project by adding an JSON file like the '/static/project_detail_pages_content/PROJECT_TEMPLATE.json'."}
 
 class AboutPage(View):
 # docstring
     projects_content_static = "project_detail_pages_content"
+    projects_content_path = os.path.join(sec.STATIC_ROOT, projects_content_static)
 
-    def get(self, request):
-        # projects_content_path = pathlib.Path(sec.BASE_DIR + sec.STATIC_URL + self.projects_content_static).resolve() 
-        # projects_content_path = os.path.join(sec.BASE_DIR + apps.get_app_config('base').name, sec.STATIC_URL)
-        projects_content_path = os.path.join(sec.STATIC_ROOT, self.projects_content_static)
+    def get(self, request, projects_content_path=projects_content_path):
         projects = get_json_content(path=projects_content_path)
-        print(projects)
 
         return render(request, "base/about.html", {"projects": projects})
 
@@ -158,8 +157,8 @@ class AboutProjectDetail(AboutPage):
 # docstring
 
     def get(self, request, project_id):
-        project = get_json_content(path=None, json_id=project_id)
+        project = get_json_content(path=self.projects_content_path, json_id=project_id)
 
-        return render(request, "project-detail.html", {"project_details": project})
+        return render(request, "base/project-detail.html", {"project": project})
     
           


### PR DESCRIPTION
Detail information about projects (on the About page), lead to a website outside the OEP. This PR implements OEP project detail pages to increase usability.    

New projects are added by:
- Creating a new project.json file in the static folder of the base django app: `/base/static/project_detail_pages_content/`
- There is a TEMPLATE file present a contributor can copy this file, rename it (e.g. project_name.json) and fill the JSON fields with details about the project.
- This files will be collected by django using the command: `python manage.py collectstatic ` 
- Django now will automaticly generate sub pages for each of the project JSON files present in the `/static/project_detail_pages_content/` folder

closing #971 