### PR TITLE
hotfix for oemetadata migration - handle oemetadata v1.3

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from django.core.exceptions import PermissionDenied
 from django.db.models import Func, Value
 from django.http import Http404
-from omi.dialects.oep import OEP_V_1_4_Dialect, OEP_V_1_5_Dialect
+from omi.dialects.oep import OEP_V_1_3_Dialect, OEP_V_1_4_Dialect, OEP_V_1_5_Dialect
 from omi.dialects.oep.compiler import JSONCompiler
 from omi.dialects.oep.parser import ParserException
 from omi.structure import Compilable
@@ -53,8 +53,8 @@ MAX_IDENTIFIER_LENGTH = 50  # postgres limit minus pre/suffix for meta tables
 IDENTIFIER_PATTERN = re.compile("^[a-z][a-z0-9_]{0,%s}$" % (MAX_IDENTIFIER_LENGTH - 1))
 
 # instances of metadata parsers / compilers, order of priority
-METADATA_PARSERS = [OEP_V_1_5_Dialect(), OEP_V_1_4_Dialect()]
-METADATA_COMPILERS = [OEP_V_1_5_Dialect(), OEP_V_1_4_Dialect(), JSONCompiler()]
+METADATA_PARSERS = [OEP_V_1_5_Dialect(), OEP_V_1_4_Dialect(), OEP_V_1_3_Dialect()]
+METADATA_COMPILERS = [OEP_V_1_5_Dialect(), OEP_V_1_4_Dialect(), OEP_V_1_3_Dialect(), JSONCompiler()]
 
 
 def get_column_obj(table, column):
@@ -2294,17 +2294,17 @@ def set_table_metadata(table, schema, metadata, cursor=None):
     # ---------------------------------------
 
     # TODO: The following 2 lines seems to duplicate with the lines below the if block 
-    oedb_table_obj = _get_table(schema=schema, table=table)
-    oedb_table_obj.comment = metadata_str
-    if cursor is not None:
-        # Surprisingly, SQLAlchemy does not seem to escape comment strings
-        # properly. Certain strings cause errors database errors.
-        # This MAY be a security issue. Therefore, we do not use
-        # SQLAlchemy's compiler here but do it manually.
-        sql = "COMMENT ON TABLE {schema}.{table} IS %s".format(
-            schema=oedb_table_obj.schema, table=oedb_table_obj.name
-        )
-        cursor.execute(sql, (metadata_str,))
+    # oedb_table_obj = _get_table(schema=schema, table=table)
+    # oedb_table_obj.comment = metadata_str
+    # if cursor is not None:
+    #     # Surprisingly, SQLAlchemy does not seem to escape comment strings
+    #     # properly. Certain strings cause errors database errors.
+    #     # This MAY be a security issue. Therefore, we do not use
+    #     # SQLAlchemy's compiler here but do it manually.
+    #     sql = "COMMENT ON TABLE {schema}.{table} IS %s".format(
+    #         schema=oedb_table_obj.schema, table=oedb_table_obj.name
+    #     )
+    #     cursor.execute(sql, (metadata_str,))
 
     # ---------------------------------------
     # update search index

--- a/api/actions.py
+++ b/api/actions.py
@@ -2294,17 +2294,20 @@ def set_table_metadata(table, schema, metadata, cursor=None):
     # ---------------------------------------
 
     # TODO: The following 2 lines seems to duplicate with the lines below the if block 
-    # oedb_table_obj = _get_table(schema=schema, table=table)
-    # oedb_table_obj.comment = metadata_str
-    # if cursor is not None:
-    #     # Surprisingly, SQLAlchemy does not seem to escape comment strings
-    #     # properly. Certain strings cause errors database errors.
-    #     # This MAY be a security issue. Therefore, we do not use
-    #     # SQLAlchemy's compiler here but do it manually.
-    #     sql = "COMMENT ON TABLE {schema}.{table} IS %s".format(
-    #         schema=oedb_table_obj.schema, table=oedb_table_obj.name
-    #     )
-    #     cursor.execute(sql, (metadata_str,))
+    # TODO: REMOVE THIS AS SOON AS oemetadata jsonb column is stable - currently we keep a duplicated 
+    #       oemetadata store 1. db 2. comment on table > remove 2. soon
+
+    oedb_table_obj = _get_table(schema=schema, table=table)
+    oedb_table_obj.comment = metadata_str
+    if cursor is not None:
+        # Surprisingly, SQLAlchemy does not seem to escape comment strings
+        # properly. Certain strings cause errors database errors.
+        # This MAY be a security issue. Therefore, we do not use
+        # SQLAlchemy's compiler here but do it manually.
+        sql = "COMMENT ON TABLE {schema}.{table} IS %s".format(
+            schema=oedb_table_obj.schema, table=oedb_table_obj.name
+        )
+        cursor.execute(sql, (metadata_str,))
 
     # ---------------------------------------
     # update search index

