### PR TITLE
Add link to scenario bundle to nav bar 

### DIFF
--- a/base/templates/base/base-full.html
+++ b/base/templates/base/base-full.html
@@ -50,7 +50,7 @@
                             <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Alpha</sup></a>
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                             <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>

--- a/base/templates/base/base-full.html
+++ b/base/templates/base/base-full.html
@@ -50,8 +50,8 @@
                             <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a>
-                            <!-- <a class="dropdown-item" href="/factsheets/rdf/study/">Study  Factsheet<sup class="small text-muted">Alpha</sup></a> -->
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Alpha</sup></a>
+                            <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>
                     <li class="nav-item dropdown">

--- a/base/templates/base/base-profile.html
+++ b/base/templates/base/base-profile.html
@@ -50,7 +50,7 @@
                             <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Alpha</sup></a>
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                             <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>

--- a/base/templates/base/base-profile.html
+++ b/base/templates/base/base-profile.html
@@ -50,8 +50,8 @@
                             <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a>
-                            <!-- <a class="dropdown-item" href="/factsheets/rdf/study/">Study  Factsheet<sup class="small text-muted">Alpha</sup></a> -->
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Alpha</sup></a>
+                            <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>
                     <li class="nav-item dropdown">

--- a/base/templates/base/base-wide-react.html
+++ b/base/templates/base/base-wide-react.html
@@ -54,8 +54,8 @@
                         <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                         <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                         <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                        <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a>
-                        <!-- <a class="dropdown-item" href="/factsheets/rdf/study/">Study  Factsheet<sup class="small text-muted">Alpha</sup></a> -->
+                        <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Alpha</sup></a>
+                        <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                     </div>
                 </li>
                 <li class="nav-item dropdown">

--- a/base/templates/base/base-wide-react.html
+++ b/base/templates/base/base-wide-react.html
@@ -54,7 +54,7 @@
                         <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                         <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                         <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                        <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Alpha</sup></a>
+                        <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                         <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                     </div>
                 </li>

--- a/base/templates/base/base-wide-react.html
+++ b/base/templates/base/base-wide-react.html
@@ -32,7 +32,7 @@
 <body>
 {% block header %}
     <nav class="navbar navbar-expand-lg navbar-dark bg-secondary">
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -47,10 +47,10 @@
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
-                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Factsheets
                     </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <div class="dropdown-menu" aria-labelledby="navbarDropdownFS">
                         <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                         <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                         <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
@@ -60,7 +60,7 @@
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
-                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Ontology
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
@@ -75,7 +75,7 @@
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
-                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         About
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
@@ -138,8 +138,12 @@
 
 {% block body-bottom-js %}
     {% block before-body-bottom-js %}{% endblock before-body-bottom-js %}
-    <script type="text/javascript" src="{% static '/js/jsi18n.js' %}"></script>
-    <script type="text/javascript" src="{% static '/js/oep-tags.js' %}"></script>
+    <script src="{% static 'js/jquery.min.js' %}"></script>
+    <script src="{% static 'js/popper.min.js' %}"></script>
+    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
+    <script src="{% static 'js/jquery-ui.min.js' %}"></script><!-- https://code.jquery.com/ui/1.12.1/jquery-ui.js -->
+    <script src="{% static 'js/jsi18n.js' %}"></script>
+    <script src="{% static 'js/oep-tags.js' %}"></script>
     {% block after-body-bottom-js %}{% endblock after-body-bottom-js %}
 {% endblock body-bottom-js %}
 

--- a/base/templates/base/base-wide.html
+++ b/base/templates/base/base-wide.html
@@ -51,7 +51,7 @@
                         <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                         <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                         <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                        <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a>
+                        <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                         <!-- <a class="dropdown-item" href="/factsheets/rdf/study/">Study  Factsheet<sup class="small text-muted">Alpha</sup></a> -->
                     </div>
                 </li>

--- a/base/templates/base/base.html
+++ b/base/templates/base/base.html
@@ -50,8 +50,8 @@
                             <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a>
-                            <!-- <a class="dropdown-item" href="/factsheets/rdf/study/">Study  Factsheet<sup class="small text-muted">Alpha</sup></a> -->
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
+                            <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>
                     <li class="nav-item dropdown">

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -74,7 +74,7 @@ MIDDLEWARE = (
     "login.middleware.DetachMiddleware",
     "axes.middleware.AxesMiddleware",
     "corsheaders.middleware.CorsMiddleware",
-    "django.middleware.common.CommonMiddleware"
+    "django.middleware.common.CommonMiddleware",
 )
 
 ROOT_URLCONF = "oeplatform.urls"
@@ -116,10 +116,7 @@ TEMPLATES = [
     }
 ]
 
-CORS_ORIGIN_WHITELIST = [
-    "http://localhost:3000", 
-    "http://127.0.0.1:3000"
-    ]
+CORS_ORIGIN_WHITELIST = ["http://localhost:3000", "http://127.0.0.1:3000"]
 
 GRAPHENE = {"SCHEMA": "factsheet.schema.schema"}
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -1,6 +1,7 @@
 ### Changes
 
 ### Features
+- Make the scenario bundle and scenario comparison app accessible via the nav bar menu. [PR#1389](https://github.com/OpenEnergyPlatform/oeplatform/pull/1389)
 
 ### Bugs
 - Remove files that are not part of the project [PR#1384](https://github.com/OpenEnergyPlatform/oeplatform/pull/1384)


### PR DESCRIPTION
## Summary of the discussion

Make the scenario bundle and scenario comparison app accessible via the nav bar menu.

## Type of change (CHANGELOG.md)

### Added
-  Make the scenario bundle and scenario comparison app accessible via the nav bar menu. [PR#1389](https://github.com/OpenEnergyPlatform/oeplatform/pull/1389)


## Workflow checklist

### Automation
Part of #1388 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
