### PR TITLE
Bugfix: readd oeo metadata annotation feature

### DIFF
--- a/dataedit/static/metaedit/schema.json
+++ b/dataedit/static/metaedit/schema.json
@@ -55,6 +55,15 @@
                     "name": {
                         "description": "The class label of the OEO term.",
                         "example": "energy",
+                        "format": "autocomplete",
+                        "options": {
+                            "autocomplete": {
+                                "search": "search_name",
+                                "getResultValue": "getResultValue_name",
+                                "renderResult": "renderResult_name",
+                                "autoSelect": true
+                            }
+                        },
                         "type": [
                             "string",
                             "null"
@@ -707,6 +716,15 @@
                                                     "name": {
                                                         "description": "A class label of the OEO terms.",
                                                         "example": "wind energy converting unit",
+                                                        "format": "autocomplete",
+                                                        "options": {
+                                                            "autocomplete": {
+                                                                "search": "search_name",
+                                                                "getResultValue": "getResultValue_name",
+                                                                "renderResult": "renderResult_name",
+                                                                "autoSelect": true
+                                                            }
+                                                        },
                                                         "type": [
                                                             "string",
                                                             "null"
@@ -752,6 +770,15 @@
                                                     "name": {
                                                         "description": "The class label of the OEO terms.",
                                                         "example": "onshore wind farm",
+                                                        "format": "autocomplete",
+                                                        "options": {
+                                                            "autocomplete": {
+                                                                "search": "search_name",
+                                                                "getResultValue": "getResultValue_name",
+                                                                "renderResult": "renderResult_name",
+                                                                "autoSelect": true
+                                                            }
+                                                        },
                                                         "type": [
                                                             "string",
                                                             "null"

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -5,3 +5,5 @@
 ## Features
 
 ## Bugs
+
+- OEMetaBuilder: Readd missing autocomplete functionality that was not added after the oemetadata schema update for metadata version 0.1.6 []()

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -6,4 +6,4 @@
 
 ## Bugs
 
-- OEMetaBuilder: Readd missing autocomplete functionality that was not added after the oemetadata schema update for metadata version 0.1.6 []()
+- OEMetaBuilder: Readd missing autocomplete functionality that was not added after the oemetadata schema update for metadata version 0.1.6 [(#1608)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1608)


### PR DESCRIPTION
## Summary of the discussion

Enable oeo annotation in oemetabuilder again. The related code was missing in the schema.json. 

## Type of change (CHANGELOG.md)

### Updated
- OEMetaBuilder: Readd missing autocomplete functionality that was not added after the oemetadata schema update for metadata version 0.1.6 [(#1608)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1608)


## Workflow checklist

### Automation

- No issue

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