--- a/api/views.py
+++ b/api/views.py
@@ -50,6 +50,9 @@ from dataedit.models import Table as DBTable
 from dataedit.views import get_tag_keywords_synchronized_metadata, schema_whitelist
 from oeplatform.securitysettings import PLAYGROUNDS, UNVERSIONED_SCHEMAS
 
+# TODO: keep and add later - /meta endpoint should retive data from oemetadata jsonb column
+# from dataedit.metadata import load_metadata_from_db
+
 logger = logging.getLogger("oeplatform")
 
 WHERE_EXPRESSION = re.compile(
@@ -271,6 +274,11 @@ class Metadata(APIView):
         table_obj = actions._get_table(schema=schema, table=table)
         comment = table_obj.comment
         return JsonResponse(json.loads(comment) if comment else {})
+        
+        # TODO: this is how it should be done - to manny follow up errors fix when no deadlines are creeping up
+        # TODO: keep and add later - ../meta endpoint should retive data from oemetadata jsonb column
+        # metadata = load_metadata_from_db(schema=schema, table=table)
+        # return JsonResponse(metadata if metadata else {})
 
     @api_exception
     @require_write_permission

--- a/dataedit/metadata/__init__.py
+++ b/dataedit/metadata/__init__.py
@@ -1,5 +1,5 @@
 from api import actions
-from dataedit.metadata import v1_5 as __LATEST
+from dataedit.metadata import v1_4 as __LATEST
 from dataedit.metadata.v1_3 import TEMPLATE_v1_3
 from dataedit.metadata.v1_4 import TEMPLATE_V1_4
 from dataedit.metadata.v1_5 import TEMPLATE_V1_5

--- a/dataedit/metadata/__init__.py
+++ b/dataedit/metadata/__init__.py
@@ -1,5 +1,5 @@
 from api import actions
-from dataedit.metadata import v1_4 as __LATEST
+from dataedit.metadata import v1_5 as __LATEST
 from dataedit.metadata.v1_3 import TEMPLATE_v1_3
 from dataedit.metadata.v1_4 import TEMPLATE_V1_4
 from dataedit.metadata.v1_5 import TEMPLATE_V1_5

--- a/dataedit/metadata/v1_5.py
+++ b/dataedit/metadata/v1_5.py
@@ -2,124 +2,151 @@ from omi.dialects.oep.dialect import OEP_V_1_5_Dialect
 from api import actions
 
 TEMPLATE_V1_5 = {
-    "name": "",
-    "title": "",
-    "id": "",
-    "description": "",
-    "language": [],
-    "subject": [
+    "name": None,
+    "title": None,
+    "id": None,
+    "description": None,
+    "language": None,
+    "subject": 
         {
-            "name": "",
-            "path": ""
-        }
-    ],
-    "keywords": [],
-    "publicationDate": "",
+            "name": None,
+            "path": None
+        },
+    "keywords": None,
+    "publicationDate": None,
     "context": {
-        "homepage": "",
-        "documentation": "",
-        "sourceCode": "",
-        "contact": "",
-        "grantNo": "",
-        "fundingAgency": "",
-        "fundingAgencyLogo": "",
-        "publisherLogo": ""
+        "homepage": None,
+        "documentation": None,
+        "sourceCode": None,
+        "contact": None,
+        "grantNo": None,
+        "fundingAgency": None,
+        "fundingAgencyLogo": None,
+        "publisherLogo": None
     },
     "spatial": {
-        "location": "",
-        "extent": "",
-        "resolution": ""
+        "location": None,
+        "extent": None,
+        "resolution": None
     },
     "temporal": {
-        "referenceDate": "",
-        "timeseries": [
+        "referenceDate": None,
+        "timeseries": 
             {
-                "start": "",
-                "end": "",
-                "resolution": "",
-                "alignment": "",
-                "aggregationType": ""
-            },
-            {
-                "start": "",
-                "end": "",
-                "resolution": "",
-                "alignment": "",
-                "aggregationType": ""
+                "start": None,
+                "end": None,
+                "resolution": None,
+                "alignment": None,
+                "aggregationType": None
             }
-        ]
     },
-    "sources": [
+    "sources": 
         {
-            "title": "",
-            "description": "",
-            "path": "",
+            "title": None,
+            "description": None,
+            "path": None,
             "licenses": [
                 {
-                    "name": "",
-                    "title": "",
-                    "path": "",
-                    "instruction": "",
-                    "attribution": ""
+                    "name": None,
+                    "title": None,
+                    "path": None,
+                    "instruction": None,
+                    "attribution": None
                 }
             ]
         },
+    "licenses": 
         {
-            "title": "",
-            "description": "",
-            "path": "",
-            "licenses": [
-                {
-                    "name": "",
-                    "title": "",
-                    "path": "",
-                    "instruction": "",
-                    "attribution": ""
-                }
-            ]
-        }
-    ],
-    "licenses": [
+            "name": None,
+            "title": None,
+            "path": None,
+            "instruction": None,
+            "attribution": None
+        },
+    "contributors":
         {
-            "name": "",
-            "title": "",
-            "path": "",
-            "instruction": "",
-            "attribution": ""
-        }
-    ],
-    "contributors": [
-        {
-            "title": "",
-            "email": "",
-            "date": "",
-            "object": "",
-            "comment": ""
-        }
-    ],
+            "title": None,
+            "email": None,
+            "date": None,
+            "object": None,
+            "comment": None
+        },
     "resources": [
         {
-            "profile": "",
-            "name": "",
-            "path": "",
-            "format": "",
-            "encoding": "",
+            "profile": None,
+            "name": None,
+            "path": None,
+            "format": None,
+            "encoding": None,
             "schema": {
-                "fields": [],
-                "primaryKey": [],
-                "foreignKeys": []
+                "fields": [
+                    {
+                        "name": None,
+                        "description": None,
+                        "type": None,
+                        "unit": None,
+                        "isAbout": [
+                            {
+                                "name": None,
+                                "path": None
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": None,
+                                "name": None,
+                                "path": None
+                            }
+                        ]
+                    },
+                    {
+                        "name": None,
+                        "description": None,
+                        "type": None,
+                        "unit": None,
+                        "isAbout": [
+                            {
+                                "name": None,
+                                "path": None
+                            }
+                        ],
+                        "valueReference": [
+                            {
+                                "value": None,
+                                "name": None,
+                                "path": None
+                            }
+                        ]
+                    }
+                ],
+                "primaryKey": [
+                    None
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": [
+                            None
+                        ],
+                        "reference": {
+                            "resource": None,
+                            "fields": [
+                                None
+                            ]
+                        }
+                    }
+                ]
             },
             "dialect": {
-                "delimiter": "",
+                "delimiter": None,
                 "decimalSeparator": "."
             }
         }
     ],
