### PR TITLE
Update metadata integration to oem151

### DIFF
--- a/api/tests/test_meta.py
+++ b/api/tests/test_meta.py
@@ -76,7 +76,6 @@ class TestPut(APITestCase):
             )
 
     def metadata_roundtrip(self, meta):
-        print(meta)
         response = self.__class__.client.post(
             "/api/v0/schema/{schema}/tables/{table}/meta/".format(
                 schema=self.test_schema, table=self.test_table

--- a/api/tests/test_meta.py
+++ b/api/tests/test_meta.py
@@ -6,7 +6,7 @@ from api import actions
 
 from . import APITestCase
 from .util import content2json, load_content, load_content_as_json
-from omi.dialects.oep.dialect import OEP_V_1_4_Dialect
+from omi.dialects.oep.dialect import OEP_V_1_4_Dialect, OEP_V_1_5_Dialect
 
 class TestPut(APITestCase):
     def setUp(self):
@@ -76,6 +76,7 @@ class TestPut(APITestCase):
             )
 
     def metadata_roundtrip(self, meta):
+        print(meta)
         response = self.__class__.client.post(
             "/api/v0/schema/{schema}/tables/{table}/meta/".format(
                 schema=self.test_schema, table=self.test_table
@@ -98,8 +99,9 @@ class TestPut(APITestCase):
 
         self.assertEqual(response.status_code, 200, response.json())
 
-        d = OEP_V_1_4_Dialect()
-        omi_meta = json.loads(json.dumps((d.compile(d.parse(json.dumps(meta))))))
+        d_14 = OEP_V_1_4_Dialect() # not tested anymore as OEM version is currently v1.5.1
+        d_15 = OEP_V_1_5_Dialect()
+        omi_meta = json.loads(json.dumps((d_15.compile(d_15.parse(json.dumps(meta))))))
 
         self.assertDictEqualKeywise(response.json(), omi_meta)
 

--- a/api/tests/test_meta.py
+++ b/api/tests/test_meta.py
@@ -131,7 +131,406 @@ class TestPut(APITestCase):
 
     def test_complete_metadata(self):
         null = None
-        meta = {"name": "oep_metadata_table_example_v14",
+        meta = {
+    "name": "oep_metadata_table_example_v151",
+    "title": "Example title for metadata example - Version 1.5.1",
+    "id": "http://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v151",
+    "description": "This is an metadata example for example data. There is a corresponding table on the OEP for each metadata version.",
+    "language": [
+        "en-GB",
+        "en-US",
+        "de-DE",
+        "fr-FR"
+    ],
+    "subject": [
+        {
+            "name": "energy",
+            "path": "https://openenergy-platform.org/ontology/oeo/OEO_00000150"
+        },
+        {
+            "name": "test dataset",
+            "path": "https://openenergy-platform.org/ontology/oeo/OEO_00000408"
+        }
+    ],
+    "keywords": [
+        "energy",
+        "example",
+        "template",
+        "test"
+    ],
+    "publicationDate": "2022-02-15",
+    "context": {
+        "homepage": "https://reiner-lemoine-institut.de/lod-geoss/",
+        "documentation": "https://openenergy-platform.org/tutorials/jupyter/OEMetadata/",
+        "sourceCode": "https://github.com/OpenEnergyPlatform/oemetadata/tree/master",
+        "contact": "https://github.com/Ludee",
+        "grantNo": "03EI1005",
+        "fundingAgency": "Bundesministerium für Wirtschaft und Klimaschutz",
+        "fundingAgencyLogo": "https://commons.wikimedia.org/wiki/File:BMWi_Logo_2021.svg#/media/File:BMWi_Logo_2021.svg",
+        "publisherLogo": "https://reiner-lemoine-institut.de//wp-content/uploads/2015/09/rlilogo.png"
+    },
+    "spatial": {
+        "location": null,
+        "extent": "europe",
+        "resolution": "100 m"
+    },
+    "temporal": {
+        "referenceDate": "2016-01-01",
+        "timeseries": [
+            {
+                "start": "2017-01-01T00:00+01",
+                "end": "2017-12-31T23:00+01",
+                "resolution": "1 h",
+                "alignment": "left",
+                "aggregationType": "sum"
+            },
+            {
+                "start": "2018-01-01T00:00+01",
+                "end": "2019-06-01T23:00+01",
+                "resolution": "15 min",
+                "alignment": "right",
+                "aggregationType": "sum"
+            }
+        ]
+    },
+    "sources": [
+        {
+            "title": "OpenEnergyPlatform Metadata Example",
+            "description": "Metadata description",
+            "path": "https://github.com/OpenEnergyPlatform",
+            "licenses": [
+                {
+                    "name": "CC0-1.0",
+                    "title": "Creative Commons Zero v1.0 Universal",
+                    "path": "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
+                    "instruction": "You are free: To Share, To Create, To Adapt",
+                    "attribution": "© Reiner Lemoine Institut"
+                }
+            ]
+        },
+        {
+            "title": "OpenStreetMap",
+            "description": "A collaborative project to create a free editable map of the world",
+            "path": "https://www.openstreetmap.org/",
+            "licenses": [
+                {
+                    "name": "ODbL-1.0",
+                    "title": "Open Data Commons Open Database License 1.0",
+                    "path": "https://opendatacommons.org/licenses/odbl/1.0/index.html",
+                    "instruction": "You are free: To Share, To Create, To Adapt; As long as you: Attribute, Share-Alike, Keep open!",
+                    "attribution": "© OpenStreetMap contributors"
+                }
+            ]
+        }
+    ],
+    "licenses": [
+        {
+            "name": "ODbL-1.0",
+            "title": "Open Data Commons Open Database License 1.0",
+            "path": "https://opendatacommons.org/licenses/odbl/1.0/",
+            "instruction": "You are free: To Share, To Create, To Adapt; As long as you: Attribute, Share-Alike, Keep open!",
+            "attribution": "© Reiner Lemoine Institut © OpenStreetMap contributors"
+        }
+    ],
+    "contributors": [
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2016-06-16",
+            "object": "metadata",
+            "comment": "Create metadata"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2016-11-22",
+            "object": "metadata",
+            "comment": "Update metadata"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2016-11-22",
+            "object": "metadata",
+            "comment": "Update header and license"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2017-03-16",
+            "object": "metadata",
+            "comment": "Add license to source"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2017-03-28",
+            "object": "metadata",
+            "comment": "Add copyright to source and license"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2017-05-30",
+            "object": "metadata",
+            "comment": "Release metadata version 1.3"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2017-06-26",
+            "object": "metadata",
+            "comment": "Move referenceDate into temporal and remove array"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2018-07-19",
+            "object": "metadata",
+            "comment": "Start metadata version 1.4"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2018-07-26",
+            "object": "data",
+            "comment": "Rename table and files"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2018-10-18",
+            "object": "metadata",
+            "comment": "Add contribution object"
+        },
+        {
+            "title": "christian-rli",
+            "email": null,
+            "date": "2018-10-18",
+            "object": "metadata",
+            "comment": "Add datapackage compatibility"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2018-11-02",
+            "object": "metadata",
+            "comment": "Release metadata version 1.4"
+        },
+        {
+            "title": "christian-rli",
+            "email": null,
+            "date": "2019-02-05",
+            "object": "metadata",
+            "comment": "Apply template structure to example"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2019-03-22",
+            "object": "metadata",
+            "comment": "Hotfix foreignKeys"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2019-07-09",
+            "object": "metadata",
+            "comment": "Release metadata version OEP-1.3.0"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2021-11-15",
+            "object": "metadata",
+            "comment": "Release metadata version OEP-1.5.0"
+        },
+        {
+            "title": "Ludee",
+            "email": null,
+            "date": "2022-02-15",
+            "object": "metadata",
+            "comment": "Release metadata version OEP-1.5.1"
+        }
+    ],
+    "resources": [
+        {
+            "profile": "tabular-data-resource",
+            "name": "model_draft.oep_metadata_table_example_v151",
+            "path": "http://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v151",
+            "format": "PostgreSQL",
+            "encoding": "UTF-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "id",
+                        "description": "Unique identifier",
+                        "type": "serial",
+                        "unit": null,
+                        "isAbout": [
+                            {
+                                "name": null,
+                                "path": null
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "name",
+                        "description": "Example name",
+                        "type": "text",
+                        "unit": null,
+                        "isAbout": [
+                            {
+                                "name": "written name",
+                                "path": "https://openenergy-platform.org/ontology/oeo/IAO_0000590"
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "type",
+                        "description": "Type of wind farm",
+                        "type": "text",
+                        "unit": null,
+                        "isAbout": [
+                            {
+                                "name": "wind farm",
+                                "path": "https://openenergy-platform.org/ontology/oeo/OEO_00000447"
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": "onshore ",
+                                "name": "onshore wind farm",
+                                "path": "https://openenergy-platform.org/ontology/oeo/OEO_00000311"
+                            },
+                            {
+                                "value": "offshore ",
+                                "name": "offshore wind farm",
+                                "path": "https://openenergy-platform.org/ontology/oeo/OEO_00000308"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "year",
+                        "description": "Reference year",
+                        "type": "integer",
+                        "unit": null,
+                        "isAbout": [
+                            {
+                                "name": "year",
+                                "path": "https://openenergy-platform.org/ontology/oeo/UO_0000036"
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "value",
+                        "description": "Example value",
+                        "type": "double precision",
+                        "unit": "MW",
+                        "isAbout": [
+                            {
+                                "name": "quantity value",
+                                "path": "https://openenergy-platform.org/ontology/oeo/OEO_00000350"
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "geom",
+                        "description": "Geometry",
+                        "type": "geometry(Point, 4326)",
+                        "unit": null,
+                        "isAbout": [
+                            {
+                                "name": "spatial region",
+                                "path": "https://openenergy-platform.org/ontology/oeo/BFO_0000006"
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": null,
+                                "name": null,
+                                "path": null
+                            }
+                        ]
+                    }
+                ],
+                "primaryKey": [
+                    "id"
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [
+                            "year"
+                        ],
+                        "reference": {
+                            "resource": "schema.table",
+                            "fields": [
+                                "year"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "dialect": {
+                "delimiter": null,
+                "decimalSeparator": "."
+            }
+        }
+    ],
+    "@id": "https://databus.dbpedia.org/kurzum/mastr/bnetza-mastr/01.04.00",
+    "@context": "https://github.com/OpenEnergyPlatform/oemetadata/blob/master/metadata/latest/context.json",
+    "review": {
+        "path": "https://github.com/OpenEnergyPlatform/data-preprocessing/issues",
+        "badge": "Platinum"
+    },
+    "metaMetadata": {
+        "metadataVersion": "OEP-1.5.1",
+        "metadataLicense": {
+            "name": "CC0-1.0",
+            "title": "Creative Commons Zero v1.0 Universal",
+            "path": "https://creativecommons.org/publicdomain/zero/1.0/"
+        }
+    },
+    "_comment": {
+        "metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/oemetadata)",
+        "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
+        "units": "Use a space between numbers and units (100 m)",
+        "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
+        "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
+        "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/blob/master/data-review/manual/review_manual.md)",
+        "null": "If not applicable use: null",
+        "todo": "If a value is not yet available, use: todo"
+    }
+}
+        meta_14 = {"name": "oep_metadata_table_example_v14",
 "title": "Good example title",
 "id": "https://openenergy-platform.org/dataedit/view/model_draft/oep_metadata_table_example_v14",
 "description": "example metadata for example data",

--- a/dataedit/metadata/widget.py
+++ b/dataedit/metadata/widget.py
@@ -106,9 +106,6 @@ class MetaDataWidget:
 
             else:
                 for item in data:
-                    print(type(item))
-                    print(item)
-                    print(parent)
                     if isinstance(item, dict):
                         item = item.copy()
                         name = item.get('title', None)
@@ -176,7 +173,6 @@ class MetaDataWidget:
         return html
 
     def render(self):
-        print(self.json)
         answer = self.__convert_to_html(data=self.json)
         return answer
 

--- a/dataedit/metadata/widget.py
+++ b/dataedit/metadata/widget.py
@@ -106,6 +106,9 @@ class MetaDataWidget:
 
             else:
                 for item in data:
+                    print(type(item))
+                    print(item)
+                    print(parent)
                     if isinstance(item, dict):
                         item = item.copy()
                         name = item.get('title', None)
@@ -121,11 +124,19 @@ class MetaDataWidget:
                             html += mark_safe('<p class="metaproperty">')
                             html += conditional_escape(name) + self.__convert_to_html(item, level + 1, parent=parent)
                             html += mark_safe('</p>')
+                        if item.get("start", None) is not None:
+                            no_valid_item = False
+                            html += mark_safe('<br>')
+                            html += mark_safe('{} element'.format(parent))
+                            html += self.__convert_to_html(item, level + 1, parent=parent)
+                    
                     else:
                         html += mark_safe('<p>Not implemented yet</p>')
+        
 
             if no_valid_item:
                 html += mark_safe('<p class="metaproperty">There is no valid entry for this field</p>')
+        
 
         elif isinstance(data, str) and re.match(self.url_regex, data):
             html += format_html('<a href="{}">{}</a>', data, data)
@@ -165,6 +176,7 @@ class MetaDataWidget:
         return html
 
     def render(self):
+        print(self.json)
         answer = self.__convert_to_html(data=self.json)
         return answer
 

--- a/dataedit/static/metaedit/schema.json
+++ b/dataedit/static/metaedit/schema.json
@@ -1,22 +1,24 @@
 {
+    "title": "OEM Creator - Generate metadata strings using OEMetadata v1.5.1",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/master/oemetadata/v140/schema.json",
-    "description": "Open Energy Plaftorm (OEP) metadata schema v1.4.0",
+    "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/master/oemetadata/v151/schema.json",
+    "description": "Open Energy Platform (OEP) metadata standard: https://github.com/OpenEnergyPlatform/oemetadata",
     "type": "object",
     "properties": {
         "name": {
-            "description": "File name or database table name. Example: oep_metadata_table_example_v14",
             "type": "string",
+            "description": "A file name or database table name. Example: oep_metadata_table_example_v151",
             "title": "Name"
         },
         "title": {
-            "description": "Human readable title. Example: Metadata Example Table",
             "type": "string",
-            "title": "Title"
+            "title": "Title",
+            "description": "A human readable full title including author. Example: Example title for metadata example - Version 1.5.1"
         },
         "id": {
-            "description": "Uniform Resource Identifier (URI) that unambiguously identifies the resource. This can be a URL on the data set. It can also be a Digital Object Identifier (DOI). Example: https://example.com",
+            "description": "Uniform Resource Identifier (URI) that unambiguously identifies the resource. This can be a URL or a DOI. Example: http://openenergyplatform.org/dataedit/view/model_draft/oep_metadata_table_example_v151",
             "type": "string",
+            "format": "uri",
             "title": "Id"
         },
         "description": {
@@ -25,22 +27,51 @@
             "title": "Description"
         },
         "language": {
-            "description": "Language used within the described data structures (e.g. titles, descriptions). The language key can be repeated if more languages are used. Standard: IETF (BCP47). Example: [en-GB, de-DE, fr-FR]",
+            "description": "An array of languages used within the described data structures. Standard: IETF (BCP47)",
             "type": "array",
             "items": {
+                "title": "language",
                 "type": "string",
-                "title": "Language"
+                "enum": [
+                    "en-GB",
+                    "en-US",
+                    "de-DE",
+                    "fr-FR",
+                    "other"
+                ]
+            }
+        },
+        "subject": {
+            "description": "Reference the topic of the resource in ontology terms",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "The class label (name) of the ontology term.",
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "path": {
+                        "description": "The URI of the class.",
+                        "type": "string",
+                        "title": "Path",
+                        "format": "uri"
+                    }
+                },
+                "additionalProperties": false,
+                "title": "Subject"
             },
-            "title": "Language"
+            "title": "Subject"
         },
         "keywords": {
-            "description": "An array of string keywords to assist users searching for the package in catalogs. Example: [example, template, test]",
+            "description": "An array of string keywords to assist users searching for the package in catalogs. Example: example, template, test",
             "type": "array",
             "items": {
                 "type": "string",
                 "title": "Keyword"
             },
-            "title": "Keywords"
+            "title": "Keyword"
         },
         "publicationDate": {
             "description": "Date of publishing. Date Format is ISO 8601 (YYYY-MM-DD). Example: 2019-02-06",
@@ -49,49 +80,51 @@
             "format": "date"
         },
         "context": {
-            "description": "Object. Contains name-value-pairs that describe the general setting, evironment or project leading to the creation or maintenance of this dataset.",
+            "description": "An object that describes the general setting, environment, or project leading to the creation or maintenance of this dataset. In science this is can be the research project.",
             "type": "object",
             "properties": {
                 "homepage": {
-                    "description": "URL of project. Example: https://openenergy-platform.org/",
+                    "description": "A URL of the project. Example: https://openenergy-platform.org/",
                     "type": "string",
                     "title": "Homepage",
                     "format": "uri"
                 },
                 "documentation": {
-                    "description": "URL of project documentation. Example: https://github.com/OpenEnergyPlatform/metadata/wiki/Metadata-Description",
+                    "description": "A URL of the project documentation. Example: https://github.com/OpenEnergyPlatform/metadata/wiki/Metadata-Description",
                     "type": "string",
+                    "format": "uri",
                     "title": "Documentation"
                 },
                 "sourceCode": {
-                    "description": "Url of project source code. Example: https://github.com/OpenEnergyPlatform",
+                    "description": "A URL of the projects source code. Example: https://github.com/OpenEnergyPlatform",
                     "type": "string",
+                    "format": "uri",
                     "title": "Source code"
                 },
                 "contact": {
-                    "description": "Reference to the creator or maintainer of the data set. Example: contact@example.com",
+                    "description": "A reference to the creator or maintainer of the data set. It can be an email address or a GitHub handle. Example: https://github.com/Ludee",
                     "type": "string",
                     "title": "Contact",
                     "format": "email"
                 },
                 "grantNo": {
-                    "description": "In a publicly funded Project: the identifying grant number. Example: 01AB2345",
+                    "description": "An identifying grant number. In case of a publicly funded project, this number is assigned by the funding agency. Example: 01AB2345",
                     "type": "string",
-                    "title": "Grant no"
+                    "title": "Grant Number"
                 },
                 "fundingAgency": {
-                    "description": "In a funded Project: The name of the funding agency. Example: Bundesministerium für Wirtschaft und Energie",
+                    "description": "A name of the entity providing the funding. This can be a government agency or a company. Example: Bundesministerium für Wirtschaft und Klimaschutz (BMWK)",
                     "type": "string",
                     "title": "Funding agency"
                 },
                 "fundingAgencyLogo": {
-                    "description": "In a publicly funded Project: A link to the Logo of the funding agency. Example: https://www.innovation-beratung-foerderung.de/INNO/Redaktion/DE/Bilder/Titelbilder/titel_foerderlogo_bmwi.jpg?__blob=poster&v=2",
+                    "description": "A URL to the logo or image of the funding agency. Example: https://commons.wikimedia.org/wiki/File:BMWi_Logo_2021.svg#/media/File:BMWi_Logo_2021.svg",
                     "type": "string",
                     "title": "Funding agency logo",
                     "format": "uri"
                 },
                 "publisherLogo": {
-                    "description": "Link to the logo of the publishing institution. Example: https://reiner-lemoine-institut.de//wp-content/uploads/2015/09/rlilogo.png",
+                    "description": "A URL to the logo of the publishing agency of data. Example: https://reiner-lemoine-institut.de//wp-content/uploads/2015/09/rlilogo.png",
                     "type": "string",
                     "title": "Publisher logo",
                     "format": "uri"
@@ -135,37 +168,41 @@
                 },
                 "timeseries": {
                     "description": "Times series object in temporal object, contains start, end, resolution, alignment and aggregation type properties.",
-                    "type": "object",
-                    "properties": {
-                        "start": {
-                            "description": "The beginning point in time of a time series. Example: 2019-02-06T10:12:04+00:00",
-                            "type": "string",
-                            "title": "Start",
-                            "format": "date-time"
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "start": {
+                                "description": "The beginning point in time of a time series. Example: 2019-02-06T10:12:04+00:00",
+                                "type": "string",
+                                "title": "Start",
+                                "format": "date-time"
+                            },
+                            "end": {
+                                "description": "The end point in time of a time series. Example: 2019-02-07T10:12:04+00:00",
+                                "type": "string",
+                                "title": "End",
+                                "format": "date-time"
+                            },
+                            "resolution": {
+                                "description": "The time span between individual points of information in a time series. Example: 30 s",
+                                "type": "string",
+                                "title": "Resolution"
+                            },
+                            "alignment": {
+                                "description": "Indicator whether stamps in a time series are left, right or middle. \"null\" if there is no time series. Example: left",
+                                "type": "string",
+                                "title": "Alignment"
+                            },
+                            "aggregationType": {
+                                "description": "Indicates whether the values are a sum, average or current. Example: sum",
+                                "type": "string",
+                                "title": "Aggregation type"
+                            }
                         },
-                        "end": {
-                            "description": "The end point in time of a time series. Example: 2019-02-07T10:12:04+00:00",
-                            "type": "string",
-                            "title": "End",
-                            "format": "date-time"
-                        },
-                        "resolution": {
-                            "description": "The time span between individual points of information in a time series. Example: 30 s",
-                            "type": "string",
-                            "title": "Resolution"
-                        },
-                        "alignment": {
-                            "description": "Indicator whether stamps in a time series are left, right or middle. \"null\" if there is no time series. Example: left",
-                            "type": "string",
-                            "title": "Alignment"
-                        },
-                        "aggregationType": {
-                            "description": "Indicates whether the values are a sum, average or current. Example: sum",
-                            "type": "string",
-                            "title": "Aggregation type"
-                        }
+                        "additionalProperties": false,
+                        "title": "Timeseries"
                     },
-                    "additionalProperties": false,
                     "title": "Timeseries"
                 }
             },
@@ -327,9 +364,7 @@
                         "description": "A string identifying the profile of this descriptor as per the profiles specification. This information is retained in order to comply with the \"Tabular Data Package\" standard. If at all in doubt the value should read \"tabular-data-resource\". Example: tabular-data-resource",
                         "type": "string",
                         "title": "Profile",
-                        "options": {
-                            "hidden": true
-                        }
+                        "default": "tabular-data-resource"
                     },
                     "name": {
                         "description": "A resource MUST contain a name unique to amongst all resources in this data package. To comply with the data package standard it must consist of only lowercase alphanumeric character plus \".\", \"-\" and \"_\". It may not start with a number. In a database this will be the name of the table within its containing schema. It would be usual for the name to correspond to the file name (minus the file-extension) of the data file the resource describes. Example: sandbox.example_table",
@@ -339,26 +374,19 @@
                     "path": {
                         "description": "A url-or-path string, that should be a permanent http(s) address or other path directly linking to the resource. Example: directly linking to the resource. https://openenergy-platform.org/dataedit/view/openstreetmap/osm_deu_roads",
                         "type": "string",
-                        "title": "Path",
-                        "options": {
-                            "hidden": true
-                        }
+                        "title": "Path"
                     },
                     "format": {
                         "description": "\"csv\", \"xls\", \"json\" etc. would be expected to be the standard file extension for this type of resource. When you upload your data to the OEDB, in the shown metadata string, the format will be changed accordingly to \"PostgreSQL\", since the data there are stored in a database. Example: csv",
                         "type": "string",
                         "title": "Format",
-                        "options": {
-                            "hidden": true
-                        }
+                        "default": "csv"
                     },
                     "encoding": {
                         "description": "Specifies the character encoding of the resource's data file. The values should be one of the \"Preferred MIME Names\" for a character encoding registered with IANA. If no value for this key is specified then the default is UTF-8. Example: UTF-8",
                         "type": "string",
                         "title": "Encoding",
-                        "options": {
-                            "hidden": true
-                        }
+                        "default": "UTF-8"
                     },
                     "schema": {
                         "description": "Object containing fields, primary key and for foreign keys. Describes the structure of the present data.",
@@ -374,8 +402,7 @@
                                         "name": {
                                             "description": "Name string unique within its scope. Example: year",
                                             "type": "string",
-                                            "title": "Name",
-                                            "readonly": true
+                                            "title": "Name"
                                         },
                                         "description": {
                                             "description": "Free-text describing the field. Example: Reference year for which the data were collected.",
@@ -385,11 +412,62 @@
                                         "type": {
                                             "description": "Data type of the field. In case of a geom-column in a database, also indicate the shape and CRS. Example: geometry(Point, 4326)",
                                             "type": "string",
-                                            "title": "Type",
-                                            "readonly": true
+                                            "title": "Type"
+                                        },
+                                        "isAbout": {
+                                            "description": "Ontology URI to describe the column header",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Name of the Dataset",
+                                                        "type": "string",
+                                                        "title": "Name"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to the OEO (URL)",
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "format": "uri"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "title": "IsAbout"
+                                            },
+                                            "title": "IsAbout"
+                                        },
+                                        "valueReference": {
+                                            "description": "Ontology URI for an extended description of the values in the column",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "value": {
+                                                        "description": "The value this reference is assinged to.",
+                                                        "type": "string",
+                                                        "title": "Value"
+                                                    },
+                                                    "name": {
+                                                        "description": "Full name of the value",
+                                                        "type": "string",
+                                                        "title": "Name",
+                                                        "format": "uri"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to the OEO",
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "format": "uri"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "title": "Value reference"
+                                            },
+                                            "title": "valueReference"
                                         },
                                         "unit": {
-                                            "description": "Unit, preferably SI-Unit, that values in this field are mapped to. If \"unit\" doesn't apply to a field, use \"none\". Example: MW",
+                                            "description": "Unit, preferably SI-Unit, that values in this field are mapped to. If \"unit\" doesn't apply to a field, use \"null\". Example: MW",
                                             "type": "string",
                                             "title": "Unit"
                                         }
@@ -397,7 +475,7 @@
                                     "additionalProperties": false,
                                     "title": "Field"
                                 },
-                                "title": "Fields"
+                                "title": "Field"
                             },
                             "primaryKey": {
                                 "description": "A primary key is a field or set of fields that uniquely identifies each row in the table. It's recorded as a list of strings, since it is possible to define the primary key as made up of several columns. Example: id",
@@ -440,7 +518,7 @@
                                                         "type": "string",
                                                         "title": "Field"
                                                     },
-                                                    "title": "Fields"
+                                                    "title": "Field"
                                                 }
                                             },
                                             "additionalProperties": false,
@@ -457,7 +535,7 @@
                         "title": "Schema"
                     },
                     "dialect": {
-                        "description": "Object. A CSV Dialect defines a simple format to describe the various dialects of CSV files in a language agnostic manner. In case of a database, the values in the containing fields are \"none\".",
+                        "description": "Object. A CSV Dialect defines a simple format to describe the various dialects of CSV files in a language agnostic manner. In case of a database, the values in the containing fields are \"null\".",
                         "type": "object",
                         "properties": {
                             "delimiter": {
@@ -472,16 +550,25 @@
                             }
                         },
                         "additionalProperties": false,
-                        "title": "Dialect",
-                        "options": {
-                            "hidden": true
-                        }
+                        "title": "Dialect"
                     }
                 },
                 "additionalProperties": false,
                 "title": "Resource"
             },
-            "title": "Resources"
+            "title": "Resource"
+        },
+        "@id": {
+            "description": "Uniform Resource Identifier (URI) that links the resource via the databus",
+            "type": "string",
+            "format": "uri",
+            "title": "@Id"
+        },
+        "@context": {
+            "description": "Explanation of metadata keys in ontology terms. Example: https://raw.githubusercontent.com/LOD-GEOSS/databus-snippets/master/oep_metadata/context.jsonld",
+            "type": "string",
+            "format": "uri",
+            "title": "@context"
         },
         "review": {
             "description": "Data uploaded through the OEP needs to go through review. The review will cover the areas described here: https://github.com/OpenEnergyPlatform/data-preprocessing/wiki and carried out by a team of the platform. The review itself is documented at the specified path and a badge is rewarded with regards to completeness.",
@@ -499,19 +586,17 @@
                 }
             },
             "additionalProperties": false,
-            "title": "Review",
-            "options": {
-                "hidden": true
-            }
+            "title": "Review"
         },
         "metaMetadata": {
             "description": "Object. Description about the metadata themselves, their format, version and license. These fields should already be provided when you’re filling out your metadata.",
             "type": "object",
             "properties": {
                 "metadataVersion": {
-                    "description": "Type and version number of the metadata. Example: OEP-1.4",
+                    "description": "Type and version number of the metadata. Example: oemetadata_v1.5.1",
                     "type": "string",
-                    "title": "Metadata version"
+                    "title": "Metadata version",
+                    "default": "oemetadata_v1.5.1"
                 },
                 "metadataLicense": {
                     "description": "Object describing the license of the provided metadata.",
@@ -520,17 +605,20 @@
                         "name": {
                             "description": "SPDX identifier. Example: CC0-1.0",
                             "type": "string",
-                            "title": "Name"
+                            "title": "Name",
+                            "default": "CC0-1.0"
                         },
                         "title": {
                             "description": "Official (human readable) license title. Example: Creative Commons Zero v1.0 Universal",
                             "type": "string",
-                            "title": "Title"
+                            "title": "Title",
+                            "default": "Creative Commons Zero v1.0 Universal"
                         },
                         "path": {
                             "description": "Url or path string, that is a fully qualified HTTP address. Example: https://creativecommons.org/publicdomain/zero/1.0/",
                             "type": "string",
-                            "title": "Path"
+                            "title": "Path",
+                            "default": "https://creativecommons.org/publicdomain/zero/1.0/"
                         }
                     },
                     "additionalProperties": false,
@@ -540,47 +628,65 @@
             "additionalProperties": false,
             "title": "Meta metadata",
             "options": {
-                "hidden": true
+                "disable_edit_json": "True",
+                "hidden": "True"
             }
         },
         "_comment": {
             "description": "Object. The “_comment”-section is used as a self-description of the final metadata-file. It is text, intended for humans and can include a link to the metadata documentation(s), required value formats and similar remarks. The comment section has no fix structure or mandatory values, but a useful self-description, similar to the one depicted here, is encouraged.",
             "type": "object",
+            "options": {
+                "disable_edit_json": "True",
+                "hidden": "True"
+            },
             "properties": {
                 "metadata": {
                     "description": "Reference to the metadata documentation in use. Example: Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
                     "type": "string",
-                    "title": "Metadata"
+                    "title": "Metadata",
+                    "default": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/oemetadata)"
                 },
                 "dates": {
                     "description": "Comment on data/time format. Example: Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
                     "type": "string",
-                    "title": "Dates"
+                    "title": "Dates",
+                    "default": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)"
                 },
                 "units": {
                     "description": "Comment on units. Example: If you must use units in cells (which is discouraged), leave a space between numbers and units (100 m)",
                     "type": "string",
-                    "title": "Units"
+                    "title": "Units",
+                    "default": "Use a space between numbers and units (100 m)"
                 },
                 "languages": {
                     "description": "Comment on language format. Example: Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
                     "type": "string",
-                    "title": "Languages"
+                    "title": "Languages",
+                    "default": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)"
                 },
                 "licenses": {
                     "description": "Reference to license format. Example: License name must follow the SPDX License List (https://spdx.org/licenses/)",
                     "type": "string",
-                    "title": "Licenses"
+                    "title": "Licenses",
+                    "default": "License name must follow the SPDX License List (https://spdx.org/licenses/)"
                 },
                 "review": {
                     "description": "Reference to review documentation. Example: Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
                     "type": "string",
-                    "title": "Review"
+                    "title": "Review",
+                    "default": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/blob/master/data-review/manual/review_manual.md)"
                 },
                 "null": {
-                    "description": "Feel free to add more descriptive comments. Like \"none\". Example: If a field is not applicable just enter \"none\"",
+                    "description": "Feel free to add more descriptive comments. Like \"null\". Example: If a field is not applicable just enter \"null\"",
                     "type": "string",
-                    "title": "Null"
+                    "title": "Null",
+                    "default": "If not applicable use: null"
+                },
+                "todo": {
+                    "description": "If an applicable value is not yet available and will be inserted later on use: 'todo' ",
+                    "type": "string",
+                    "title": "Todo",
+                    "default": "If a value is not yet available, use: todo"
                 }
             },
             "title": "_comment"

--- a/docs/source/api/how_to.rst
+++ b/docs/source/api/how_to.rst
@@ -438,7 +438,7 @@ information. You can query this metadata
     >>> result = requests.get(oep_url+'/api/v0/schema/sandbox/tables/example_table/meta/')
     >>> result.status_code
     200
-    >>> result.json() == {'id': 'sandbox.example_table', 'metaMetadata': {'metadataVersion': 'OEP-1.4.0', 'metadataLicense': {'name': 'CC0-1.0', 'title': 'Creative Commons Zero v1.0 Universal', 'path': 'https://creativecommons.org/publicdomain/zero/1.0/'}}}
+    >>> result.json() == {'id': 'sandbox.example_table', 'metaMetadata': {'metadataVersion': 'OEP-1.5.1', 'metadataLicense': {'name': 'CC0-1.0', 'title': 'Creative Commons Zero v1.0 Universal', 'path': 'https://creativecommons.org/publicdomain/zero/1.0/'}}}
     True
 
 Note that the returned metadata differs from the metadata passed when creating
@@ -480,7 +480,7 @@ on existing tables via `POST`-requests (granted that you have write-permissions)
     ...        }
     ...    ],
     ...    "metaMetadata": {
-    ...        "metadataVersion": "OEP-1.4.0",
+    ...        "metadataVersion": "OEP-1.5.1",
     ...        "metadataLicense": {
     ...            "name": "CC0-1.0",
     ...            "title": "Creative Commons Zero v1.0 Universal",
@@ -488,13 +488,14 @@ on existing tables via `POST`-requests (granted that you have write-permissions)
     ...        }
     ...    },
     ...    "_comment": {
-    ...        "metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
+    ...        "metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/oemetadata)",
     ...        "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
     ...        "units": "Use a space between numbers and units (100 m)",
     ...        "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
     ...        "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
-    ...        "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
-    ...        "null": "If not applicable use (null)"
+    ...        "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/blob/master/data-review/manual/review_manual.md)",
+    ...        "null": "If not applicable use: null",
+    ...        "todo": "If a value is not yet available, use: todo"
     ...    }
     ... }
     >>> result = requests.post(oep_url+'/api/v0/schema/sandbox/tables/example_table/meta/', json=data, headers={'Authorization': 'Token %s'%your_token})

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ alembic
 django-simple-captcha
 django-bootstrap4
 django-fontawesome-5
-omi
+omi>=0.0.7
 django-jquery
 zipstream-new
 rdflib<6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ alembic
 django-simple-captcha
 django-bootstrap4
 django-fontawesome-5
-omi>0.0.6
+omi==0.0.7b1 # Raise omi version to beta release (omi is release as beta because release was not reviewd)
 django-jquery
 zipstream-new
 rdflib<6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ alembic
 django-simple-captcha
 django-bootstrap4
 django-fontawesome-5
-omi==0.0.7b1 # Raise omi version to beta release (omi is release as beta because release was not reviewd)
+omi
 django-jquery
 zipstream-new
 rdflib<6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ alembic
 django-simple-captcha
 django-bootstrap4
 django-fontawesome-5
-omi
+omi>0.0.6
 django-jquery
 zipstream-new
 rdflib<6.0

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -4,6 +4,7 @@
 - Update navigation bar (PR #898)
 - Python 3.6 is no longer supported due to dependency requirements (PR#941)
 - slightly improved tutorial markdown capabilities <#951>
+- Update OEMetadata integration (using new omi version) and metadater widget to be bale to use OEM v1.5.1 (PR#986)
 
 
 ### Bugs


### PR DESCRIPTION
**NOTE: This PR depends on the release of OMI package. [This PR must be merged first.](https://github.com/OpenEnergyPlatform/omi/pull/45)** 
If you want to test this now, you would have to check out the linked branch from the PR above and install the package locally
`pip install -U path\omi` . This is also the reason why the CI fails.

- Update API: It is now possible to post metadata using OEM v151 to a table via the api
  - I used some bad code to implement this, as there is no validation functionality in place to be able to identify the metadata version and therefore use the correct omi dialect to parse and compile the metadata.

[Example](https://github.com/OpenEnergyPlatform/oeplatform/blob/e3acfd6b644efed289605e4caab90e0a6669cd8f/api/actions.py#L130-L173) for bad code I used, see the nested try except block:
```python 
try:
        metadata = parser_15.parse(jsn)
    except ParserException as e:
        return None, str(e)
    except Exception as e:
        APIError("Metadata could not be parsed{}".format(e))
        try:
            metadata = parser_14.parse(jsn)
        except ParserException as e:
            return None, str(e)
        except Exception as e:
            raise APIError("Metadata could not be parsed{}".format(e))
        else:
            return metadata, None
    else:
        return metadata, None
```
- Update MetaEdit Schema: The metaEdit is now able to create metadata for oem v151
  - it seems like a few fields are out of place ATM

To do´s:
- [x] Update OMI pypi release -> `pip install omi`
- [ ] Try to improve the code
- [x] Fix metadata widget