### PR TITLE
Add intro text to model factsheet page 

### DIFF
--- a/modelview/templates/modelview/modellist.html
+++ b/modelview/templates/modelview/modellist.html
@@ -31,6 +31,7 @@
             Overview
         </div>
     </div>
+
 {% endblock site-header %}
 
 {% block main-right-sidebar-content %}
@@ -78,6 +79,17 @@
 {% endblock main-right-sidebar-content %}
 
 {% block factsheets_content %}
+
+    <div>
+        The <a href="http://openenergy-platform.org/ontology/oeo/OEO_00000277">model factsheet</a> characterise models used in energy system analysis in a 
+        structured way regarding important characteristics, such as their scope and <a href="https://openenergy-platform.org/ontology/oeo/OEO_00020015">licence</a> 
+        and their developing <a href="https://openenergy-platform.org/ontology/oeo/OEO_00000238">institutions</a>. You are developing a model? Then you can inform 
+        about its characteristics here. The models available as a factsheet can be integrated as an element into a <a href="https://openenergy-platform.org/sirop/">scenario bundle</a> 
+        which weave together important information about <a href="http://openenergy-platform.org/ontology/oeo/OEO_00000364">scenarios</a>, such as the model used for conducting a 
+        <a href="https://openenergy-platform.org/ontology/oeo/OEO_00010262">scenario projection</a>, <a href="https://openenergy-platform.org/ontology/oeo/IAO_0000027">data</a> 
+        provided on the OEP, and <a href="https://openenergy-platform.org/ontology/oeo/OEO_00020012">publications</a>.
+    </div>
+    <br>
 
     <div style="width:100%; overflow-y: auto; padding-bottom: 1em">
         <table id="overview" class="display" style="width:100%;">

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -9,6 +9,7 @@
 - Update homepage: Replace the Factsheet box with Scenario Bundles and update the text & remove the factsheet overview page and add a updated version of the text to the scenario bundle overview page. Also update and harmonize the several versions of the navigation bar and add external link icons. [(#1449)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1449)
 - Update the link to the scenario bundle (SB) page on the start page. Also change the SB page url to /scenario-bundles/ and update all applications. [(#1453)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1453)
 - Add a delete button & functionality to framework and model factsheet [(#1465)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1465)
+- Add intro text to model factsheet page [(#1466)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1466)
 
 ### Bugs
 


### PR DESCRIPTION
## Summary of the discussion

Add intro text to model factsheet page.

## Type of change (CHANGELOG.md)

### Added
- Add intro text to model factsheet page [(#1466)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1466)


## Workflow checklist

### Automation
Closes #1450

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
