### PR TITLE
Add table tag permission check to strict

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -38,6 +38,7 @@ from dataedit.structures import TableTags as OEDBTableTags
 from dataedit.structures import Tag as OEDBTag
 from oeplatform.securitysettings import PLAYGROUNDS, UNVERSIONED_SCHEMAS
 
+
 pgsql_qualifier = re.compile(r"^[\w\d_\.]+$")
 
 
@@ -77,6 +78,10 @@ def get_table_name(schema, table, restrict_schemas=True):
     if restrict_schemas:
         if schema not in PLAYGROUNDS + UNVERSIONED_SCHEMAS:
             raise PermissionDenied
+    # TODO check if table in schema_whitelist but circular import
+    # from dataedit.views import schema_whitelist
+    # if schema not in schema_whitelist
+    #     raise PermissionDenied
     return schema, table
 
 

--- a/api/actions.py
+++ b/api/actions.py
@@ -97,6 +97,34 @@ def assert_permission(user, table, permission, schema=None):
         raise PermissionDenied
 
 
+def assert_add_tag_permission(user, table, permission, schema):
+    """
+    Tags can be added to tables that are in any schema. However, 
+    it is necessary to check whether the user has write permission 
+    to the table, since not every user should be able to add tags 
+    to every table.
+
+    Args:
+        user (_type_): _description_
+        table (_type_): _description_
+        permission (_type_): _description_
+        schema (_type_): _description_
+
+    Raises:
+        PermissionDenied: _description_
+    
+    """
+    # if not request.user.is_anonymous:
+    #         level = request.user.get_table_permission_level(table)
+    #         can_add = level >= login_models.WRITE_PERM
+
+    if (
+        user.is_anonymous
+        or user.get_table_permission_level(DBTable.load(schema, table)) < permission
+    ):
+        raise PermissionDenied
+
+
 def _translate_fetched_cell(cell):
     if isinstance(cell, geoalchemy2.WKBElement):
         return _get_engine().execute(cell.ST_AsText()).scalar()

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -1476,11 +1476,11 @@ def update_table_tags(request):
     """
     # check if valid table / schema
     schema, table = actions.get_table_name(
-        schema=request.POST["schema"], table=request.POST["table"]
+        schema=request.POST["schema"], table=request.POST["table"], restrict_schemas=False
     )
 
     # check write permission
-    actions.assert_permission(
+    actions.assert_add_tag_permission(
         request.user, table, login_models.WRITE_PERM, schema=schema
     )
 


### PR DESCRIPTION
Update the assert permission to check if the user can write to a table and allow the user to add tags to tables that are not included in model_draft.

fixes #1069