### PR TITLE
Error on contributor page when reviewing a field in spatial category

### DIFF
--- a/dataedit/static/peer_review/opr_reviewer.js
+++ b/dataedit/static/peer_review/opr_reviewer.js
@@ -555,13 +555,6 @@ function saveEntrances() {
   checkReviewComplete();
   selectNextField();
   
-
-  // IS THIS NEEDED?
-  // alert(JSON.stringify(current_review, null, 4));
-  // document.getElementById("summary").innerHTML = (
-  //   JSON.stringify(current_review, null, 4)
-  // );
-
   renderSummaryPageFields();
 }
 

--- a/dataedit/templates/dataedit/opr_contributor.html
+++ b/dataedit/templates/dataedit/opr_contributor.html
@@ -138,6 +138,7 @@
                       <span class="value">{{ item.value }}</span>
                       <span class="suggestion">{{ reviewer_suggestions.item.field }}</span>
                       <span class="suggestion suggestion--highlight">{{ item.reviewer_suggestion }}</span>
+                      <span class="comment suggestion--comment"> {{ item.suggestion_comment }}</span>
                     {% endif %}
                   </p>
                 </div>

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -5,5 +5,6 @@
 
 ### Bugs
 - Fix access to profile review page: restict to current user [(#1279)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1279)
+- Fix error on contributor page when reviewing a field in the spatial category [(#1291)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1291)
 
 ### Removed


### PR DESCRIPTION
## Summary of the discussion

Prevent reading null values in opr contributor view.

## Type of change (CHANGELOG.md)




## Workflow checklist

### Automation
Closes #1289 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [Read The Docs](https://oeplatform.readthedocs.io/en/latest/?badge=latest) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
