### PR TITLE
Show scenario bundle on homepage and describe its components

### DIFF
--- a/base/templates/base/base-full.html
+++ b/base/templates/base/base-full.html
@@ -44,13 +44,13 @@
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownFS" role="button"
                            data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Factsheets
+                            Scenario Bundles
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownFS">
-                            <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
+                            <!-- <a class="dropdown-item" href="/factsheets/overview/">Overview</a> -->
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                             <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>
@@ -67,7 +67,7 @@
                         </div>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}">Academy</a>
+                        <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}" target="_blank">Academy <i class="fas fa-external-link-alt"></i></a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownAbout" role="button"
@@ -76,8 +76,10 @@
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownAbout">
                             <a class="dropdown-item" href="/about/">Overview</a>
-                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank">Developer Documentation</a>
-                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.tutorials_faq }}">FAQ</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.compendium }}" target="_blank"><i class="fas fa-external-link-alt"></i> Compendium</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.mkdocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> Developer Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> REST-API Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.tutorials_faq }}" target="_blank"><i class="fas fa-external-link-alt"></i> FAQ</a>
                         </div>
                     </li>
                 </ul>

--- a/base/templates/base/base-profile.html
+++ b/base/templates/base/base-profile.html
@@ -44,13 +44,14 @@
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownFS" role="button"
                            data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Factsheets
+                            Scenario Bundles
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownFS">
-                            <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
+                            <!-- <a class="dropdown-item" href="/factsheets/overview/">Overview</a> -->
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
+                            
                             <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>
@@ -67,7 +68,7 @@
                         </div>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}">Academy</a>
+                        <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}" target="_blank">Academy <i class="fas fa-external-link-alt"></i></a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownAbout" role="button"
@@ -76,8 +77,10 @@
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownAbout">
                             <a class="dropdown-item" href="/about/">Overview</a>
-                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.compendium }}">Compendium</a>
-                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank">Developer Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.compendium }}" target="_blank"><i class="fas fa-external-link-alt"></i> Compendium</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.mkdocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> Developer Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> REST-API Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.tutorials_faq }}" target="_blank"><i class="fas fa-external-link-alt"></i> FAQ</a>
                         </div>
                     </li>
                 </ul>

--- a/base/templates/base/base-wide-react.html
+++ b/base/templates/base/base-wide-react.html
@@ -48,13 +48,13 @@
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
                        data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        Factsheets
+                        Scenario Bundles
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownFS">
-                        <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
+                        <!-- <a class="dropdown-item" href="/factsheets/overview/">Overview</a> -->
+                        <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                         <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                         <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                        <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                         <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                     </div>
                 </li>
@@ -71,7 +71,7 @@
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/tutorials/">Tutorials</a>
+                    <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}" target="_blank">Academy <i class="fas fa-external-link-alt"></i></a>
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
@@ -80,8 +80,10 @@
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                         <a class="dropdown-item" href="/about/">Overview</a>
-                        <a class="dropdown-item" href="https://oep-data-interface.readthedocs.io/en/latest/">Developer Documentation</a>
-                        <a class="dropdown-item" href="/tutorials/17/">FAQ</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.compendium }}" target="_blank"><i class="fas fa-external-link-alt"></i> Compendium</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.mkdocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> Developer Documentation</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> REST-API Documentation</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.tutorials_faq }}" target="_blank"><i class="fas fa-external-link-alt"></i> FAQ</a>
                     </div>
                 </li>
             </ul>

--- a/base/templates/base/base-wide.html
+++ b/base/templates/base/base-wide.html
@@ -68,7 +68,7 @@
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}">Academy</a>
+                    <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}" target="_blank">Academy <i class="fas fa-external-link-alt"></i></a>
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownAbout" role="button"
@@ -77,8 +77,10 @@
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownAbout">
                         <a class="dropdown-item" href="/about/">Overview</a>
