### PR TITLE
OPR: Reset review controles once another field is selected

### DIFF
--- a/dataedit/static/peer_review/opr_contributor.js
+++ b/dataedit/static/peer_review/opr_contributor.js
@@ -218,7 +218,6 @@ function click_field(fieldKey, fieldValue, category) {
   }
   // console.log("Category:", category, "Field key:", cleanedFieldKey, "Data:", fieldDescriptionsData[cleanedFieldKey]);
   const fieldState = getFieldState(fieldKey);
-
   if (fieldState === 'ok' || !fieldState) {
     document.getElementById("ok-button").disabled = true;
     document.getElementById("rejected-button").disabled = true;
@@ -238,7 +237,7 @@ function click_field(fieldKey, fieldValue, category) {
   }
 
   clearInputFields();
-
+  hideReviewerOptions();
 }
 
 function clearInputFields() {
@@ -451,9 +450,31 @@ function createFieldList(fields) {
   `;
 }
 
-// Function to show the error toast
-function showErrorToast(liveToast) {
-  liveToast.show();
+// // Function to show the error toast
+// function showErrorToast(liveToast) {
+//   liveToast.show();
+// }
+
+function showToast(title, message, type) {
+  var toast = document.getElementById('liveToast');
+  var toastTitle = document.getElementById('toastTitle');
+  var toastBody = document.getElementById('toastBody');
+  
+  // Update the toast's header and body based on the type
+  if (type === 'error') {
+    toast.classList.remove('bg-success');
+    toast.classList.add('bg-danger');
+  } else if (type === 'success') {
+    toast.classList.remove('bg-danger');
+    toast.classList.add('bg-success');
+  }
+  
+  // Set the title and body text
+  toastTitle.textContent = title;
+  toastBody.textContent = message;
+  
+  var bsToast = new bootstrap.Toast(toast);
+  bsToast.show();
 }
 
 
@@ -472,7 +493,7 @@ function saveEntrances() {
     // Validate the valuearea before proceeding
     if (valuearea.value.trim() === '') {
       valuearea.setCustomValidity('Value suggestion is required');
-      showErrorToast(liveToast);
+      showToast("Error", "The value suggestion text field is required to save the field review!", "error");
       return; // Stop execution if validation fails
     } else {
       valuearea.setCustomValidity('');
@@ -566,6 +587,7 @@ function checkReviewComplete() {
     }
   }
   $('#submit_summary').removeClass('disabled');
+  showToast("Success", "You have reviewed all fields an can submit the review to get feedback!", 'success');
 }
 
 

--- a/dataedit/static/peer_review/opr_reviewer.js
+++ b/dataedit/static/peer_review/opr_reviewer.js
@@ -213,6 +213,8 @@ function cancelPeerReview() {
  */
 
 function click_field(fieldKey, fieldValue, category) {
+
+
   // this seems unused but it is relevant to select next and prev field functions
   selectedField = fieldKey;
   selectedFieldValue = fieldValue;
@@ -255,7 +257,7 @@ function click_field(fieldKey, fieldValue, category) {
       document.getElementById("ok-button").disabled = true;
       document.getElementById("rejected-button").disabled = true;
       document.getElementById("suggestion-button").disabled = true;
-    } else if (fieldState === 'rejected') {
+    } else if (fieldState === 'suggestion' || fieldState === 'rejected') {
       document.getElementById("ok-button").disabled = false;
       document.getElementById("rejected-button").disabled = false;
       document.getElementById("suggestion-button").disabled = false;
@@ -269,8 +271,8 @@ function click_field(fieldKey, fieldValue, category) {
   if (selectedDiv) {
     selectedDiv.style.backgroundColor = '#F6F9FB';
   }
-
   clearInputFields();
+  hideReviewerOptions();
 }
 
 
@@ -501,9 +503,31 @@ function createFieldList(fields) {
   `;
 }
 
-// Function to show the error toast
-function showErrorToast(liveToast) {
-  liveToast.show();
+// // Function to show the error toast
+// function showErrorToast(liveToast) {
+//   liveToast.show();
+// }
+
+function showToast(title, message, type) {
+  var toast = document.getElementById('liveToast');
+  var toastTitle = document.getElementById('toastTitle');
+  var toastBody = document.getElementById('toastBody');
+  
+  // Update the toast's header and body based on the type
+  if (type === 'error') {
+    toast.classList.remove('bg-success');
+    toast.classList.add('bg-danger');
+  } else if (type === 'success') {
+    toast.classList.remove('bg-danger');
+    toast.classList.add('bg-success');
+  }
+  
+  // Set the title and body text
+  toastTitle.textContent = title;
+  toastBody.textContent = message;
+  
+  var bsToast = new bootstrap.Toast(toast);
+  bsToast.show();
 }
 
 /**
@@ -521,7 +545,7 @@ function saveEntrances() {
     // Validate the valuearea before proceeding
     if (valuearea.value.trim() === '') {
       valuearea.setCustomValidity('Value suggestion is required');
-      showErrorToast(liveToast);
+      showToast("Error", "The value suggestion text field is required to save the field review!", "error");
       return; // Stop execution if validation fails
     } else {
       valuearea.setCustomValidity('');
@@ -647,6 +671,8 @@ function checkReviewComplete() {
     }
   }
   $('#submit_summary').removeClass('disabled');
+
+  showToast("Success", "You have reviewed all fields an can submit the review to get feedback!", 'success');
 }
 
 
@@ -671,6 +697,7 @@ function check_if_review_finished() {
 
   if (checkFieldStates() && !clientSideReviewFinished) {
     clientSideReviewFinished = true;
+    showToast("Review completed!", "You completed the review an can now grant a suitable badge!", 'success');
     // Creating the div with radio buttons
     var reviewerDiv = $('<div class="bg-warning" id="finish-review-div"></div>');
     var bronzeRadio = $('<input type="radio" name="reviewer-option" value="bronze"> Bronze<br>');

--- a/dataedit/static/peer_review/opr_reviewer.js
+++ b/dataedit/static/peer_review/opr_reviewer.js
@@ -671,8 +671,9 @@ function checkReviewComplete() {
     }
   }
   $('#submit_summary').removeClass('disabled');
-
-  showToast("Success", "You have reviewed all fields an can submit the review to get feedback!", 'success');
+  if (!clientSideReviewFinished){
+    showToast("Success", "You have reviewed all fields an can submit the review to get feedback!", 'success');
+  }
 }
 
 
@@ -697,7 +698,7 @@ function check_if_review_finished() {
 
   if (checkFieldStates() && !clientSideReviewFinished) {
     clientSideReviewFinished = true;
-    showToast("Review completed!", "You completed the review an can now grant a suitable badge!", 'success');
+    showToast("Review completed!", "You completed the review an can now award a suitable  badge!", 'success');
     // Creating the div with radio buttons
     var reviewerDiv = $('<div class="bg-warning" id="finish-review-div"></div>');
     var bronzeRadio = $('<input type="radio" name="reviewer-option" value="bronze"> Bronze<br>');

--- a/dataedit/templates/dataedit/opr_contributor.html
+++ b/dataedit/templates/dataedit/opr_contributor.html
@@ -29,13 +29,21 @@
     <div class="content__container">
 
       <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
-        <div id="liveToast" class="toast hide" role="alert" aria-live="assertive" aria-atomic="true">
+        <!-- <div id="liveToast" class="toast hide" role="alert" aria-live="assertive" aria-atomic="true">
           <div class="toast-header bg-danger">
             <strong class="me-auto">Error</strong>
             <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
           </div>
           <div class="toast-body">
             The value suggestion text field is required to save the field review!
+          </div>
+        </div> -->
+        <div id="liveToast" class="toast hide" role="alert" aria-live="assertive" aria-atomic="true">
+          <div class="toast-header">
+            <strong class="me-auto" id="toastTitle"></strong>
+            <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+          </div>
+          <div class="toast-body" id="toastBody">
           </div>
         </div>
       </div>

--- a/dataedit/templates/dataedit/opr_review.html
+++ b/dataedit/templates/dataedit/opr_review.html
@@ -28,13 +28,25 @@
     <div class="content__container">
 
       <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
-        <div id="liveToast" class="toast hide" role="alert" aria-live="assertive" aria-atomic="true">
+        <!-- <div id="liveToast" class="toast hide" role="alert" aria-live="assertive" aria-atomic="true">
+          <div class="toast-header bg-success"> 
+            <strong class="me-auto">Success</strong> 
+            <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+          </div>
           <div class="toast-header bg-danger">
             <strong class="me-auto">Error</strong>
             <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
           </div>
           <div class="toast-body">
             The value suggestion text field is required to save the field review!
+          </div>
+        </div> -->
+        <div id="liveToast" class="toast hide" role="alert" aria-live="assertive" aria-atomic="true">
+          <div class="toast-header">
+            <strong class="me-auto" id="toastTitle"></strong>
+            <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+          </div>
+          <div class="toast-body" id="toastBody">
           </div>
         </div>
       </div>

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -12,6 +12,7 @@
 - Add delete table button to dataview page [(#1280)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1280)
 
 ### Bugs
+- Reset review controles once another field is selected [(#1326)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1326)
 - Fix the active reviews list in the profile page will now always show the latest open review and the all reviews list provides a link to the review if it is ongoing [(#1317)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1317)
 - Fixed a bug that prevents a review from being completed (awarding a badge) and the contributor getting stuck on the review page because the "Submit" button remains disabled [(#1314)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1314)
 - Fix Open Peer review: Remove duplicated entries in summary table [(#1279)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1279)

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -12,7 +12,7 @@
 - Add delete table button to dataview page [(#1280)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1280)
 
 ### Bugs
-- Reset review controles once another field is selected [(#1326)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1326)
+- Reset review controles once another field is selected and enhance notifications [(#1326)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1326)
 - Fix the active reviews list in the profile page will now always show the latest open review and the all reviews list provides a link to the review if it is ongoing [(#1317)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1317)
 - Fixed a bug that prevents a review from being completed (awarding a badge) and the contributor getting stuck on the review page because the "Submit" button remains disabled [(#1314)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1314)
 - Fix Open Peer review: Remove duplicated entries in summary table [(#1279)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1279)


### PR DESCRIPTION
## Summary of the discussion

Review controls should be reset if another field is clicked to prevent accessible controls on fields that are already accepted. 

Also enhance notifications.

## Type of change (CHANGELOG.md)

### Updated
-  Reset review controls once another field is selected and enhance notifications [(#1326)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1326)


## Workflow checklist

### Automation
Closes #1325 
Closes #1327

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [Read The Docs](https://oeplatform.readthedocs.io/en/latest/?badge=latest) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
