### PR TITLE
Enhance oeo pages

### DIFF
--- a/ontology/templates/ontology/about.html
+++ b/ontology/templates/ontology/about.html
@@ -1,8 +1,44 @@
 {% extends "base/base.html" %}
+{% load static %}
+
+{% block site-header %}
+    <div class="main-header">
+        <h1 class="main-header__title">
+            <img src="/static/img/welcome/OpenEnergyFamily_Logo_OpenEnergyOntology_icon.svg" width="16" height="16" alt="OEO">         
+            Ontology
+        </h1>
+        <div class="main-header__wizard">
+            Overview
+        </div>
+    </div>
+
+{% endblock site-header %}
+
+{% block main-right-sidebar-content %}
+<div class="container">
+    <div class="row">
+        <h3>Ontologies</h3>
+    </div>
+    <div class="row">
+        <table class="table">
+            <tr>
+                <th>Name</th>
+                <th>Version</th>
+            </tr>
+            <tr>
+                <td><a href="/ontology/oeo">Open Energy Ontology (OEO)</a></td>
+                <td>{{ version }}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+
+{% endblock main-right-sidebar-content %}
+
 
 {% block main-content-body %}
 
-<h2 id="open-energy-ontology">Open Energy Ontology</h2>
+<h3>Open Energy Ontology</h3>
 <p>The Open Energy Ontology (OEO) is created as a domain ontology within the
   field of energy system modelling. It is growing constantly and under a regular
   release cycle. The latest OEO version is {{ version }} and its files can be accessed <a href="https://openenergy-platform.org/ontology/oeo">here</a>.</p>
@@ -69,14 +105,4 @@ We can then facilitate someone who can follow up on your question.
 
 <p>A  <a href={% url 'oeo-s-c'%}>OEO steering committee</a> was created in autumn 2019.</p>
 
-<h3>Ontologies</h3>
-<table class="table">
-    <tr>
-        <th>Name</th>
-        <th>Description</th>
-    </tr>
-    <tr>
-        <td><a href="/ontology/oeo">OEO</a></td>
-    </tr>
-</table>
 {% endblock %}

--- a/ontology/templates/ontology/class.html
+++ b/ontology/templates/ontology/class.html
@@ -1,10 +1,24 @@
 {% extends "base/base.html" %}
 {% load django_bootstrap5 %}
 {% load ontology.rdf %}
-{% block main-content-body %}
 {% load static %}
 
-<br><br>
+{% block site-header %}
+    <div class="main-header">
+        <h1 class="main-header__title">
+            <img src="/static/img/welcome/OpenEnergyFamily_Logo_OpenEnergyOntology_icon.svg" width="16" height="16" alt="OEO">         
+            Ontology
+        </h1>
+        <div class="main-header__wizard">
+            <a href="/ontology/">Overview</a> / <a href="/ontology/oeo">Open Energy Ontology</a> / Class {{ class_name }}
+        </div>
+    </div>
+
+{% endblock site-header %}
+
+
+{% block main-content-body %}
+
 <h5>Label: {{ class_name }}</h5>
 
 <hr>

--- a/ontology/templates/ontology/oeo-steering-committee.html
+++ b/ontology/templates/ontology/oeo-steering-committee.html
@@ -1,9 +1,21 @@
 {% extends "base/base.html" %}
 {% load django_bootstrap5 %}
-
-{% block main-content-body %}
 {% load static %}
 
+{% block site-header %}
+    <div class="main-header">
+        <h1 class="main-header__title">
+            <img src="/static/img/welcome/OpenEnergyFamily_Logo_OpenEnergyOntology_icon.svg" width="16" height="16" alt="OEO">         
+            Ontology
+        </h1>
+        <div class="main-header__wizard">
+            <a href="/ontology/">Overview</a> / Steering Committee (OEO-SC)
+        </div>
+    </div>
+
+{% endblock site-header %}
+
+{% block main-content-body %}
 <h2>Open Energy Ontology Steering Committee (OEO-SC)</h2> <br>
 
 <h3 id="oeo-sc">What is the Steering Committee?</h3>

--- a/ontology/templates/ontology/oeo.html
+++ b/ontology/templates/ontology/oeo.html
@@ -1,39 +1,83 @@
 {% extends "base/base.html" %}
 {% load django_bootstrap5 %}
 {% load ontology.rdf %}
-{% block main-content-body %}
 {% load static %}
 
