### PR TITLE
Prototype TIB terminology service to oep integration

### DIFF
--- a/base/templates/base/base-full.html
+++ b/base/templates/base/base-full.html
@@ -64,6 +64,7 @@
                             <a class="dropdown-item" href="/ontology/oeo/">OEO Modules</a>
                             <a class="dropdown-item" href="/viewer/oeo/">OEO Viewer</a>
                             <a class="dropdown-item" href="{% url 'oeo-s-c'%}">OEO Steering Committee</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.tib_terminology_service }}" target="_blank" data-toggle="tooltip" data-placement="top" title="We want to combine our efforts in ontology development with the TIB as part of the NFDI4Energy project."><i class="fas fa-external-link-alt"></i> TIB Terminology Service</a>
                         </div>
                     </li>
                     <li class="nav-item">

--- a/base/templates/base/base-profile.html
+++ b/base/templates/base/base-profile.html
@@ -65,6 +65,7 @@
                             <a class="dropdown-item" href="/ontology/oeo/">OEO Modules</a>
                             <a class="dropdown-item" href="/viewer/oeo/">OEO Viewer</a>
                             <a class="dropdown-item" href="{% url 'oeo-s-c'%}">OEO Steering Committee</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.tib_terminology_service }}" target="_blank" data-toggle="tooltip" data-placement="top" title="We want to combine our efforts in ontology development with the TIB as part of the NFDI4Energy project."><i class="fas fa-external-link-alt"></i> TIB Terminology Service</a>
                         </div>
                     </li>
                     <li class="nav-item">

--- a/base/templates/base/base-wide-react.html
+++ b/base/templates/base/base-wide-react.html
@@ -68,6 +68,7 @@
                         <a class="dropdown-item" href="/ontology/oeo/">OEO Modules</a>
                         <a class="dropdown-item" href="/viewer/oeo/">OEO Viewer</a>
                         <a class="dropdown-item" href="{% url 'oeo-s-c'%}">OEO Steering Committee</a>
+                        <a class="dropdown-item" href="{{ EXTERNAL_URLS.tib_terminology_service }}" target="_blank" data-toggle="tooltip" data-placement="top" title="We want to combine our efforts in ontology development with the TIB as part of the NFDI4Energy project."><i class="fas fa-external-link-alt"></i> TIB Terminology Service</a>
                     </div>
                 </li>
                 <li class="nav-item">

--- a/base/templates/base/base.html
+++ b/base/templates/base/base.html
@@ -64,6 +64,7 @@
                             <a class="dropdown-item" href="/ontology/oeo/">OEO Modules</a>
                             <a class="dropdown-item" href="/viewer/oeo/">OEO Viewer</a>
                             <a class="dropdown-item" href="{% url 'oeo-s-c'%}">OEO Steering Committee</a>
+                            <a class="dropdown-item" href="{{ EXTERNAL_URLS.tib_terminology_service }}" target="_blank" data-toggle="tooltip" data-placement="top" title="We want to combine our efforts in ontology development with the TIB as part of the NFDI4Energy project."><i class="fas fa-external-link-alt"></i> TIB Terminology Service</a>
                         </div>
                     </li>
                     <li class="nav-item">

--- a/base/views.py
+++ b/base/views.py
@@ -38,7 +38,7 @@ def read_version_changes():
     markdowner = markdown2.Markdown()
     import logging
 
-    logging.error("READING")
+    logging.info("READING VERSION file.")
     try:
         with open(os.path.join(SITE_ROOT, "..", "VERSION")) as version_file:
             match = re.match(version_expr, version_file.read())
@@ -54,6 +54,7 @@ def read_version_changes():
                 "\n".join(line for line in change_file.readlines())
             )
     except Exception:
+        logging.error("READING VERSION file.")
         # probably because change_file is missing
         major, minor, patch, changes = "", "", "", ""
     return {"version": (major, minor, patch), "changes": changes}

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -87,6 +87,7 @@ EXTERNAL_URLS = {
     "readthedocs": "https://oeplatform.readthedocs.io/en/latest/?badge=latest",
     "mkdocs": "https://openenergyplatform.github.io/oeplatform/",
     "compendium": "https://openenergyplatform.github.io/organisation/",
+    "tib_terminology_service": "https://terminology.tib.eu/ts/collections",
 }
 
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -20,13 +20,14 @@
 
 - Enhance the ontology/oeo pages based on user feedback [(#1552)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1552)
 
-
 ### Features
 
 - Add a htmx based page loading after initial page is visible to the user. [(#1503)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1503)
 - Scenario Bundle: Sort scenario years in ascending order [(#1557)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1557)
 
 - Add http api list endpoint for factsheets (both framework & model) and datasets in the scenario topic [(#1553)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1553)
+
+- Add a new external url that is displayed in the ontology nav menu: Link to the TIB as prototype terminology service integration (part of NFDI4Energy) [(#1564)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1564)
 
 ### Bugs
 


### PR DESCRIPTION
## Summary of the discussion

Link to the TIB website to combine efforts. 

## Type of change (CHANGELOG.md)

### Added

- Add a new external url that is displayed in the ontology nav menu: Link to the TIB as prototype terminology service integration (part of NFDI4Energy) [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)


## Workflow checklist

### Automation
Closes #1551

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
