### PR TITLE
restrict access to profile review page

### DIFF
--- a/login/templates/login/user_review.html
+++ b/login/templates/login/user_review.html
@@ -64,6 +64,7 @@
 {% endblock %}
 
 {% block main-content-body %}
+{% if profile_user == request.user %}
 {% include "login/user_nav.html" %}
     <h2>Active Open Peer Reviews</h2>
     <p> 
@@ -296,4 +297,5 @@
         {% endif %}
     
 </div>
+{% endif %}
 {% endblock %}

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -4,5 +4,6 @@
 ### Features
 
 ### Bugs
+- Fix access to profile review page: restict to current user [(#1279)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1279)
 
 ### Removed


### PR DESCRIPTION
## Summary of the discussion

closes #1278 

## Type of change (CHANGELOG.md)

### Updated
- Fix access to profile review page: restict to current user [(#1279)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1279)



## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [Read The Docs](https://oeplatform.readthedocs.io/en/latest/?badge=latest) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
