### PR TITLE
OPR Bugfix: cant grant badge if review is finished right away

### DIFF
--- a/dataedit/models.py
+++ b/dataedit/models.py
@@ -165,6 +165,14 @@ class PeerReview(models.Model):
                 pm_new = PeerReviewManager(opr=self,  status=ReviewDataStatus.SUBMITTED.value)
                 pm_new.set_next_reviewer()
 
+            elif review_type == "finished":
+                # TODO: fails if the review is completed without submitting (finish in one run)
+                pm_new = PeerReviewManager(opr=self,  status=ReviewDataStatus.FINISHED.value)
+                self.is_finished = True
+                self.date_finished = timezone.now()
+                # Call the parent class's save method to save the PeerReview instance
+                super().save(*args, **kwargs)
+
             pm_new.save() 
 
             # if prev_review is not None:
@@ -179,6 +187,7 @@ class PeerReview(models.Model):
         Update the peer review if the latest peer review is not finished yet but either saved or submitted.
 
         """
+
         review_type = kwargs.pop('review_type', None)
         if not self.contributor == self.reviewer:
             current_pm = PeerReviewManager.load(opr=self)

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -2107,14 +2107,11 @@ class PeerReviewView(LoginRequiredMixin, View):
 
         Missing parts:
         - once the opr is finished (all field reviews agreed on)
-            - set the review to finished
             - merge field review results to metadata on table
             - awarde a badge
                 - is field filled in?
                 - calculate the badge by comparing filled fields
                   and the badges form metadata schema
-            - update indicator on table view (this table was succesuflly reviewed)
-            - ...
         """
         context = {}
         if request.method == "POST":

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -3,5 +3,6 @@
 ### Features
 
 ### Bugs
+- Open Peer Review: Fix a bug in the review backend to handle reviews that are finished in one go (without any feedback). [(#1333)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1333)
 
 ### Removed


### PR DESCRIPTION
## Summary of the discussion

Fix a bug in the review backend to handle reviews that are finished without any feedback.

## Type of change (CHANGELOG.md)


### Updated
- Open Peer Review: Fix a bug in the review backend to handle reviews that are finished in one go (without any feedback). [(#1333)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1333)



## Workflow checklist

### Automation
Closes #1332  

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [Read The Docs](https://oeplatform.readthedocs.io/en/latest/?badge=latest) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