-    "@id": "",
-    "@context": "",
+    "@id": None,
+    "@context": None,
     "review": {
-        "path": "",
-        "badge": ""
+        "path": None,
+        "badge": None
     },
     "metaMetadata": {
         "metadataVersion": "OEP-1.5.0",
@@ -136,7 +163,7 @@ TEMPLATE_V1_5 = {
         "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
         "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
         "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/blob/master/data-review/manual/review_manual.md)",
-        "": "If not applicable use: """,
+        "Null": "If not applicable use: Null",
         "todo": "If a value is not yet available, use: todo"
     }
 }

--- a/dataedit/metadata/v1_5.py
+++ b/dataedit/metadata/v1_5.py
@@ -2,151 +2,124 @@ from omi.dialects.oep.dialect import OEP_V_1_5_Dialect
 from api import actions
 
 TEMPLATE_V1_5 = {
-    "name": None,
-    "title": None,
-    "id": None,
-    "description": None,
-    "language": None,
-    "subject": 
+    "name": "",
+    "title": "",
+    "id": "",
+    "description": "",
+    "language": [],
+    "subject": [
         {
-            "name": None,
-            "path": None
-        },
-    "keywords": None,
-    "publicationDate": None,
+            "name": "",
+            "path": ""
+        }
+    ],
+    "keywords": [],
+    "publicationDate": "",
     "context": {
-        "homepage": None,
-        "documentation": None,
-        "sourceCode": None,
-        "contact": None,
-        "grantNo": None,
-        "fundingAgency": None,
-        "fundingAgencyLogo": None,
-        "publisherLogo": None
+        "homepage": "",
+        "documentation": "",
+        "sourceCode": "",
+        "contact": "",
+        "grantNo": "",
+        "fundingAgency": "",
+        "fundingAgencyLogo": "",
+        "publisherLogo": ""
     },
     "spatial": {
-        "location": None,
-        "extent": None,
-        "resolution": None
+        "location": "",
+        "extent": "",
+        "resolution": ""
     },
     "temporal": {
-        "referenceDate": None,
-        "timeseries": 
+        "referenceDate": "",
+        "timeseries": [
             {
-                "start": None,
-                "end": None,
-                "resolution": None,
-                "alignment": None,
-                "aggregationType": None
+                "start": "",
+                "end": "",
+                "resolution": "",
+                "alignment": "",
+                "aggregationType": ""
+            },
+            {
+                "start": "",
+                "end": "",
+                "resolution": "",
+                "alignment": "",
+                "aggregationType": ""
             }
+        ]
     },
