### PR TITLE
Fixes #1628: Wrong academy links

### DIFF
--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -83,8 +83,8 @@ ROOT_URLCONF = "oeplatform.urls"
 EXTERNAL_URLS = {
     "tutorials_index": "https://openenergyplatform.github.io/academy/",
     "tutorials_faq": "https://openenergyplatform.github.io/academy/questions/",
-    "tutorials_api1": "https://openenergyplatform.github.io/academy/tutorials/01_api/01_api_download/",  # noqa E501
-    "tutorials_licenses": "https://openenergyplatform.github.io/academy/tutorials/metadata/tutorial_open-data-licenses/",  # noqa E501
+    "tutorials_api1": "https://openenergyplatform.github.io/academy/tutorials/01%20API/01_api_download/",  # noqa E501
+    "tutorials_licenses": "https://openenergyplatform.github.io/academy/tutorials/99%20Other/tutorial_open-data-licenses/",  # noqa E501
     "readthedocs": "https://oeplatform.readthedocs.io/en/latest/?badge=latest",
     "mkdocs": "https://openenergyplatform.github.io/oeplatform/",
     "compendium": "https://openenergyplatform.github.io/organisation/",

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -8,3 +8,4 @@
 ## Bugs
 
 - OEMetaBuilder: Readd missing autocomplete functionality that was not added after the oemetadata schema update for metadata version 0.1.6 [(#1608)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1608)
+- Update links to academy pages [(#1629)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1629)


### PR DESCRIPTION
## Summary of the discussion
Link to API docs is wrong. See #1628 

## Type of change (CHANGELOG.md)

### Updated
- Update links to academy pages [(#1629)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1629)

## Workflow checklist

### Automation
Closes #1628

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