-                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank">Developer Documentation</a>
-                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.tutorials_faq }}">FAQ</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.compendium }}" target="_blank"><i class="fas fa-external-link-alt"></i> Compendium</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.mkdocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> Developer Documentation</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> REST-API Documentation</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.tutorials_faq }}" target="_blank"><i class="fas fa-external-link-alt"></i> FAQ</a>
                     </div>
                 </li>
             </ul>

--- a/base/templates/base/base.html
+++ b/base/templates/base/base.html
@@ -44,13 +44,13 @@
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownFS" role="button"
                            data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Factsheets
+                            Scenario Bundles
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownFS">
-                            <a class="dropdown-item" href="/factsheets/overview/">Overview</a>
+                            <!-- <a class="dropdown-item" href="/factsheets/overview/">Overview</a> -->
+                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                             <a class="dropdown-item" href="/factsheets/frameworks/">Framework Factsheet</a>
                             <a class="dropdown-item" href="/factsheets/models/">Model Factsheet</a>
-                            <a class="dropdown-item" href="/sirop/">Scenario Bundle<sup class="small text-muted">Early Access</sup></a>
                             <!-- <a class="dropdown-item" href="/factsheets/scenarios/">Scenario Factsheet</a> -->
                         </div>
                     </li>
@@ -67,7 +67,7 @@
                         </div>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}">Academy</a>
+                        <a class="nav-link" href="{{ EXTERNAL_URLS.tutorials_index }}" target="_blank">Academy <i class="fas fa-external-link-alt"></i></a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownAbout" role="button"
@@ -76,8 +76,10 @@
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownAbout">
                             <a class="dropdown-item" href="/about/">Overview</a>
-                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.compendium }}">Compendium</a>
-                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank">Developer Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.compendium }}" target="_blank"><i class="fas fa-external-link-alt"></i> Compendium</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.mkdocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> Developer Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.readthedocs }}" target="_blank"><i class="fas fa-external-link-alt"></i> REST-API Documentation</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.tutorials_faq }}" target="_blank"><i class="fas fa-external-link-alt"></i> FAQ</a>
                         </div>
                     </li>
                 </ul>

--- a/base/templates/base/index.html
+++ b/base/templates/base/index.html
@@ -37,7 +37,7 @@
                             <div class= "panel-description">
                                 <h2> Scenario Bundles </h2>
                                 <p class = "alternative">
-                                    Do you want to learn more about scenarios and models related to the data? Then, this is the right place to look. Also if you contributed data and want to provide more context, Create your own Scenario Bundle here.
+                                    Do you want to learn more about scenarios, the models used to project them and the actual data? Then, this is the right place for you. If you contributed data to the OEP this is the place where you can provide more context by creating your own scenario bundle.
                                 </p>
                             </div>
                         </div>

--- a/base/templates/base/index.html
+++ b/base/templates/base/index.html
@@ -31,16 +31,17 @@
                         {% comment %} <div class ="hovertext"> This text will be trimmed down to what is visible in the div </div> {% endcomment %}
                     </div>
                     <div class="index-tile index-tile-colored index-tile-color-2">
-                        <img src="/static/img/welcome/OpenEnergyFamily_Logo_Factsheets_icon.svg" alt="Factsheets">
+                        <!-- <img src="/static/img/welcome/OpenEnergyFamily_Logo_Factsheets_icon.svg" alt="Factsheets"> -->
+                        <img src="/static/img/welcome/bundles.png" alt="Scenario Bundle">
                          <div class="inner-index-tile">
                             <div class= "panel-description">
-                                <h2> Factsheets </h2>
+                                <h2> Scenario Bundles </h2>
                                 <p class = "alternative">
-                                    Do you want to learn more about scenarios and models related to the data? Then, this is the right place to look. Also if you contributed data and want to provide more context, Create your own factsheet here.
+                                    Do you want to learn more about scenarios and models related to the data? Then, this is the right place to look. Also if you contributed data and want to provide more context, Create your own Scenario Bundle here.
                                 </p>
                             </div>
                         </div>
