### PR TITLE
Implement http API list endpoints for factsheets and scenario datatables 

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,0 +1,54 @@
+from rest_framework import serializers
+from modelview.models import Energyframework, Energymodel
+from dataedit.models import Table
+from django.urls import reverse
+
+
+class EnergyframeworkSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, obj):
+        kwargs = {"sheettype": "framework", "model_name": obj.id}
+        detail_url = reverse(
+            "modelview:show-factsheet",
+            kwargs=kwargs,
+        )
+        return detail_url
+
+    class Meta:
+        model = Energyframework
+        fields = ["id", "model_name", "acronym", "url"]
+
+
+class EnergymodelSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, obj):
+        kwargs = {"sheettype": "model", "model_name": obj.id}
+        detail_url = reverse(
+            "modelview:show-factsheet",
+            kwargs=kwargs,
+        )
+        return detail_url
+
+    class Meta:
+        model = Energymodel
+        # fields = ["id", "model_name", "acronym", "url"]
+        fields = ["id", "model_name", "acronym", "url"]
+
+
+class ScenarioDataTablesSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, obj):
+        kwargs = {"sheettype": "model", "model_name": obj.id}
+        detail_url = reverse(
+            "modelview:show-factsheet",
+            kwargs=kwargs,
+        )
+        return detail_url
+
+    class Meta:
+        model = Table
+        # fields = ["id", "model_name", "acronym", "url"]
+        fields = ["id", "model_name", "acronym", "url"]

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -41,9 +41,9 @@ class ScenarioDataTablesSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField()
 
     def get_url(self, obj):
-        kwargs = {"sheettype": "model", "model_name": obj.id}
+        kwargs = {"schema": "scenario", "table": obj.name}
         detail_url = reverse(
-            "modelview:show-factsheet",
+            "dataedit:view",
             kwargs=kwargs,
         )
         return detail_url
@@ -51,4 +51,4 @@ class ScenarioDataTablesSerializer(serializers.ModelSerializer):
     class Meta:
         model = Table
         # fields = ["id", "model_name", "acronym", "url"]
-        fields = ["id", "model_name", "acronym", "url"]
+        fields = ["id", "name", "url"]

--- a/api/tests/test_regression/test_issue_832_tag_filter_with_missing_tag.py
+++ b/api/tests/test_regression/test_issue_832_tag_filter_with_missing_tag.py
@@ -6,13 +6,13 @@ from api.tests import APITestCase
 class Test_issue_832_tag_filter_with_missing_tag(APITestCase):
     def test_issue_832_tag_filter_with_missing_tag(self):
         # index without filter
-        res = self.client.post(reverse("index"))
+        res = self.client.post(reverse("dataedit:index"))
         self.assertEqual(res.status_code, 200)
 
         # index with tag filter with non existent tag_id
-        res = self.client.post(reverse("index") + "?tags=-1")
+        res = self.client.post(reverse("dataedit:index") + "?tags=-1")
         self.assertEqual(res.status_code, 200)
 
         # index with tag filter with invalid tag_id
-        res = self.client.post(reverse("index") + "?tags=xxx")
+        res = self.client.post(reverse("dataedit:index") + "?tags=xxx")
         self.assertEqual(res.status_code, 404)

--- a/api/urls.py
+++ b/api/urls.py
@@ -21,7 +21,11 @@ urlpatterns = [
         views.Metadata.as_view(),
         name="api_table_meta",
     ),
