### PR TITLE
adding locking mechanism for entities

### DIFF
--- a/factsheet/models.py
+++ b/factsheet/models.py
@@ -29,3 +29,8 @@ class ScenarioBundleAccessControl(models.Model):
     @classmethod
     def load_by_uid(cls, uid):
         return ScenarioBundleAccessControl.objects.filter(bundle_id=uid).first()
+        
+class LockTable(models.Model):
+    resource_name = CharField(max_length=400)
+    timeout_time = DateTimeField(default=timezone.now)
+    transaction_id = CharField(max_length=400)


### PR DESCRIPTION
## Summary of the discussion

As mentioned in Issue #1504 , I added a locking mechanism so any entity currently being edited gets locked from being edited by other people.
An error message is currently not being displayed, as I edited only the backend, not the frontend. Furthermore, when editing an entity, for example an institution, the insititution label is always displayed as though it had been changed in the current tab - even when the edit is not saved (due to the entity being locked at the time of attempting to edit it). That the change has not been saved only become apparent if one leaves the current bundle, returns to scenario-bundles/main and then selects the bundle again:
![Uploading after-editing-locked-entity.png…]()
![after_editing_locked-entity-2](https://github.com/OpenEnergyPlatform/oeplatform/assets/135056238/2761157c-cd9e-4ba4-a0a7-08fe874a8dcb)



## Type of change (CHANGELOG.md)

### Added
- Add a new functionality [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

### Updated
- Update existing functionality [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/


## Workflow checklist

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