-                        <a role="button" class="btn btn-secondary" style="font-size: 16px;" href="/factsheets/overview/">Factsheets</a>
+                        <a role="button" class="btn btn-secondary" style="font-size: 16px;" href="/factsheets/overview/">Scenario Bundles</a>
                     </div>
                     {#    <div class="index-tile index-tile-colored index-tile-color-3">#}
                     {#    <img src="/static/img/welcome/bundles.png" alt="">#}

--- a/modelview/urls.py
+++ b/modelview/urls.py
@@ -4,7 +4,6 @@ from modelview import views
 
 urlpatterns = [
     url(r"^(?P<sheettype>[\w\d_]+)s/$", views.listsheets, {}, name="modellist"),
-    url(r"^overview/$", views.overview, {}),
     url(
         r"^(?P<sheettype>[\w\d_]+)s/add/$",
         views.FSAdd.as_view(),

--- a/modelview/views.py
+++ b/modelview/views.py
@@ -46,10 +46,6 @@ def getClasses(sheettype):
     return c, f
 
 
-def overview(request):
-    return render(request, "modelview/overview.html")
-
-
 def load_tags():
     engine = _get_engine()
     Session = sessionmaker(bind=engine)
@@ -213,11 +209,12 @@ def processPost(post, c, f, files=None, pk=None, key=None):
     if "new" in fields and fields["new"] == "True":
         fields["study"] = key
     for field in c._meta.get_fields():
-        if type(field) == ArrayField: # noqa
+        if type(field) == ArrayField:  # noqa
             parts = []
             for fi in fields.keys():
                 if (
-                    re.match(r"^{}_\d$".format(field.name), str(fi)) and fields[fi] # noqa
+                    re.match(r"^{}_\d$".format(field.name), str(fi))
+                    and fields[fi]  # noqa
                 ):
                     parts.append(fi)
             parts.sort()

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -85,6 +85,7 @@ EXTERNAL_URLS = {
     "tutorials_api1": "https://openenergyplatform.github.io/academy/tutorials/01_api/01_api_download/",  # noqa E501
     "tutorials_licenses": "https://openenergyplatform.github.io/academy/tutorials/metadata/tutorial_open-data-licenses/",  # noqa E501
     "readthedocs": "https://oeplatform.readthedocs.io/en/latest/?badge=latest",
+    "mkdocs": "https://openenergyplatform.github.io/oeplatform/",
     "compendium": "https://openenergyplatform.github.io/organisation/",
 }
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -6,7 +6,7 @@
 - Update styling of scenario bundles detail view [(#1435)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1435)
 - Improve installation instructions: Setup oeo [(#1396)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1396)
 - Enhance documentation structure for development practice, code and architectural information [(#1441)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1441)
-
+- Update homepage: Replace the Factsheet box with Scenario Bundles and update the text & remove the factsheet overview page and add a updated version of the text to the scenario bundle overview page. Also update and harmonize the several versions of the navigation bar and add external link icons. [(#1449)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1449)
 
 ### Bugs
 


### PR DESCRIPTION
## Summary of the discussion

The scenario bundles will be the new hart of the all data related context information (like factsheets ...). This PR updates the homepage and navigation bar. 

I also harmonized the navigation bar as we currently have 4 different versions and each of them presents different content.

## Type of change (CHANGELOG.md)


### Updated
- Update homepage: Replace the Factsheet box with Scenario Bundles and update the text & remove the factsheet overview page and add a updated version of the text to the scenario bundle overview page. Also update and harmonize the several versions of the navigation bar and add external link icons. [(#1449)](https://github.com/OpenEnergyPlatform/oeplatform/pull/144ß)

## Workflow checklist

### Automation
Part of #1418 

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
