### PR TITLE
Fixes #1626: OfflineGenerationError on docker-startup

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,7 +20,7 @@ python manage.py migrate
 echo "Migrating local database..."
 python manage.py alembic upgrade head
 
-echo "Compress stylesheets"
+echo "Compress stylesheets & JavaScript"
 python manage.py compress
 
 echo "Starting apache2"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,6 +20,9 @@ python manage.py migrate
 echo "Migrating local database..."
 python manage.py alembic upgrade head
 
+echo "Compress stylesheets"
+python manage.py compress
+
 echo "Starting apache2"
 
 /usr/sbin/apache2ctl -DFOREGROUND

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -8,3 +8,5 @@
 ## Bugs
 
 - OEMetaBuilder: Readd missing autocomplete functionality that was not added after the oemetadata schema update for metadata version 0.1.6 [(#1608)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1608)
+- Docker: docker-entrypoint.sh wasn't running compression of stylesheets on startup [(#1627)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1627)
+


### PR DESCRIPTION
## Summary of the discussion
When first starting the docker image, I got a OfflineGenerationError, see #1626..

## Type of change (CHANGELOG.md)

### Updated
- Updated docker-entrypoint.sh to run compression of stylesheets on startup [(#1627)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1627)

## Workflow checklist

### Automation
Closes #1626

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
