### PR TITLE
General enhancement profile tables page & enable view my tables button

### DIFF
--- a/base/templates/base/base-full.html
+++ b/base/templates/base/base-full.html
@@ -88,7 +88,7 @@
             {% if user.is_authenticated %} {# This should stay here - later the above if becomes obsolete #}
 
                 <div class="btn profile-bar">
-                    <a class="btn-profile" href="/user/profile/{{ user.pk }}">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
+                    <a class="btn-profile" href="/user/profile/{{ user.pk }}/settings">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
                     <a class="btn-logout" href="/user/logout/?next=/">{% fa5_icon 'arrow-right' 'fas' %} Logout</a>
                 </div>
 

--- a/base/templates/base/base-profile.html
+++ b/base/templates/base/base-profile.html
@@ -89,7 +89,7 @@
             {% if user.is_authenticated %} {# This should stay here - later the above if becomes obsolete #}
 
                 <div class="btn profile-bar">
-                    <a class="btn-profile" href="/user/profile/{{ user.pk }}">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
+                    <a class="btn-profile" href="/user/profile/{{ user.pk }}/settings">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
                     <a class="btn-logout" href="/user/logout/?next=/">{% fa5_icon 'arrow-right' 'fas' %} Logout</a>
                 </div>
 

--- a/base/templates/base/base-wide-react.html
+++ b/base/templates/base/base-wide-react.html
@@ -92,7 +92,7 @@
         {% if user.is_authenticated %} {# This should stay here - later the above if becomes obsolete #}
 
             <div class="btn profile-bar">
-                <a class="btn-profile" href="/user/profile/{{ user.pk }}">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
+                <a class="btn-profile" href="/user/profile/{{ user.pk }}/settings">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
                 <a class="btn-logout" href="/user/logout/?next=/">{% fa5_icon 'arrow-right' 'fas' %} Logout</a>
             </div>
 

--- a/base/templates/base/base.html
+++ b/base/templates/base/base.html
@@ -88,7 +88,7 @@
             {% if user.is_authenticated %} {# This should stay here - later the above if becomes obsolete #}
 
                 <div class="btn profile-bar">
-                    <a class="btn-profile" href="/user/profile/{{ user.pk }}">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
+                    <a class="btn-profile" href="/user/profile/{{ user.pk }}/settings">{% fa5_icon 'user' 'fas' %} {{ user }}</a>
                     <a class="btn-logout" href="/user/logout/?next=/">{% fa5_icon 'arrow-right' 'fas' %} Logout</a>
                 </div>
 

--- a/dataedit/templates/dataedit/filter.html
+++ b/dataedit/templates/dataedit/filter.html
@@ -69,13 +69,13 @@
             </a> 
         </div>
         <div>
-            <button type="button" class="btn btn-outline-primary disabled">
+            <button type="button" class="btn btn-outline-primary" onclick="redirectToLink('/user/profile/{{ user.pk }}/tables')">
                 <span class="btn__icon">
                     <svg width="16" height="16" version="1.1" fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                         <path d="m16,1v1H0v-1h16ZM0,8h16v-1H0v1Zm0,6h16v-1H0v1Z"/>
                     </svg>
                 </span>
-                <span class="btn__text">View tables</span>
+                <span class="btn__text">View my tables</span>
             </button>
         </div>
     </div>
@@ -124,7 +124,9 @@
         }
     });
 
-
+    function redirectToLink(link) {
+        window.location.href = link;
+    }
 
 </script>
 {% endblock after-body-bottom-js %}

--- a/login/templates/login/user_tables.html
+++ b/login/templates/login/user_tables.html
@@ -6,124 +6,139 @@
 {% include "login/user_nav.html" %}
 
 <div class="container">
-<div class="row">
-    
-    <div class="accordion" id="accordionTables">
-        <div class="accordion-item">
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTables" aria-expanded="true" aria-controls="collapseTables">
-                How to manage your data resources?
-            </button>
-            </h2>
-            <div id="collapseTables" class="accordion-collapse collapse" aria-labelledby="headingTables" data-bs-parent="#accordionTables">
-            <div class="accordion-body">
-                <strong>Access your data tables:</strong> Listed below are tables associated with you, either created by you or by a group you're part of, 
-                which has permission to access the table. This simplifies resource identification and access. 
-                Expect future enhancements for better data management through additional grouping and sorting options. 
-                <br>
-                <br>
-                <strong>Publish your complete, openly licensed and preferable open peer reviewed data:</strong> 
-                The displayed categories indicate whether a table has been published and assigned 
-                to a specific topic. The "model_draft" section is where you initially create and review your table. 
-                Once data is uploaded to "model_draft," an optional open peer review assesses metadata and data quality, performed by a user other than the creator. 
-                A automated license check verifies the license name you provided in the table metadata. It checks the license name against the SPDX list for open licenses.
-                If your data is openly licensed you can publish your table by moving it to one of the suggested topics on the Open Energy Platform. 
-                The "Publish" button becomes visible once all criteria for publishing are met.
-            </div>
+    <div class="row">
+        
+        <div class="accordion" id="accordionTables">
+            <div class="accordion-item">
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTables" aria-expanded="true" aria-controls="collapseTables">
+                    How to manage your data resources?
+                </button>
+                </h2>
+                <div id="collapseTables" class="accordion-collapse collapse" aria-labelledby="headingTables" data-bs-parent="#accordionTables">
+                <div class="accordion-body">
+                    <strong>Access your data tables:</strong> Listed below are tables associated with you, either created by you or by a group you're part of, 
+                    which has permission to access the table. This simplifies resource identification and access. 
+                    Expect future enhancements for better data management through additional grouping and sorting options. 
+                    <br>
+                    <br>
+                    <strong>Publish your complete, openly licensed and preferable open peer reviewed data:</strong> 
+                    The displayed categories indicate whether a table has been published and assigned 
+                    to a specific topic. The "model_draft" section is where you initially create and review your table. 
+                    Once data is uploaded to "model_draft," an optional open peer review assesses metadata and data quality, performed by a user other than the creator. 
+                    A automated license check verifies the license name you provided in the table metadata. It checks the license name against the SPDX list for open licenses.
+                    If your data is openly licensed you can publish your table by moving it to one of the suggested topics on the Open Energy Platform. 
+                    The "Publish" button becomes visible once all criteria for publishing are met.
+                </div>
+                </div>
             </div>
         </div>
     </div>
-</div>
-<div class="row" id="tableContainer" hx-get="/profile/{{ profile_user.id }}/tables" hx-trigger="load">
-    <h2>Published</h2>
-    <div class="container">
-        <div class="row">
-            {% for table in published_tables %}
-                <div class="col-md-4 mb-3">
-                    <div class="card">
+    <div class="row" id="tableContainer" hx-get="/profile/{{ profile_user.id }}/tables" hx-trigger="load">
+        <h2>Published</h2>
+        <div class="container">
+            <div class="row">
+                {% for table in published_tables %}
+                    <div class="col-md-4 mb-3">
+                        <div class="card">
+                            <div class="card">
+                                <h5 class="card-header">Datatable</h5>
+                                <div class="card-body">
+                                    <h5 class="card-title">{{ table.name }} - {{ table.schema }}</h5>
+                                    <a href="/dataedit/view/{{ table.schema }}/{{ table.name }}" class="btn btn-primary">View Table</a>
+                                    <p class="card-text">
+                                        <h5>License check</h5> 
+                                        Automated open data license check
+                                        {% if table.license_status.status %}
+                                        <span class="badge text-bg-success">Success</span>
+
+                                        {% else %}
+                                        <span class="badge text-bg-danger">Failed</span>
+                                        {% endif %}
+                                    </p>
+                                    {% if table.license_status.error %}
+                                    
+                                    <div class="alert alert-danger" role="alert">
+                                        <strong>Reason:</strong> {{ table.license_status.error }}
+                                    </div>
+                                    
+                                    <div class="alert alert-danger" role="alert">
+                                        <strong>Potential publishing without an open license.</strong> Please revisit your metadata and check the license information. 
+                                        Please do not publish data that does not hold an open license. 
+                                        <br>
+                                        
+                                    </div>
+                                    <a href={{EXTERNAL_URLS.spdx_licenses}} class="card-link">Please use a SPDX license identifier.</a>
+                                    {% endif %}                                
+                                    
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+
+        <h2>Draft</h2>
+        <div class="container">
+            <div class="row">
+                {% for table in draft_tables %}
+                    <div class="col-md-4 mb-3">
                         <div class="card">
                             <h5 class="card-header">Datatable</h5>
                             <div class="card-body">
+                                
                                 <h5 class="card-title">{{ table.name }} - {{ table.schema }}</h5>
                                 <a href="/dataedit/view/{{ table.schema }}/{{ table.name }}" class="btn btn-primary">View Table</a>
                                 <p class="card-text">
                                     <h5>License check</h5>
-                                    The automated open data license check result is: {{ table.license_status.status }}
+                                    Automated open data license check
+                                    {% if table.license_status.status %}
+                                    <span class="badge text-bg-success">Success</span>
+
+                                    {% else %}
+                                    <span class="badge text-bg-danger">Failed</span>
+                                    {% endif %}
+                                    {% if table.license_status.error %}
+                                    <div class="alert alert-danger" role="alert">
+                                        <strong>Reason:</strong> {{ table.license_status.error }}
+                                    </div>
+                                    <a href={{EXTERNAL_URLS.spdx_licenses}} class="card-link">Please use a SPDX license identifier.</a>
+                                    {% endif %}
                                 </p>
-                                {% if table.license_status.error %}
-                                <div class="alert alert-danger" role="alert">
-                                    <strong>Reason:</strong> {{ table.license_status.error }}
-                                </div>
                                 
-                                <div class="alert alert-danger" role="alert">
-                                    <strong>Potential publishing without open license.</strong> Please revisit your metadata and check the license information. 
-                                    Please do not publish data that does not hold an open license. 
-                                    <br>
+                                <p class="card-text">
                                     
-                                </div>
-                                {% endif %}                                
-                                <a href={{EXTERNAL_URLS.spdx_licenses}} class="card-link">More information on SPDX licenses</a>
+                                    {% if table.license_status.status and not table.is_publish %}
+                                    <h5>Publish data</h5>
+                                    {% if not table.is_reviewed %}
+                                    
+                                    <span class="badge text-bg-warning">Optional</span>
+                                    <span class="badge text-bg-warning">Open Peer Review is still in development.</span>
+                                    <div class="alert alert-warning" role="alert">
+                                    <strong>Before publishing your data, please note:</strong> 
+                                    While you can publish with an open license, we encourage your participation in the ongoing peer review for this table. 
+                                    Your involvement enhances data quality and credibility. Connect on GitHub or initiate a review on the OpenEnergyPlatform. 
+                                    Thanks for advancing open data practices!
+                                    </div>
+                                </p>
+                                {% endif %}
+                                    <button class="btn btn-primary publish-button" data-schema="{{ table.schema }}" data-tableName="{{ table.name }}">Publish</button>
+                                    <div class="publish-options" style="display: none;">
+                                        <select class="schema-dropdown"></select>
+                                        <button class="btn btn-secondary confirm-publish">Confirm</button>
+                                    </div>
+                                {% endif %}
                             </div>
                         </div>
                     </div>
-                </div>
-            {% endfor %}
+                {% endfor %}
+            </div>
         </div>
     </div>
-
-    <h2>Draft</h2>
-<div class="container">
-    <div class="row">
-        {% for table in draft_tables %}
-            <div class="col-md-4 mb-3">
-                <div class="card">
-                    <h5 class="card-header">Datatable</h5>
-                    <div class="card-body">
-                        
-                        <h5 class="card-title">{{ table.name }} - {{ table.schema }}</h5>
-                        <a href="/dataedit/view/{{ table.schema }}/{{ table.name }}" class="btn btn-primary">View Table</a>
-                        <p class="card-text">
-                            <h5>License check</h5>
-                            The automated open data license check result is: {{table.license_status.status}}
-                            {% if table.license_status.error %}
-                            <div class="alert alert-danger" role="alert">
-                                <strong>Reason:</strong> {{ table.license_status.error }}
-                            </div>
-                            {% endif %}
-                        </p>
-                        <a href={{EXTERNAL_URLS.spdx_licenses}} class="card-link">More information on SPDX licenses</a>
-                        <p class="card-text">
-                            
-                            {% if table.license_status.status and not table.is_publish %}
-                            <h5>Publish data</h5>
-                            {% if not table.is_reviewed %}
-                            
-                            <div class="alert alert-warning" role="alert">
-                            <strong>Consider before publish your data.</strong> 
-                            Before publishing your data, please note:
-                            While you can publish with an open license, we encourage your participation in the ongoing peer review for this table. 
-                            Your involvement enhances data quality and credibility. Connect on GitHub or initiate a review on the OpenEnergyPlatform. 
-                            Thanks for advancing open data practices!
-                            </div>
-                        </p>
-                        {% endif %}
-                            <button class="btn btn-primary publish-button" data-schema="{{ table.schema }}" data-tableName="{{ table.name }}">Publish</button>
-                            <div class="publish-options" style="display: none;">
-                                <select class="schema-dropdown"></select>
-                                <button class="btn btn-secondary confirm-publish">Confirm</button>
-                            </div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        {% endfor %}
-    </div>
-</div>
-
-</div>
-{% endif %}
-<div id="reviewedTablesData" style="display: none;">{{ reviewed_tables|json_script:"reviewedTablesData" }}</div>
-<div id="schemaWhitelistData" style="display: none;">{{ schema_whitelist|json_script:"schemaWhitelistData" }}</div>
-{% endblock %}
+    {% endif %}
+    <div id="reviewedTablesData" style="display: none;">{{ reviewed_tables|json_script:"reviewedTablesData" }}</div>
+    <div id="schemaWhitelistData" style="display: none;">{{ schema_whitelist|json_script:"schemaWhitelistData" }}</div>
+    {% endblock %}
 </div>
 
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -33,6 +33,8 @@
 
 - Introduction of an automatic license check module that attempts to check whether the license specified in the metadata for a particular table is open. It normalises the license name in the metadata (whitespaces become "-", everything is capitalised) and compares it with the official SPDX license list. [(#1565)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1565)
 
+- Link to profile/tables page via view my tables button on topic and table list pages and enhance the profile/tables page content [(#1570)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1570)
+
 ### Bugs
 
 - Scenario Bundles: Fix repeated DOIs [(#1556)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1556)
@@ -44,6 +46,5 @@
 - Foreign Key fields are rendered as expected again. [(#1569)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1569)
 
 - Each open peer review now stored the oemetadata. This avoids changes to the metadata that is or was reviewed and helps to maintain a review history [(#1567)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1567)
-
 
 ### Removed


### PR DESCRIPTION
## Summary of the discussion

This pr implements some UX features to help the user navigate the OEP database and profile/table pages. It also improves the content of the profile/table page to provide clear information on how to successfully perform the automatic licence check, how to publish data and how to deal with data that has been published but has not been assigned an Open Data licence.

## Type of change (CHANGELOG.md)

### Added
- Link to profile/tables page via view my tables button on topic and table list pages and enhance the profile/tables page content [(#1570)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1570)

## Workflow checklist

### Automation
Closes # - no issue created/found yet

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
