### PR TITLE
add swagger ui to make API endpoints more visible:

### DIFF
--- a/api/templates/swagger-ui.html
+++ b/api/templates/swagger-ui.html
@@ -1,0 +1,33 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Swagger</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" />
+</head>
+
+<body>
+    <div id="swagger-ui"></div>
+    <script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script>
+        const ui = SwaggerUIBundle({
+            url: "{% static 'openapi-schema.yml' %}",
+            dom_id: '#swagger-ui',
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIBundle.SwaggerUIStandalonePreset
+            ],
+            layout: "BaseLayout",
+            requestInterceptor: (request) => {
+                request.headers['X-CSRFToken'] = "{{ csrf_token }}"
+                return request;
+            }
+        })
+    </script>
+</body>
+
+</html>

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,6 @@
 from django.conf.urls import url
+from django.views.generic import TemplateView
+from django.urls import path
 
 from api import actions, views
 
@@ -173,4 +175,7 @@ urlpatterns = [
     ),
     url(r"usrprop/", views.get_users),
     url(r"grpprop/", views.get_groups),
-]
+] + [path('swagger-ui/', TemplateView.as_view(
+        template_name='swagger-ui.html',
+        extra_context={'schema_url':'/static/openapi-schema.yml'}
+    ), name='swagger-ui'),]


### PR DESCRIPTION
**for dev purpose (not sure if this will be implemented in production)**
- see list of api endpoints at URL .../api/swagger-ui
- to generate the api schema that is mandatory to show swagger ui:
   - pip install pyyaml uritemplate
   - python manage.py generateschema --file api/static/openapi-schema.yml
   - python manage.py collectstatic
_ makesure the openapi-schema.yml is present in the gloabl /static/ folder