### PR TITLE
Open Peer Review: Fix the review history

### DIFF
--- a/login/views.py
+++ b/login/views.py
@@ -79,12 +79,12 @@ class ReviewsView(View):
                 reviewer_user=user
             )
 
-            review_history = peer_review_reviews.exclude(pk=active_peer_review_revewier.pk)
+            # review_history = peer_review_reviews.exclude(pk=active_peer_review_revewier.pk)
             
             # Context da for the "All reviews" section on the profile page
             reviewed_context.update({
                 "latest": latest_review, # mainly used to check if review exists
-                "history": review_history,
+                # "history": review_history,
             })
 
             


### PR DESCRIPTION
## Summary of the discussion

The review history should only show reviews that have been finished and not the active review.

## Type of change (CHANGELOG.md)


### Updated
- Update a definition [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)



## Workflow checklist

### Automation
Closes #1335 

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [Read The Docs](https://oeplatform.readthedocs.io/en/latest/?badge=latest) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
