### PR TITLE
Fix tutorial accordions

### DIFF
--- a/tutorials/templates/list.html
+++ b/tutorials/templates/list.html
@@ -27,14 +27,14 @@
 
 <div id="tutorials-overview">
 {% for tutorial in tutorials_overview %}
-  <h3 class="my-2"><a href="#tut-training-start" title="back to top"><i class="mr-2 fa fa-caret-up"></i></a>{{ tutorial.title }}</h3>
+  <h3 class="mt-5 mb-3">{{ tutorial.title }}</h3>
   <div class="tutorial-container">
     {{ tutorial.html | safe }}
   </div>
 {% endfor %}
 </div><!-- end of overview tutorials -->
 
-<h2 class="my-5">Tutorials by category</h2>
+<h2 class="mt-5 mb-3">Tutorials by category</h2>
 
 <table class="table table-bordered">
     <thead class="table-dark">


### PR DESCRIPTION
@jh-RLI I fixed the broken accordions in the tutorial sections 02 and 03. I actually had to change a bit the HTML structure, so it was not just an easy fix with a missing class. Therefore it would be good if someone could check on that to see if everything is still there. I saved the older tutorial versions because I don't know where/if they are saved somewhere?

Regarding the arrow pointing down on section 01, 02 and 03, actually they were not built as accordions but as buttons to go back to the top of the page. I found it quite misleading, I also thought it was supposed to be accordions. So I just removed them because I don't think we need them. If we really want that go-back-to-top button, we should think of another solution.

close #1112 