### PR TITLE
Implement api token reset button in profile page

### DIFF
--- a/login/templates/login/user_settings.html
+++ b/login/templates/login/user_settings.html
@@ -1,6 +1,7 @@
 {% extends "base/base-profile.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load compress %}
 {% block main-content-body %}
 {% include "login/user_nav.html" %}
 
@@ -13,7 +14,13 @@
                 <a id="toggler" href="#" onclick="toggler('token');">Show token</a>
                 <div style="display:none" id="token">
                 {% if token %}
-                     {{ token }}
+                    <div class="userApiToken">
+                        {{ token }}
+                    </div>
+                    <div>
+                        <button hx-post="{% url 'reset-token' %}" hx-target=".userApiToken">Reset token</button>
+                        <i>Resetting the token will affect your REST-API based requests. In most cases it only makes sense to reset it in case it was accidentally published.</i>
+                    </div>
                 {% endif %}
                 </div>
             </td>
@@ -197,3 +204,14 @@
 {% endif %}
 {% endblock %}
 
+
+{% block after-body-bottom-js %}
+{% compress js %}
+<script src="{% static 'ontology/htmx.js' %}"></script>
+{% endcompress %}
+<script>
+    document.body.addEventListener('htmx:configRequest', (event) => {
+        event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+    })
+</script>
+{% endblock %}

--- a/login/urls.py
+++ b/login/urls.py
@@ -102,4 +102,5 @@ urlpatterns = [
     url(r"^detach$", views.DetachView.as_view()),
     url(r"^activate/(?P<token>[\w\d\-\s]+)$", views.activate),
     url(r"^activate/$", views.ActivationNoteView.as_view(), name="activate"),
+    url(r"^reset/token$", views.token_reset, name="reset-token"),
 ]

--- a/login/views.py
+++ b/login/views.py
@@ -4,14 +4,18 @@ from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import PasswordChangeView
 from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.views.generic import FormView, View
 from django.views.generic.edit import DeleteView, UpdateView
 
+from rest_framework.authtoken.models import Token
+
 import login.models as models
 from dataedit.models import PeerReviewManager, Table, PeerReview
 from dataedit.views import schema_whitelist
+
 
 from oeplatform.settings import UNVERSIONED_SCHEMAS
 
@@ -567,3 +571,18 @@ def activate(request, token):
         token_obj.user.save()
         token_obj.delete()
     return redirect("/user/profile/{id}".format(id=token_obj.user.id))
+
+
+def token_reset(request):
+    if request.user.is_authenticated:
+
+        user_token = get_object_or_404(
+            Token, user=request.user.id
+        )  # Get the current user's token
+        user_token.delete()  # Delete the existing token
+
+        new_token = Token.objects.create(user=request.user)
+
+        return HttpResponse(new_token)
+    else:
+        return HttpResponseForbidden("You are not authorized to reset the token.")

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -6,6 +6,8 @@
 
 - Add NFDI to our list of Partners [(#1605)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1605).
 
+- Add feature to reset a api token via the profile/settings page [(#1637)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1637)
+
 ## Bugs
 
 - Bugfix: Adding tags if metadata is empty does not result in a server error anymore. [(#1528)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1528)


### PR DESCRIPTION
## Summary of the discussion

The user will be able to reset their API token. This is particularly useful in the event that the token has been made public.

## Type of change (CHANGELOG.md)

### Added
- Add feature to reset a api token via the profile/settings page [(#1637)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1637)

## Workflow checklist

### Automation
Closes #1175

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
