### PR TITLE
fix open() with encoding, plus pre-commit code quality

### DIFF
--- a/api/references.py
+++ b/api/references.py
@@ -213,7 +213,7 @@ def read_bibtexfile(file_name):
     metadata.create_all(bind=engine)
     sess = Session(bind=engine)
 
-    with open(file_name) as bibtex_file:
+    with open(file_name, encoding="utf-8") as bibtex_file:
         bibtex_database = btp.load(bibtex_file)
     for ent in bibtex_database.entries:
         props = {

--- a/base/views.py
+++ b/base/views.py
@@ -40,7 +40,9 @@ def read_version_changes():
 
     logging.info("READING VERSION file.")
     try:
-        with open(os.path.join(SITE_ROOT, "..", "VERSION")) as version_file:
+        with open(
+            os.path.join(SITE_ROOT, "..", "VERSION"), encoding="utf-8"
+        ) as version_file:
             match = re.match(version_expr, version_file.read())
             major, minor, patch = match.groups()
         with open(
@@ -48,7 +50,8 @@ def read_version_changes():
                 SITE_ROOT,
                 "..",
                 "versions/changelogs/%s_%s_%s.md" % (major, minor, patch),
-            )
+            ),
+            encoding="utf-8",
         ) as change_file:
             changes = markdowner.convert(
                 "\n".join(line for line in change_file.readlines())
@@ -74,7 +77,7 @@ def get_logs(request):
         markdowner = markdown2.Markdown()
         if match:
             major, minor, patch = match.groups()
-            with open("versions/changelogs" + file) as f:
+            with open("versions/changelogs" + file, encoding="utf-8") as f:
                 logs[(major, minor, patch)] = markdowner.convert(
                     "\n".join(line for line in f.readlines())
                 )

--- a/login/utilities.py
+++ b/login/utilities.py
@@ -1,8 +1,8 @@
 import json
-from pathlib import Path
 import logging
-from functools import lru_cache
 import re
+from functools import lru_cache
+from pathlib import Path
 
 from oeplatform.settings import STATIC_ROOT
 
@@ -21,7 +21,7 @@ def read_spdx_licenses_from_static():
     try:
         # Open the file in read mode
         if json_file_path:
-            with open(json_file_path, "r") as file:
+            with open(json_file_path, "r", encoding="utf-8") as file:
                 # Load the JSON data into a Python dictionary
                 data_dict = json.load(file)
 
@@ -37,7 +37,10 @@ def create_license_id_set():
     # Check if the "licenses" key exists in the dictionary
     if "licenses" in licenses:
         # Create a set of unique licenseId values
-        return {license_info.get("licenseId").upper() for license_info in licenses["licenses"]}
+        return {
+            license_info.get("licenseId").upper()
+            for license_info in licenses["licenses"]
+        }
 
     else:
         return set()
@@ -65,14 +68,16 @@ def validate_open_data_license(django_table_obj):
     if not first_license.get("name"):
         return (
             False,
-            "The license name is missing (only checked the first license element in the oemetadata).",
+            "The license name is missing "
+            "(only checked the first license element in the oemetadata).",
         )
 
     identifier = first_license["name"]
     if not search_oem_license_in_spdx_list(input_license_id=identifier):
         return (
             False,
-            "The license name was not found in the SPDX licenses list. (See https://github.com/spdx/license-list-data/blob/main/json/licenses.json)",
+            "The license name was not found in the SPDX licenses list. (See "
+            "https://github.com/spdx/license-list-data/blob/main/json/licenses.json)",
         )
 
     return True, None

--- a/oeo_viewer/management/commands/build_oeo_viewer.py
+++ b/oeo_viewer/management/commands/build_oeo_viewer.py
@@ -1,13 +1,12 @@
+import json
 import os
 import subprocess as sp
-from rdflib import Graph, RDFS, URIRef
-import json
-from rdflib.namespace import XSD, Namespace
 from collections import defaultdict
 
-from django.core.management.base import BaseCommand
-from django.conf import settings
 from django.apps import apps
+from django.core.management.base import BaseCommand
+from rdflib import Graph
+from rdflib.namespace import Namespace
 
 from oeplatform.settings import ONTOLOGY_ROOT, OPEN_ENERGY_ONTOLOGY_NAME
 
@@ -115,10 +114,12 @@ class Command(BaseCommand):
             class_name = row.s.split("/")[-1]
             classes_notes[class_name].append(row.o)
 
-        ontology_description = ""
+        # TODO: noqa F841:variable assigned to but never used
+        ontology_description = ""  # noqa: F841
         for row in q_main_description:
             if row.s.split("/")[-1] == "":
-                ontology_description = row.o
+                # noqa F841: TODO: variable assigned to but never used
+                ontology_description = row.o  # noqa: F841
 
         # Begin prepare data for oeo-viewer. Only need to be executed once per release
         graphLinks = []
@@ -160,7 +161,7 @@ class Command(BaseCommand):
                             "editor_note": classes_notes[source],
                         }
                     )
-            except:
+            except Exception:
                 pass
 
         # static_path = settings.STATIC_ROOT
@@ -174,7 +175,7 @@ class Command(BaseCommand):
 
         oeo_viewer_file_path = os.path.join(oeo_viewer_data_path, oeo_viewer_data_file)
 
-        with open(oeo_viewer_file_path, "w") as f:
+        with open(oeo_viewer_file_path, "w", encoding="utf-8") as f:
             json.dump({"nodes": graphNodes, "links": graphLinks}, f)
 
         print("The data for OEO viewer app has been created successfully!")


### PR DESCRIPTION
Some environments do not have utf-8 as default character encoding.
Therefore, all `open("r")` statements need to specify utf-8 as  encoding, otherwise an error occurs (just happened on a test server)

I also had to add more changes because of the pre-commit code quality requirements, otherwise I could not commit.
@adelmemariani , @jh-RLI please use local pre-commit hooks so that changed filesalways follow the code guidelines.

Cheers,
C
