### PR TITLE
1548 delete a row using the http api leads to server error if table includes not nullable fileds

### DIFF
--- a/api/tests/test_regression/test_issue_1548_delete_not_null.py
+++ b/api/tests/test_regression/test_issue_1548_delete_not_null.py
@@ -1,0 +1,20 @@
+from api.tests import APITestCaseWithTable
+
+
+class Test1548(APITestCaseWithTable):
+    """Delete a row using the http-api leads to server error
+    if table includes not nullable fields"""
+
+    test_structure = {
+        "columns": [
+            {"name": "name", "data_type": "varchar(18)", "is_nullable": False},
+        ]
+    }
+    test_data = [{"name": "name1"}, {"name": "name2"}]
+
+    def test1548(self):
+        # id=1 was generated automatically
+        res = self.api_req("GET", path="rows/1")
+        self.assertEqual(res["id"], 1)
+        # now we delete it
+        self.api_req("DELETE", path="rows/1")

--- a/api/tests/test_regression/test_issue_1548_delete_not_null.py
+++ b/api/tests/test_regression/test_issue_1548_delete_not_null.py
@@ -8,13 +8,18 @@ class Test1548(APITestCaseWithTable):
     test_structure = {
         "columns": [
             {"name": "name", "data_type": "varchar(18)", "is_nullable": False},
+            {"name": "value", "data_type": "int", "is_nullable": False},
         ]
     }
-    test_data = [{"name": "name1"}, {"name": "name2"}]
+    test_data = [{"name": "name1", "value": 10}, {"name": "name2", "value": 20}]
 
     def test1548(self):
+        self.assertEqual(len(self.api_req("GET", path="rows/")), 2)
         # id=1 was generated automatically
         res = self.api_req("GET", path="rows/1")
         self.assertEqual(res["id"], 1)
-        # now we delete it
+        # now we delete it (This created the error)
         self.api_req("DELETE", path="rows/1")
+        # check that delete worked
+        self.api_req("GET", path="rows/1", exp_code=404)
+        self.assertEqual(len(self.api_req("GET", path="rows/")), 1)

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -8,4 +8,6 @@
 
 ## Bugs
 
+Bugfix: Delete a row using the http api leads to server error if table includes not nullable fields [#1581](https://github.com/OpenEnergyPlatform/oeplatform/pull/1581)
+
 ## Removed


### PR DESCRIPTION
### Bugfix: delete a row using the http api leads to server error if table includes not nullable fields

Closes #1548
