### PR TITLE
Feature fix missing ontologies in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ COPY ./docker/apache2.conf /etc/apache2/conf-enabled/oeplatform.conf
 COPY . /app
 COPY ./docker/docker-entrypoint.sh /app/docker-entrypoint.sh
 
+RUN mkdir /app/ontologies && cd /app/ontologies && wget https://github.com/OpenEnergyPlatform/ontology/releases/latest/download/build-files.zip && unzip build-files.zip && rm build-files.zip
 
 RUN cp /app/oeplatform/securitysettings.py.default /app/oeplatform/securitysettings.py && python manage.py collectstatic --noinput && rm /app/oeplatform/securitysettings.py
 

--- a/docker/USAGE.md
+++ b/docker/USAGE.md
@@ -13,11 +13,11 @@ This is a short introduction into the usage of Docker with Open Energy Platform 
 
 This can be used, if you just want to host your own OEP installation or test API scipts or something similar, that should not be done with the public instance. We use `docker-compose` to deploy more than one container.
 
-Docker Compose is a tool for defining and running multi-container Docker applications. Our applications consists of two different containers, a database container and an application container. We need both containers to get a fully working oeplatform deployment. `docker-compose.yaml` contains a definiton for an isolated environment to run both containers.
+Docker Compose is a tool for defining and running multi-container Docker applications. Our application consists of two different containers, a database container and an application container. We need both containers to get a fully working oeplatform deployment. `docker-compose.yaml` contains a definition for an isolated environment to run both containers.
 
 Starting a oeplatform installation with Docker is easy, since it is zero configuration and zero dependencies. Our deployment will create persistent files in your current work directory which needs to be reused across restart. Make sure, you use the same working directory each time, e.g. repository root.
 
-`docker-compose up` will start the deployment and you should be able to access a fresh installation via `http://localhost:8000`. Ctrl + C will stop the entire deployment. If it is restarted in the same working directory, it will keep state.
+`docker-compose up` will start the deployment, and you should be able to access a fresh installation via `http://localhost:8000`. Ctrl + C will stop the entire deployment. If it is restarted in the same working directory, it will keep state.
 
 #### Tasks
 
@@ -103,6 +103,12 @@ If you followed this documentation, you can skip the entire `Setup Your Database
 - Start Database
   - Database will recreate all needed tables
   - You need to reapply the migrations
+
+##### Build oeplatform image
+If you want to build the oeplatform docker image yourself, e.g. after you've changed the code, you can do this by running the following command in the main directory of this repository.
+```shell
+docker build -t oeplatform -f docker/Dockerfile .
+```
 
 ## Further Information
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -11,3 +11,5 @@
 - OEMetaBuilder: Readd missing autocomplete functionality that was not added after the oemetadata schema update for metadata version 0.1.6 [(#1608)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1608)
 
 - Update requirements: Fix drf pip version to v3.14 to avoid [django-reset-framework issue](https://github.com/encode/django-rest-framework/issues/9300) [(1630)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1630)
+
+- Include oeo in oeplatform docker image [(#1631)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1631)


### PR DESCRIPTION
## Summary of the discussion
As of #1622 the docker-image is currently missing the oeo. This PR adds a command to the Dockerfile to create the folder, download the latest oeo from github and extract it. So the oeo is correctly included in the Docker image. Afterwards, #1622 is fixed (in connection with #1627).

Also the docker readme is extended to include the docker build command to create the image on your own (if you e.g. change stuff).

## Type of change (CHANGELOG.md)

### Updated
- Include oeo in oeplatform docker image [(#1631)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1631)

## Workflow checklist

### Automation
Closes #1622

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
