### PR TITLE
Get metadata form database instead of comment on table 

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -1114,9 +1114,9 @@ def _get_table(schema, table):
 
 
 def get_table_metadata(schema, table):
-    table_obj = _get_table(schema=schema, table=table)
-    comment = table_obj.comment
-    return json.loads(comment) if comment else {}
+    django_obj = DBTable.load(schema=schema, table=table)
+    oemetadata = django_obj.oemetadata
+    return oemetadata if oemetadata else {}
 
 
 def __internal_select(query, context):

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -14,7 +14,8 @@
 
 - Add new embargo area feature: Users can set an embargo period once they create a table or once they publish a table. The embargo period restricts the data access for bot ui & api. [(#1534)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1534)
 
-
 ## Bugs
+
+- REST-API: Retrieve oemetadata from database instead of comment on table. [(#1703)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1703)
 
 ## Documentation updates


### PR DESCRIPTION
## Summary of the discussion

Fixed a bug that leads to incorrect oemetadata returns when trying to download the metadata via the REST API.

## Type of change (CHANGELOG.md)

### Bugs

- REST-API: Retrieve oemetadata from database instead of comment on table. [(#1703)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1703)

## Workflow checklist

### Automation

Closes #1701

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
