### PR TITLE
PK constraint is skipped if PK is set in column

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -866,6 +866,8 @@ def table_create(schema, table, column_definitions, constraints_definitions):
                 ccolumns = [constraint["constraint_parameter"]]
 
             if primary_key_col_names:
+                if ccolumns in primary_key_col_names:
+                    continue
                 raise APIError("Multiple definitions of primary key")
             primary_key_col_names = ccolumns
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -5,3 +5,4 @@
 
 
 ### Bugs
+ - Fix check for id to strict (PR#1111)


### PR DESCRIPTION
Fixes #1110

This PR checks whether PK constraint is already present as PK in column.
If PK (pointing to same column) is already present, no error is raised and PK constraint is not added to constraints.

Could you review @wingechr ?
Attention: Not tested, as I have no OEPlatform setup!