### PR TITLE
Add pagination for user table listings on the profile page

### DIFF
--- a/login/templates/login/user_tables.html
+++ b/login/templates/login/user_tables.html
@@ -12,7 +12,7 @@
     <h2 class="profile-category__heading">Published tables</h2>
     <div class="profile-tables">
         <div class="profile-tables__row">
-            {% for table in published_tables %}
+            {% for table in published_tables_page %}
             <div class="profile-tables__col">
                 <div class="profile-table-card">
                     <div class="profile-table-card__content">
@@ -112,18 +112,28 @@
             {% endfor %}
         </div>
     </div>
-    <nav aria-label="Page navigation profile tables" class="pagination-nav">
+    <nav aria-label="Page navigation profile tables" class="pagination pagination-nav">
         <ul>
-            <li class="page-item disabled">
-                <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Previous</a>
-            </li>
-            <li class="page-item active"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
+            {% if published_tables_page.has_previous %}
             <li class="page-item">
-                <a class="page-link" href="#">Next</a>
+                <a class="page-link" href="?published_page={{ published_tables_page.previous_page_number }}" tabindex="-1" aria-disabled="true">&laquo;Previous</a>
+                <a href="?published_page=1">1</a>
             </li>
+            {% endif %}
+            
+            <li class="page-item active">
+                <a class="page-link" href="?published_page={{ published_tables_page.number }}"> {{ published_tables_page.number  }} </a>
+            </li>
+
+            {% if published_tables_page.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?published_page={{published_tables_page.next_page_number}}">Next</a>
+            </li>
+            {% endif %}
         </ul>
+        <span class="current">
+            Page {{ published_tables_page.number }} of {{ published_tables_page.paginator.num_pages }}.
+        </span>
     </nav>
 </section>
 
@@ -132,7 +142,7 @@
     <h2 class="profile-category__heading">Draft tables</h2>
     <div class="profile-tables">
         <div class="profile-tables__row">
-            {% for table in draft_tables %}
+            {% for table in draft_tables_page %}
             <div class="profile-tables__col">
                 <div class="profile-table-card">
                     <div class="profile-table-card__content">
@@ -227,16 +237,25 @@
     </div>
     <nav aria-label="Page navigation profile tables" class="pagination-nav">
         <ul>
-            <li class="page-item disabled">
-                <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Previous</a>
-            </li>
-            <li class="page-item active"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
+            {% if draft_tables_page.has_previous %}
             <li class="page-item">
-                <a class="page-link" href="#">Next</a>
+                <a class="page-link" href="?draft_page={{ draft_tables_page.previous_page_number }}" tabindex="-1" aria-disabled="true">&laquo;Previous</a>
             </li>
+            {% endif %}
+            
+            <li class="page-item active">
+                <a class="page-link" href="?draft_page={{ draft_tables_page.number }}"> {{ draft_tables_page.number  }} </a>
+            </li>
+
+            {% if draft_tables_page.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?draft_page={{draft_tables_page.next_page_number}}">Next</a>
+            </li>
+            {% endif %}
         </ul>
+        <span class="current">
+            Page {{ draft_tables_page.number }} of {{ draft_tables_page.paginator.num_pages }}.
+        </span>
     </nav>
 </section>
 {% endif %}

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -12,7 +12,7 @@
 
 - Add feature to reset a api token via the profile/settings page [(#1637)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1637)
 
-- Add Pagination to user tables section in the profile page [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
+- Add Pagination to user tables section in the profile page [(#1655)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1655)
 
 ## Bugs
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -12,6 +12,8 @@
 
 - Add feature to reset a api token via the profile/settings page [(#1637)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1637)
 
+- Add Pagination to user tables section in the profile page [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
+
 ## Bugs
 
 - Bugfix: Adding tags if metadata is empty does not result in a server error anymore. [(#1528)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1528)


### PR DESCRIPTION
## Summary of the discussion

There is no navigation on the profile page if the user has authorisations for multiple tables. In addition to the live search, scrolling through the table results can help to provide some control over the search results.

## Type of change (CHANGELOG.md)

### Features
- Add Pagination to user tables section in the profile page [(#1655)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1655)


## Workflow checklist

### Automation
Closes #1607

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/) 

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