-    path('v0/schema/<str:schema>/tables/<str:table>/move/<str:to_schema>/', views.Move.as_view(), name ='move'),
+    path(
+        "v0/schema/<str:schema>/tables/<str:table>/move/<str:to_schema>/",
+        views.Move.as_view(),
+        name="move",
+    ),
     url(
         r"^v0/schema/(?P<schema>[\w\d_\s]+)/tables/(?P<table>[\w\d_\s]+)/columns/(?P<column>[\w\d_\s]+)?$",  # noqa
         views.Column.as_view(),
@@ -163,4 +167,14 @@ urlpatterns = [
     url(r"usrprop/", views.get_users),
     url(r"grpprop/", views.get_groups),
     url("oeo-search", views.oeo_search),
+    url(
+        r"^v0/factsheet/frameworks/?$",
+        views.EnergyframeworkFactsheetListAPIView.as_view(),
+        name="list-framework-factsheets",
+    ),
+    url(
+        r"^v0/factsheet/models/?$",
+        views.EnergymodelFactsheetListAPIView.as_view(),
+        name="list-model-factsheets",
+    ),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -177,4 +177,9 @@ urlpatterns = [
         views.EnergymodelFactsheetListAPIView.as_view(),
         name="list-model-factsheets",
     ),
+    url(
+        r"^v0/datasets/list_all/scenario/?$",
+        views.ScenarioDataTablesListAPIView.as_view(),
+        name="list-scenario-datasets",
+    ),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -20,7 +20,11 @@ from omi.structure import OEPMetadata
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework import generics
-from api.serializers import EnergyframeworkSerializer, EnergymodelSerializer
+from api.serializers import (
+    EnergyframeworkSerializer,
+    EnergymodelSerializer,
+    ScenarioDataTablesSerializer,
+)
 
 import api.parser
 import login.models as login_models
@@ -1176,3 +1180,14 @@ class EnergymodelFactsheetListAPIView(generics.ListAPIView):
 
     queryset = Energymodel.objects.all()
     serializer_class = EnergymodelSerializer
+
+
+class ScenarioDataTablesListAPIView(generics.ListAPIView):
+    """
+    Used for the scenario bundles react app to be able to select a existing
+    framework or model factsheet.
+    """
+
+    topic = "scenario"
+    queryset = DBTable.objects.filter(schema__name=topic)
+    serializer_class = ScenarioDataTablesSerializer

--- a/api/views.py
+++ b/api/views.py
@@ -1184,8 +1184,8 @@ class EnergymodelFactsheetListAPIView(generics.ListAPIView):
 
 class ScenarioDataTablesListAPIView(generics.ListAPIView):
     """
-    Used for the scenario bundles react app to be able to select a existing
-    framework or model factsheet.
+    Used for the scenario bundles react app to be able to populate
+    form select options with existing datasets from scenario topic.
     """
 
     topic = "scenario"

--- a/api/views.py
+++ b/api/views.py
@@ -19,6 +19,8 @@ from omi.dialects.oep.compiler import JSONCompiler
 from omi.structure import OEPMetadata
 from rest_framework import status
 from rest_framework.views import APIView
+from rest_framework import generics
+from api.serializers import EnergyframeworkSerializer, EnergymodelSerializer
 
 import api.parser
 import login.models as login_models
@@ -30,6 +32,8 @@ from dataedit.models import Schema as DBSchema
 from dataedit.models import Table as DBTable
 from dataedit.views import get_tag_keywords_synchronized_metadata, schema_whitelist
 from oeplatform.securitysettings import PLAYGROUNDS, UNVERSIONED_SCHEMAS
+
+from modelview.models import Energyframework, Energymodel
 
 logger = logging.getLogger("oeplatform")
 
@@ -1151,3 +1155,24 @@ def oeo_search(request):
     # res: something like [{"label": "testlabel", "resource": "testresource"}]
     # send back to client
     return JsonResponse(res, safe=False)
+
+
+# Energyframework, Energymodel
+class EnergyframeworkFactsheetListAPIView(generics.ListAPIView):
+    """
+    Used for the scenario bundles react app to be able to select a existing
+    framework or model factsheet.
+    """
+
+    queryset = Energyframework.objects.all()
+    serializer_class = EnergyframeworkSerializer
+
+
+class EnergymodelFactsheetListAPIView(generics.ListAPIView):
+    """
+    Used for the scenario bundles react app to be able to select a existing
+    framework or model factsheet.
+    """
+
+    queryset = Energymodel.objects.all()
+    serializer_class = EnergymodelSerializer

--- a/dataedit/templates/dataedit/dataview.html
+++ b/dataedit/templates/dataedit/dataview.html
@@ -199,7 +199,7 @@
             <th>Date finished</th>
           </tr>
           <tr>
-            <td> <a class="btn btn-primary" href="{% url 'peer_review_reviewer' table=table schema=schema review_id=opr_result.review_id %}">Review details</a></td>
+            <td> <a class="btn btn-primary" href="{% url 'dataedit:peer_review_reviewer' table=table schema=schema review_id=opr_result.review_id %}">Review details</a></td>
             <td>{{ opr_result.badge }}</td>
             <td>{{ opr_result.date_finished }}</td>
           </tr>
@@ -234,7 +234,7 @@
           Table not reviewed
         </div>
         <a class="btn btn-success btn-sm" type="button"
-        href="{% url 'peer_review_create' table=table schema=schema %}">
+        href="{% url 'dataedit:peer_review_create' table=table schema=schema %}">
           Start Open-Peer-Review-Process
         </a>
 
@@ -245,7 +245,7 @@
           Table not reviewed
         </div>
         <a class="btn btn-success btn-sm disabled" type="button"
-        href="{% url 'peer_review_create' table=table schema=schema %}">
+        href="{% url 'dataedit:peer_review_create' table=table schema=schema %}">
           Start Open-Peer-Review-Process
         </a>
         <i class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="You cant review this table if you are the table owner or not logged in."></i>
@@ -256,7 +256,7 @@
         The table is currently under review.
       </div>
       <a class="btn btn-success btn-sm" type="button"
-      href="{% url 'peer_review_reviewer' table=table schema=schema review_id=opr.opr_id %}">
+      href="{% url 'dataedit:peer_review_reviewer' table=table schema=schema review_id=opr.opr_id %}">
         Continue Review
       </a>
     {% else %}
@@ -297,7 +297,7 @@
 <span class="mb-2" {% if not can_add %} data-bs-toggle="tooltip"
   title="You need write permissions on this table to upload data" {% endif %}>
   <a class="btn btn-sm btn-success {% if not can_add %} disabled {% endif %}"
-    href="{% url 'wizard_upload' schema=schema table=table %}">
+    href="{% url 'dataedit:wizard_upload' schema=schema table=table %}">
     Upload CSV (Wizard)
   </a>
 </span>

--- a/dataedit/templates/dataedit/filter.html
+++ b/dataedit/templates/dataedit/filter.html
@@ -63,7 +63,7 @@
     </div>
     <div class="controls-container__btns">
         <div>
-            <a class="btn btn-secondary" href="{% url 'oemetabuilder' %}">OEMetaBuilder</a>
+            <a class="btn btn-secondary" href="{% url 'dataedit:oemetabuilder' %}">OEMetaBuilder</a>
             <a href="https://github.com/OpenEnergyPlatform/oemetadata/blob/master/metadata/latest/metadata_key_description.md" target="_blank">
                 <i class="fas fa-info-circle" title="Klick to open the OEMetadata - Key Description."></i>
             </a> 
@@ -93,7 +93,7 @@
 
     // blongs to dataedit_schemalist.hmtl
     function open_wizzard(){
-        location.href = "{% url 'wizard_create' %}"
+        location.href = "{% url 'dataedit:wizard_create' %}"
     }
 
     $(function () {

--- a/dataedit/templates/dataedit/wizard.html
+++ b/dataedit/templates/dataedit/wizard.html
@@ -267,7 +267,7 @@
             <div class="card-header">
                 <h2 class="mb-0">
                     <!-- go to existing form -->
-                    <a id="editMetadata" target="_blank" href="{% if schema and table %}{% url 'meta_edit' schema=schema table=table %}{% else %}#{% endif %}">Edit metadata</a>
+                    <a id="editMetadata" target="_blank" href="{% if schema and table %}{% url 'dataedit:meta_edit' schema=schema table=table %}{% else %}#{% endif %}">Edit metadata</a>
                 </h2>
             </div>
         </div>
@@ -276,7 +276,7 @@
             <div class="card-header">
                 <h2 class="mb-0">
                     <!-- go to existing form -->
-                    <a id="viewData" target="_blank" href="{% if schema and table %}{% url 'view' schema=schema table=table %}{% else %}#{% endif %}">View data</a>
+                    <a id="viewData" target="_blank" href="{% if schema and table %}{% url 'dataedit:view' schema=schema table=table %}{% else %}#{% endif %}">View data</a>
                 </h2>
             </div>
         </div>

--- a/dataedit/urls.py
+++ b/dataedit/urls.py
@@ -4,7 +4,7 @@ from django.views.generic import RedirectView
 from dataedit import views
 
 pgsql_qualifier = r"[\w\d_]+"
-
+app_name = "dataedit"
 urlpatterns = [
     url(r"^schemas$", views.listschemas, name="index"),
     url(r"^$", RedirectView.as_view(url="/dataedit/schemas")),

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -1845,7 +1845,7 @@ class MetaEditView(LoginRequiredMixin, View):
             can_add = level >= login_models.WRITE_PERM
 
         url_table_id = request.build_absolute_uri(
-            reverse("view", kwargs={"schema": schema, "table": table})
+            reverse("dataedit:view", kwargs={"schema": schema, "table": table})
         )
 
         context_dict = {
@@ -1859,7 +1859,7 @@ class MetaEditView(LoginRequiredMixin, View):
                         "api_table_meta", kwargs={"schema": schema, "table": table}
                     ),
                     "url_view_table": reverse(
-                        "view", kwargs={"schema": schema, "table": table}
+                        "dataedit:view", kwargs={"schema": schema, "table": table}
                     ),
                     "cancle_url": get_cancle_state(self.request),
                     "standalone": False,
@@ -2113,7 +2113,7 @@ class PeerReviewView(LoginRequiredMixin, View):
         # Generate URL for peer_review_reviewer
         if review_id is not None:
             url_peer_review = reverse(
-                "peer_review_reviewer",
+                "dataedit:peer_review_reviewer",
                 kwargs={"schema": schema, "table": table, "review_id": review_id},
             )
             opr_review = PeerReviewManager.filter_opr_by_id(opr_id=review_id)
@@ -2133,7 +2133,7 @@ class PeerReviewView(LoginRequiredMixin, View):
             )
         else:
             url_peer_review = reverse(
-                "peer_review_create", kwargs={"schema": schema, "table": table}
+                "dataedit:peer_review_create", kwargs={"schema": schema, "table": table}
             )
             # existing_review={}
             state_dict = None
@@ -2142,7 +2142,7 @@ class PeerReviewView(LoginRequiredMixin, View):
         config_data = {
             "can_add": can_add,
             "url_peer_review": url_peer_review,
-            "url_table": reverse("view", kwargs={"schema": schema, "table": table}),
+            "url_table": reverse("dataedit:view", kwargs={"schema": schema, "table": table}),
             "topic": schema,
             "table": table,
             "review_finished": review_finished,
@@ -2316,7 +2316,7 @@ class PeerRreviewContributorView(PeerReviewView):
                 {
                     "can_add": can_add,
                     "url_peer_review": reverse(
-                        "peer_review_contributor",
+                        "dataedit:peer_review_contributor",
                         kwargs={
                             "schema": schema,
                             "table": table,
@@ -2324,7 +2324,7 @@ class PeerRreviewContributorView(PeerReviewView):
                         },
                     ),
                     "url_table": reverse(
-                        "view", kwargs={"schema": schema, "table": table}
+                        "dataedit:view", kwargs={"schema": schema, "table": table}
                     ),
                     "topic": schema,
                     "table": table,

--- a/login/templates/login/user_review.html
+++ b/login/templates/login/user_review.html
@@ -137,7 +137,7 @@
                     <div class="profile-rvw__item-btm">
                         <!-- placeholder table name -->
                         <div class="profile-rvw__item-name">
-                            <a href="{% url 'peer_review_reviewer' reviewer_reviewed.latest_active.schema reviewer_reviewed.latest_active.table reviewer_reviewed.latest_active.id %}" class="btn btn-primary">
+                            <a href="{% url 'dataedit:peer_review_reviewer' reviewer_reviewed.latest_active.schema reviewer_reviewed.latest_active.table reviewer_reviewed.latest_active.id %}" class="btn btn-primary">
                                 {{ reviewer_reviewed.latest_active.schema }} - {{ reviewer_reviewed.latest_active.table }} 
                             </a>
                         </div>
@@ -200,7 +200,7 @@
             <div class="profile-rvw__item-btm">
                 <!-- placeholder table name -->
                 <div class="button profile-rvw__item-name">
-                    <a href="{% url 'peer_review_contributor' contributor_reviewed.latest_active.schema contributor_reviewed.latest_active.table contributor_reviewed.latest_active.id %}" class="btn btn-primary">
+                    <a href="{% url 'dataedit:peer_review_contributor' contributor_reviewed.latest_active.schema contributor_reviewed.latest_active.table contributor_reviewed.latest_active.id %}" class="btn btn-primary">
                         {{ contributor_reviewed.latest_active.schema }} - {{ contributor_reviewed.latest_active.table }}  
                     </a>
                 </div>
@@ -303,7 +303,7 @@
                         {% if review.is_finished == True %} 
                             <a href="/dataedit/view/{{ review.schema }}/{{ review.table }}">{{ review.schema }} - {{ review.table }}</a> 
                         {% else %} 
-                            <a href=" {% url 'peer_review_reviewer' table=review.table schema=review.schema review_id=review.id %}">{{ review.schema }} - {{ review.table }}</a> 
+                            <a href=" {% url 'dataedit:peer_review_reviewer' table=review.table schema=review.schema review_id=review.id %}">{{ review.schema }} - {{ review.table }}</a> 
                         {% endif %}  
                     </div>
                     <div class="profile-rvw__item-history">
@@ -379,7 +379,7 @@
                     {% if review.is_finished == True %} 
                         <a href="/dataedit/view/{{ review.schema }}/{{ review.table }}">{{ review.schema }} - {{ review.table }}</a> 
                     {% else %} 
-                        <a href=" {% url 'peer_review_contributor' table=review.table schema=review.schema review_id=review.id %}">{{ review.schema }} - {{ review.table }}</a> 
+                        <a href=" {% url 'dataedit:peer_review_contributor' table=review.table schema=review.schema review_id=review.id %}">{{ review.schema }} - {{ review.table }}</a> 
                     {% endif %}
                 </div>
                 <div class="profile-rvw__item-history">

--- a/modelview/templates/modelview/framework.html
+++ b/modelview/templates/modelview/framework.html
@@ -9,7 +9,7 @@
 {% block main-right-sidebar-content-actions %}
   <a class="btn btn-info" href="edit">Edit</a>
   <a class="btn btn-danger" 
-    hx-delete="{% url 'delete_factsheet' sheettype='framework' pk=model.pk %}" 
+    hx-delete="{% url 'modelview:delete-factsheet' sheettype='framework' pk=model.pk %}" 
     hx-confirm="Are you sure you want to delete this entry?" 
     >
     Delete

--- a/modelview/templates/modelview/model.html
+++ b/modelview/templates/modelview/model.html
@@ -8,7 +8,7 @@
 {% block main-right-sidebar-content-actions %}
   <a class="btn btn-info" href="edit">Edit</a>
   <a class="btn btn-danger" 
-    hx-delete="{% url 'delete_factsheet' sheettype='model' pk=model.pk %}" 
+    hx-delete="{% url 'modelview:delete-factsheet' sheettype='model' pk=model.pk %}" 
     hx-confirm="Are you sure you want to delete this entry?"
     hx-target="#liveToast"
     hx-swap="innerHTML" 

--- a/modelview/urls.py
+++ b/modelview/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import url
-from django.urls import path
+from django.urls import path, include
 
 from modelview import views
 
+
+app_name = "modelview"
 # urlpatterns = [
 #     path(r"^(?P<sheettype>[\w\d_]+)s/$", views.listsheets, {}, name="modellist"),
 #     url(
@@ -48,10 +50,10 @@ urlpatterns = [
     path(
         "<str:sheettype>s/delete/<int:pk>/",
         views.fs_delete,
-        name="delete_factsheet",
+        name="delete-factsheet",
     ),
     path("<str:sheettype>s/download/", views.model_to_csv, name="index"),
-    path("<str:sheettype>s/<int:model_name>/", views.show, name="index"),
+    path("<str:sheettype>s/<int:model_name>/", views.show, name="show-factsheet"),
     path("<str:sheettype>s/<int:model_name>/edit/", views.editModel, name="index"),
     path(
         "<str:sheettype>s/<int:pk>/update/",

--- a/modelview/views.py
+++ b/modelview/views.py
@@ -332,7 +332,7 @@ def fs_delete(request, sheettype, pk):
     response_data = {"success": True, "message": "Entry deleted successfully."}
 
     response = HttpResponse(response_data)
-    url = reverse("modellist", kwargs={"sheettype": sheettype})
+    url = reverse("modelview:modellist", kwargs={"sheettype": sheettype})
     response["HX-Redirect"] = url
     return response
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -20,6 +20,8 @@
 
 - Add a htmx based page loading after initial page is visible to the user. [(#1503)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1503)
 
+- Add http api list endpoint for factsheets (both framework & model) and datasets in the scenario topic [(#1553)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1553)
+
 ### Bugs
 
 ### Removed


### PR DESCRIPTION
## Summary of the discussion

For the form to create/edit the scenario bundle, we need a list of all available tables and also factsheets (both model and framework). This list is currently generated statically. This pull requests use django's rest framework to implement dynamic http-based api endpoints that list all resources in json format.

## Type of change (CHANGELOG.md)

### Added
- Add http api list endpoint for factsheets (both framework & model) and datasets in the scenario topic [(#1553)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1553)

## Workflow checklist

### Automation
Closes #1500 
part of #1540

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
