### PR TITLE
Update faq links.

### DIFF
--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -81,7 +81,7 @@ ROOT_URLCONF = "oeplatform.urls"
 
 EXTERNAL_URLS = {
     "tutorials_index": "https://openenergyplatform.github.io/academy/",
-    "tutorials_faq": "https://openenergyplatform.github.io/academy/",
+    "tutorials_faq": "https://openenergyplatform.github.io/academy/questions/",
     "tutorials_api1": "https://openenergyplatform.github.io/academy/tutorials/01_api/01_api_download/",  # noqa E501
     "tutorials_licenses": "https://openenergyplatform.github.io/academy/tutorials/metadata/tutorial_open-data-licenses/",  # noqa E501
     "readthedocs": "https://oeplatform.readthedocs.io/en/latest/?badge=latest",

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,6 +13,7 @@
 - Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed [PR#1404](https://github.com/OpenEnergyPlatform/oeplatform/pull/1404)
 - Update factsheet (model/framework) tooltip for field link_to_source_code & deactivate the GitHub Organization widget that was part of the factsheets [(#1405)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1405)
 - Update nav tabs implementation in factsheet edit pages to bootstrap5  [PR#1407](https://github.com/OpenEnergyPlatform/oeplatform/pull/1407)
+- Update link to correct faq page in oeacademy [PR#14](https://github.com/OpenEnergyPlatform/oeplatform/pull/14)
 
 ### Removed
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,7 +13,7 @@
 - Fixed a bug that displayed outdated data on model & framework factsheet pages because a cached version of the page was displayed [PR#1404](https://github.com/OpenEnergyPlatform/oeplatform/pull/1404)
 - Update factsheet (model/framework) tooltip for field link_to_source_code & deactivate the GitHub Organization widget that was part of the factsheets [(#1405)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1405)
 - Update nav tabs implementation in factsheet edit pages to bootstrap5  [PR#1407](https://github.com/OpenEnergyPlatform/oeplatform/pull/1407)
-- Update link to correct faq page in oeacademy [PR#14](https://github.com/OpenEnergyPlatform/oeplatform/pull/14)
+- Update link to correct faq page in oeacademy [PR#1454](https://github.com/OpenEnergyPlatform/oeplatform/pull/1454)
 
 ### Removed
 


### PR DESCRIPTION
## Summary of the discussion

The link in the navbar about -> faq now redirects to oea/questions page.

## Type of change (CHANGELOG.md)


### Updated
- Update link to correct faq page in oeacademy [PR#1454](https://github.com/OpenEnergyPlatform/oeplatform/pull/1454)


## Workflow checklist

### Automation
Closes #1452 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
