### PR TITLE
update test - adapt test to omi updates

### DIFF
--- a/docs/source/api/how_to.rst
+++ b/docs/source/api/how_to.rst
@@ -438,7 +438,7 @@ information. You can query this metadata
     >>> result = requests.get(oep_url+'/api/v0/schema/sandbox/tables/example_table/meta/')
     >>> result.status_code
     200
-    >>> result.json() == {'id': 'sandbox.example_table', 'metaMetadata': {'metadataVersion': 'OEP-1.5.1', 'metadataLicense': {'name': 'CC0-1.0', 'title': 'Creative Commons Zero v1.0 Universal', 'path': 'https://creativecommons.org/publicdomain/zero/1.0/'}}}
+    >>> result.json() == {'id': 'sandbox.example_table', 'metaMetadata': {'metadataVersion': 'OEP-1.5.1', 'metadataLicense': {'name': 'CC0-1.0', 'title': 'Creative Commons Zero v1.0 Universal', 'path': 'https://creativecommons.org/publicdomain/zero/1.0/'}},  "_comment": {"metadata": "Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/oemetadata)", "dates": "Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)", "units": "Use a space between numbers and units (100 m)", "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)", "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)", "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/blob/master/data-review/manual/review_manual.md)", "null": "If not applicable use: null", "todo": "If a value is not yet available, use: todo"}}
     True
 
 Note that the returned metadata differs from the metadata passed when creating

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -5,6 +5,7 @@
 - API enforce column name format as well as table names (PR#1065)
 - API simplify api tests (PR#1067)
 - improve tables oemetadata json parsing/website loading time by reworking the oemetadata storage system (PR#1059)
+- adapt omi updates in tests (PR#1092)
 
 ### Features
 


### PR DESCRIPTION
- with omi 0.0.9 the oemetadata key "_comment" does not rely on user input - that means the key and its values will be added by default to any metadata json that is compiled using omi.