### PR TITLE
Bugfix: Clicking tags should lead to list of tables with tag again

### DIFF
--- a/dataedit/templates/dataedit/dataedit_tablelist.html
+++ b/dataedit/templates/dataedit/dataedit_tablelist.html
@@ -28,11 +28,11 @@
     <tbody>
         {% for table, label, tags in tables %}
 
-            <tr onclick="window.open('/dataedit/view/{{ schema }}/{{ table }}', name='_blank')">
+            <tr>
                 {% if label %}
-                    <td>{{ label }}</td>
+                    <td onclick="window.open('/dataedit/view/{{ schema }}/{{ table }}', name='_blank')">{{ label }}</td>
                 {% else %}
-                    <td>{{ table }}</td>
+                    <td onclick="window.open('/dataedit/view/{{ schema }}/{{ table }}', name='_blank')">{{ table }}</td>
                 {% endif %}
                 <td>
                     {% for tag in tags %}

--- a/dataedit/templates/dataedit/taggable_setting.html
+++ b/dataedit/templates/dataedit/taggable_setting.html
@@ -7,7 +7,7 @@
         No tags were added, yet.
     {% endif %}
     {% for t in selected %}
-        <a href="" class="btn tag" style="background:{{t.color}};color:{% readable_text_color t.color %}">{{ t.name }}</a>
+        <a href="/dataedit/view/{{ schema }}?query=&tags={{ t.id }}" class="btn tag" style="background:{{t.color}};color:{% readable_text_color t.color %}">{{ t.name }}</a>
     {% endfor %}
     <button data-bs-toggle="collapse"  data-bs-target="#tag_handler" class="btn btn-add btn-circle">
         {% fa5_icon 'plus' 'fas' %}

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -32,4 +32,6 @@
 
 - Scenario Bundles: Fix repeated DOIs [(#1556)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1556)
 
+- Clicking on tags opens a list of tagged tables again [(#1561)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1561)
+
 ### Removed


### PR DESCRIPTION
## Summary of the discussion

Clicking on any tag should open a page that lists all tagged tables (that are tagged with the clicked tag). This worked before and is fixed by this PR.

## Type of change (CHANGELOG.md)


### Updated
- Clicking on tags opens a list of tagged tables again [(#1561)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1561)


## Workflow checklist

### Automation
Closes #1536 

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
