### PR TITLE
Move endpoint variable to settings

### DIFF
--- a/factsheet/views.py
+++ b/factsheet/views.py
@@ -17,7 +17,7 @@ from rdflib.plugins.stores import sparqlstore
 from rdflib.namespace import XSD, Namespace
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID as default
 import os
-from oeplatform.settings import ONTOLOGY_ROOT, RDF_DATABASES, OPEN_ENERGY_ONTOLOGY_NAME
+from oeplatform.settings import ONTOLOGY_ROOT, RDF_DATABASES, OPEN_ENERGY_ONTOLOGY_NAME, query_endpoint, update_endpoint
 
 from SPARQLWrapper import SPARQLWrapper, JSON
 import sys
@@ -62,15 +62,6 @@ oeo = Graph()
 oeo.parse(Ontology_URI.as_uri())
 
 oeo_owl = get_ontology(Ontology_URI_STR).load()
-
-# query_endpoint = "http://localhost:3030/ds/query"
-# update_endpoint = "http://localhost:3030/ds/update"
-
-# query_endpoint = 'https://toekb.iks.cs.ovgu.de:3443/oekg/query'
-# update_endpoint = 'https://toekb.iks.cs.ovgu.de:3443/oekg/update'
-
-query_endpoint = "https://oekb.iks.cs.ovgu.de:3443/oekg_main/query"
-update_endpoint = "https://oekb.iks.cs.ovgu.de:3443/oekg_main/update"
 
 sparql = SPARQLWrapper(query_endpoint)
 

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -188,3 +188,13 @@ COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_REBUILD_TIMEOUT = 0
 COMPRESS_MTIME_DELAY = 0
+
+
+# query_endpoint = "http://localhost:3030/ds/query"
+# update_endpoint = "http://localhost:3030/ds/update"
+
+# query_endpoint = 'https://toekb.iks.cs.ovgu.de:3443/oekg/query'
+# update_endpoint = 'https://toekb.iks.cs.ovgu.de:3443/oekg/update'
+
+query_endpoint = "https://oekb.iks.cs.ovgu.de:3443/oekg_main/query"
+update_endpoint = "https://oekb.iks.cs.ovgu.de:3443/oekg_main/update"

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -2,6 +2,8 @@
 
 ## Changes
 
+- Move query_endpoint and update_endpoint to settings.py
+
 ## Features
 
 - Add NFDI to our list of Partners [(#1605)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1605).


### PR DESCRIPTION
## Summary of the discussion

As part of solving issue [1394](https://github.com/OpenEnergyPlatform/oeplatform/issues/1394), the variables query_endpoint and update_endpoint should be moved from views.py to settings.py


## Workflow checklist

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform-code/) 

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
