### PR TITLE
Keep null values in oemetadata

### DIFF
--- a/dataedit/static/metaedit/metaedit.js
+++ b/dataedit/static/metaedit/metaedit.js
@@ -296,7 +296,7 @@ var MetaEdit = function (config) {
                     array_controls_top: true,
                     no_additional_properties: true,
                     required_by_default: false,
-                    remove_empty_properties: true, // don't remove, otherwise the metadata will not pass the validation on the server
+                    remove_empty_properties: false, // don't remove, otherwise the metadata will not pass the validation on the server
                 }
 
                 config.editor = new JSONEditor(config.form[0], options);

--- a/dataedit/static/metaedit/metaedit.js
+++ b/dataedit/static/metaedit/metaedit.js
@@ -217,11 +217,26 @@ var MetaEdit = function (config) {
 
     }
 
+    // Function to recursively convert empty strings to null
+    function convertEmptyStringsToNull(obj) {
+        for (var key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                if (typeof obj[key] === 'string' && obj[key] === '') {
+                    obj[key] = null;
+                } else if (typeof obj[key] === 'object') {
+                    convertEmptyStringsToNull(obj[key]);
+                }
+            }
+        }
+    }
+
     function bindButtons() {
         // download
         $('#metaedit-download').bind('click', function downloadMetadata() {
             var json = config.editor.getValue();
             // create data url
+            convertEmptyStringsToNull(json);
+            console.log(json);
             json = JSON.stringify(json, null, 1);
             blob = new Blob([json], { type: "application/json" }),
                 dataUrl = URL.createObjectURL(blob);

--- a/docs/install-and-documentation/oeplatform-code/features/metaBuilder/index.md
+++ b/docs/install-and-documentation/oeplatform-code/features/metaBuilder/index.md
@@ -1,0 +1,11 @@
+# metaBuilder
+
+The metaBuilder is a tool to create, edit and download metadata for the oeplatform.
+
+## Create
+
+## Download
+
+We currently offer multiple download buttons on the OEP. You can either download the metadata while editing the metadata on a table or when you use the standalone version of the metaBuilder. It is also possible to download the metadata when you view the metadata on a table in the "meta information" tab.
+
+When you download the metadata json file the empty fields are kept as "null" values. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
           - install-and-documentation/oeplatform-code/web-api/oekg-api/index.md 
       - Features:
         - install-and-documentation/oeplatform-code/features/index.md
+        - metaBuilder Metadata creation: install-and-documentation/oeplatform-code/features/metaBuilder/index.md
         - Open Peer Review Process:
           - install-and-documentation/oeplatform-code/features/open-peer-review-process/index.md
           - Technical docs: install-and-documentation/oeplatform-code/features/open-peer-review-process/technical-docs.md

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -12,6 +12,8 @@
 
 - UI Feature for Publishing Draft Tables: Integrated JavaScript to handle publish actions, including schema selection and confirmation steps, ensuring a seamless user experience.  [(PR#1526)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1526)
 
+- The oemetadata on the oep is now stored including null / none values. Users reported that it otherwise is confusing and hinders there metadata workflow. This is related to the update in [omi v0.2.0]() [(PR#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
+
 ### Features
 
 - Add a htmx based page loading after initial page is visible to the user. [(#1503)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1503)

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -12,7 +12,7 @@
 
 - UI Feature for Publishing Draft Tables: Integrated JavaScript to handle publish actions, including schema selection and confirmation steps, ensuring a seamless user experience.  [(PR#1526)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1526)
 
-- The oemetadata on the oep is now stored including null / none values. Users reported that it otherwise is confusing and hinders there metadata workflow. This is related to the update in [omi v0.2.0]() [(PR#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
+- The oemetadata on the oep is now stored including null / none values. Users reported that it otherwise is confusing and hinders there metadata workflow. This is related to the update in [omi v0.2.0](https://pypi.org/project/omi/0.2.0/) [(PR#1541)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1541)
 
 ### Features
 


### PR DESCRIPTION
## Summary of the discussion

**Only merge if https://github.com/OpenEnergyPlatform/omi/pull/72 is available on pypi**

As described in #1273, removing null / none values causes confusion and should therefore not be done by the platform. 

This is related to a change in omi that was introduced to give the user control over whether to omit null values. This functionality now retains null values by default.

## Type of change (CHANGELOG.md)

### Updated
- The oemetadata on the oep is now stored including null / none values. Users reported that it otherwise is confusing and hinders there metadata workflow. This is related to the update in [omi v0.2.0](https://pypi.org/project/omi/0.2.0/) [(PR#1541)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1541)


## Workflow checklist

### Automation
Closes #1273 
Closes #1108

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
