### PR TITLE
Documentation: Virtual environments are created with the python executable, not with pip.

### DIFF
--- a/docs/install-and-documentation/install/installation.md
+++ b/docs/install-and-documentation/install/installation.md
@@ -25,6 +25,7 @@ The installation steps have been proofed on linux and windows for python 3.6 and
         - `git clone https://github.com/OpenEnergyPlatform/oeplatform.git`
         - `cd oeplatform`
         - `python -m venv env`
+        - `source env/bin/activate`
         - `pip install -r requirements.txt`
 
     2. Install databases & setup connection


### PR DESCRIPTION
Small documentation update.

## Type of change (CHANGELOG.md)

### Updated
Virtual environments are created with the python executable, not with pip.