-
-
-<h2>{{ main_module.name }}<div class="btn-group float-end" role="group" aria-label="Basic example">
-        {% for ex in main_module.extensions %}
-        <a class="btn btn-secondary" href="/ontology/{{ontology}}/releases/{{main_module.name}}.{{ex}}">
-            {{ex}}
-        </a>
-        {% endfor %}
-
-        <a class="btn btn-secondary" href="/ontology/{{ontology}}/releases/oeo-closure.owl">
-            closure
-        </a>
-
-        <a class="btn btn-secondary" href="/ontology/{{ontology}}/BFO_0000001">
-            classes
-        </a>
-        <a class="btn btn-secondary" href="/viewer/oeo/">
-            viewer
-        </a>
+{% block site-header %}
+    <div class="main-header">
+        <h1 class="main-header__title">
+            <img src="/static/img/welcome/OpenEnergyFamily_Logo_OpenEnergyOntology_icon.svg" width="16" height="16" alt="OEO">         
+            Ontology
+        </h1>
+        <div class="main-header__wizard">
+            <a href="/ontology/">Overview</a> / Open Energy Ontology ({{ main_module.name }})
+        </div>
     </div>
-</h2> <br>
 
-<div class="card">
-    <div class="card-header">
-        {{ ontology_description }}
+{% endblock site-header %}
+
+{% block main-right-sidebar-content %}
+<div class="container">
+    <div class="row">
+        <h3>View the oeo</h3>
     </div>
+    <div class="row">
+        <div class="col">
+            <div class="btn-group float-end" role="group" aria-label="Basic example">
+                <a class="btn btn-secondary" href="/ontology/{{ontology}}/BFO_0000001">
+                    Browse oeo classes
+                </a>
+                <a class="btn btn-secondary" href="/viewer/oeo/">
+                    Graphical oeo viewer
+                </a>
+            </div>
+        </div>
+    </div>
+    <hr>
+    <div class="row">
+        <h3>Download the oeo</h3>
+    </div>
+    <div class="row">
+        <div class="col">
+            <a class="btn btn-secondary" href="https://github.com/OpenEnergyPlatform/ontology/releases" target="_blank">
+                <i class="fas fa-external-link-alt"></i>
+                Download release from GitHub.
+            </a>
+        </div>
+    </div>
+    <br>
+    <div class="row">
+        <div class="col">
+            <a class="btn btn-secondary" href="/ontology/{{ontology}}/releases/oeo-full.owl">
+                full-oeo-owl
+            </a>
+            <div class="btn-group float-end" role="group" aria-label="Basic example">
+                {% for ex in main_module.extensions %}
+                <a class="btn btn-secondary" href="/ontology/{{ontology}}/releases/{{main_module.name}}.{{ex}}">
+                    {{ex}}
+                </a>
+                {% endfor %}
+                <a class="btn btn-secondary" href="/ontology/{{ontology}}/releases/oeo-closure.owl">
+                    closure
+                </a>
+            </div>
+        </div>
+    </div>
+    <hr>
 </div>
 
+{% endblock main-right-sidebar-content %}
 
-<br><br>
+{% block main-content-body %}
+ 
+
+<div class="">
+    <!-- <div class="card-header"> -->
+        {{ ontology_description }}
+    <!-- </div> -->
+</div>
+
+<br>
 <h3>Modules</h3><br>
 
 <div id="accordion">
@@ -43,13 +87,7 @@
             <a class="card-link" data-bs-toggle="collapse" href="#collapse{{ forloop.counter }}">
                 {{module}}
             </a>
-            <div class="btn-group float-end" role="group" aria-label="Basic example">
-                {% for ex in about.extensions %}
-                <a class="btn btn-secondary" href="/ontology/{{ontology}}/releases/{{module}}.{{ex}}">
-                    {{ex}}
-                </a>
-                {% endfor %}
-            </div>
+            
         </div>
         <div id="collapse{{ forloop.counter }}" class="collapse" data-bs-parent="#accordion">
             <div class="card-body">

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -20,6 +20,8 @@
 - sort sub-classes in text-based oeo-viewer #1469 [PR#1491](https://github.com/OpenEnergyPlatform/oeplatform/pull/1491)
 - sort regions and interacting regions alphabetically #1423 [PR#1491](https://github.com/OpenEnergyPlatform/oeplatform/pull/1491)
 - Add management command to reset published tables to not published [(#1493)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1493)
+- Add a new function for reading the oeo module/import descriptions [(#1499)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1499)
+- Improvement of the ontology pages by adding the oep page navigation heading and restructuring the content of the oeo-release page [(#1499)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1499)
 
 
 ### Bugs


### PR DESCRIPTION
## Summary of the discussion

On the OEO pages, the general OEP page navigation header is missing, and the oeo version page needed a general facelift as well as a reorganization of the download and view functions (view classes/ oeo viewer). 
Also the functionality to read the descriptions and comments from the .owl files for each module/import that is part of the oeo version.

## Type of change (CHANGELOG.md)

### Added
- Add a new function for reading the oeo module/import descriptions [(#1499)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1499)

### Updated
- Improvement of the ontology pages by adding the oep page navigation heading and restructuring the content of the oeo-release page [(#1499)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1499)



## Workflow checklist

### Automation
Closes #1496 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
