### PR TITLE
Hotfix fix missing owner check on delete bundle

### DIFF
--- a/factsheet/views.py
+++ b/factsheet/views.py
@@ -1215,7 +1215,7 @@ def query_oekg(request, *args, **kwargs):
     )
     return response
 
-
+@only_if_user_is_owner_of_scenario_bundle
 @login_required
 def delete_factsheet_by_id(request, *args, **kwargs):
     """

--- a/versions/changelogs/0_17_1.md
+++ b/versions/changelogs/0_17_1.md
@@ -1,0 +1,8 @@
+### Changes
+
+### Features
+
+### Bugs
+- Add missing check for scenari bundle owner if user attempts to delete a factsheet [(#1517)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1517)
+
+### Removed


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Updated
- Add missing check for scenari bundle owner if user attempts to delete a factsheet [(#1517)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1517)



## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
