### PR TITLE
Prevent browser from showing cached factsheet pages after an edit-submit action.

### DIFF
--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -3,6 +3,6 @@
 ### Features
 
 ### Bugs
-- Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed (PR#1404)[https://github.com/OpenEnergyPlatform/oeplatform/pull/1404]
+- Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed [PR#1404](https://github.com/OpenEnergyPlatform/oeplatform/pull/1404)
 
 ### Removed

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -3,6 +3,6 @@
 ### Features
 
 ### Bugs
-- Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed (#)[]
+- Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed (PR#1404)[https://github.com/OpenEnergyPlatform/oeplatform/pull/1404]
 
 ### Removed

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-
 ### Bugs
+- Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed (#)[]
 
 ### Removed


### PR DESCRIPTION
## Summary of the discussion

This bugfix includes an update to the modelview/views.py code. It declears the never cache decorator from django in the detail and edit views to prevent the browser from showing cached factsheet pages after an edit-submit action.

Note: This is not about the react based scenario-bundles (also called factsheet before). It is related to the modle and framework factsheets that have been implemented using django.

## Type of change (CHANGELOG.md)

### Updated
- Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed [PR#1404](https://github.com/OpenEnergyPlatform/oeplatform/pull/1404)


## Workflow checklist

### Automation
Closes #697 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