-    "sources": 
+    "sources": [
         {
-            "title": None,
-            "description": None,
-            "path": None,
+            "title": "",
+            "description": "",
+            "path": "",
             "licenses": [
                 {
-                    "name": None,
-                    "title": None,
-                    "path": None,
-                    "instruction": None,
-                    "attribution": None
+                    "name": "",
+                    "title": "",
+                    "path": "",
+                    "instruction": "",
+                    "attribution": ""
                 }
             ]
         },
-    "licenses": 
         {
-            "name": None,
-            "title": None,
-            "path": None,
-            "instruction": None,
-            "attribution": None
-        },
-    "contributors":
+            "title": "",
+            "description": "",
+            "path": "",
+            "licenses": [
+                {
+                    "name": "",
+                    "title": "",
+                    "path": "",
+                    "instruction": "",
+                    "attribution": ""
+                }
+            ]
+        }
+    ],
+    "licenses": [
         {
-            "title": None,
-            "email": None,
-            "date": None,
-            "object": None,
-            "comment": None
-        },
+            "name": "",
+            "title": "",
+            "path": "",
+            "instruction": "",
+            "attribution": ""
+        }
+    ],
+    "contributors": [
+        {
+            "title": "",
+            "email": "",
+            "date": "",
+            "object": "",
+            "comment": ""
+        }
+    ],
     "resources": [
         {
-            "profile": None,
-            "name": None,
-            "path": None,
-            "format": None,
-            "encoding": None,
+            "profile": "",
+            "name": "",
+            "path": "",
+            "format": "",
+            "encoding": "",
             "schema": {
-                "fields": [
-                    {
-                        "name": None,
-                        "description": None,
-                        "type": None,
-                        "unit": None,
-                        "isAbout": [
-                            {
-                                "name": None,
-                                "path": None
-                            }
-                        ],
-                        "valueReference": [
-                            {
-                                "value": None,
-                                "name": None,
-                                "path": None
-                            }
-                        ]
-                    },
-                    {
-                        "name": None,
-                        "description": None,
-                        "type": None,
-                        "unit": None,
-                        "isAbout": [
-                            {
-                                "name": None,
-                                "path": None
-                            }
-                        ],
-                        "valueReference": [
-                            {
-                                "value": None,
-                                "name": None,
-                                "path": None
-                            }
-                        ]
-                    }
-                ],
-                "primaryKey": [
-                    None
-                ],
-                "foreignKeys": [
-                    {
-                        "fields": [
-                            None
-                        ],
-                        "reference": {
-                            "resource": None,
-                            "fields": [
-                                None
-                            ]
-                        }
-                    }
-                ]
+                "fields": [],
+                "primaryKey": [],
+                "foreignKeys": []
             },
             "dialect": {
-                "delimiter": None,
+                "delimiter": "",
                 "decimalSeparator": "."
             }
         }
     ],
-    "@id": None,
-    "@context": None,
+    "@id": "",
+    "@context": "",
     "review": {
-        "path": None,
-        "badge": None
+        "path": "",
+        "badge": ""
     },
     "metaMetadata": {
         "metadataVersion": "OEP-1.5.0",
@@ -163,7 +136,7 @@ TEMPLATE_V1_5 = {
         "languages": "Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
         "licenses": "License name must follow the SPDX License List (https://spdx.org/licenses/)",
         "review": "Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/blob/master/data-review/manual/review_manual.md)",
-        "Null": "If not applicable use: Null",
+        "Null": "If not applicable use: 'Null'",
         "todo": "If a value is not yet available, use: todo"
     }
 }

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -1364,6 +1364,9 @@ def get_tag_keywords_synchronized_metadata(
     session = create_oedb_session()
 
     metadata = load_metadata_from_db(schema=schema, table=table)
+    if metadata["keywords"] is None:
+        metadata["keywords"] = []
+
     keywords_old = set(
         k for k in metadata.get("keywords", []) if Tag.create_name_normalized(k)
     )  # remove empy


### PR DESCRIPTION
add omi dialect for metadata oem-v1.3
update oemetadata migration to handle oemetadata v1.3

Add note to remove functionality that updates for comment on table as soon as oemetadata migration is stable
Add presentation template for metadata widget - this is no proper oemetadata v1.5.1 json template but modified to be properly displayed by the metadata widget