### PR TITLE
Modify review page to present review details of finished reviews without any review edeting functionality

### DIFF
--- a/dataedit/static/peer_review/opr_reviewer.js
+++ b/dataedit/static/peer_review/opr_reviewer.js
@@ -617,9 +617,19 @@ function check_if_review_finished(){
 
     finishButton.on('click', finishPeerReview);
 
+    if (config.review_finished !== true){
     // Displaying the div
     reviewerDiv.show();
     $('#submit_summary').prop('disabled', true);
+    }
+    else{
+      reviewerDiv.hide(); // Hiding the div
+      $('#submit_summary').hide();
+      $('#peer_review-save').hide();
+      // $('#review-window').hide();
+      $('#review-window').css('visibility', 'hidden');
+      
+    }
 
 
     // Adding the div to the desired location in the document

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -2008,6 +2008,7 @@ class PeerReviewView(LoginRequiredMixin, View):
             )
             # existing_review={}
             state_dict=None
+            review_finished=None
 
         config_data = {
             "can_add": can_add,
@@ -2015,6 +2016,7 @@ class PeerReviewView(LoginRequiredMixin, View):
             "url_table": reverse("view", kwargs={"schema": schema, "table": table}),
             "topic": schema,
             "table": table,
+            "review_finished": review_finished,
         }
 
         context_meta = {
@@ -2023,7 +2025,7 @@ class PeerReviewView(LoginRequiredMixin, View):
             "meta": metadata,
             "json_schema": json_schema,
             "field_descriptions_json": json.dumps(field_descriptions),
-            "state_dict": json.dumps(state_dict),
+            "state_dict": json.dumps(state_dict), 
         }
         return render(request, 'dataedit/opr_review.html', context=context_meta)
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -8,7 +8,7 @@
 - Enhanced review functionality: Following the submission of the initial review by the reviewer, subsequent field reviews are now seamlessly stored within the review JSON file. This improvement facilitates effective communication between the contributor and reviewer by enabling the loading of these reviews onto the review or contributor page. (#1252)
 - Add functionality to handel finished open peer reviews and extend the reviewer page to grant a badge and finish the current review.  [(#1260)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1260)
 - Implement the review result tab on the table dataview page. [(#1262)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1262)
-
+- Expand the reviewer page so that it can be used as a review detail page when a review is completed. All editing functionality is removed. [(#1267)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1267)
 
 ### Bugs
 


### PR DESCRIPTION
## Summary of the discussion

closes #1266

## Type of change (CHANGELOG.md)

### Updated
- Expand the reviewer page so that it can be used as a review detail page when a review is completed. All editing functionality is removed. [(#1267)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1267)


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [Read The Docs](https://oeplatform.readthedocs.io/en/latest/?badge=latest) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
