### PR TITLE
Mitigate effect of outdated scenario table links

### DIFF
--- a/factsheet/frontend/src/components/factsheet.js
+++ b/factsheet/frontend/src/components/factsheet.js
@@ -1345,9 +1345,30 @@ function Factsheet(props) {
   };
 
 
-  const handleOpenURL = (e) => {
-    if (e !== '') {
-      window.open(e, "_blank")
+  // enhance open url function to handle urls better
+  // TODO change once OEKG is migrated
+  const handleOpenURL = (url, setError) => {
+    if (!url || url.trim() === '') {
+      setError('Invalid URL');
+      return;
+    }
+  
+    let processedURL = url.trim();
+  
+    // Handle URLs with spaces in the middle
+    processedURL = processedURL.replace(/\s+/g, '%20');
+  
+    // Prepend base URL if not starting with http:// or https://
+    if (!processedURL.startsWith('http://') && !processedURL.startsWith('https://')) {
+      processedURL = `https://openenergy-platform.org/${processedURL}`;
+    }
+  
+    // Encode the URL to handle special characters
+    try {
+      const encodedURL = encodeURI(processedURL);
+      window.open(encodedURL, "_blank");
+    } catch (error) {
+      setError('Invalid URL format');
     }
   };
 
@@ -2180,7 +2201,7 @@ function Factsheet(props) {
                     </div>
                   </FirstRowTableCell>
                   <ContentTableCell>
-                    {v.input_datasets.map((e) => <span> <span> <Chip label={e.value.label} size="small" variant="outlined" onClick={() => handleOpenURL(e.value.iri)} /> </span> <span>  <b className="separator-dot">  </b> </span> </span>)}
+                    {v.input_datasets.map((e) => <span> <span> <Chip label={e.value.label} size="small" variant="outlined" onClick={() => handleOpenURL(e.value.url)} /> </span> <span>  <b className="separator-dot">  </b> </span> </span>)}
                   </ContentTableCell>
                 </TableRow>
                 <TableRow>
@@ -2203,7 +2224,7 @@ function Factsheet(props) {
                     </div>
                   </FirstRowTableCell>
                   <ContentTableCell>
-                    {v.output_datasets.map((e) => <span> <span>  <Chip sx={{ marginTop: "5px" }} label={e.value.label} size="small" variant="outlined" onClick={() => handleOpenURL(e.value.iri)} /> </span> <span>  <b className="separator-dot">  </b> </span> </span>)}
+                    {v.output_datasets.map((e) => <span> <span>  <Chip sx={{ marginTop: "5px" }} label={e.value.label} size="small" variant="outlined" onClick={() => handleOpenURL(e.value.url)} /> </span> <span>  <b className="separator-dot">  </b> </span> </span>)}
                   </ContentTableCell>
                 </TableRow>
               </TableBody>

--- a/factsheet/frontend/src/components/factsheet.js
+++ b/factsheet/frontend/src/components/factsheet.js
@@ -1354,15 +1354,20 @@ function Factsheet(props) {
     }
   
     let processedURL = url.trim();
-  
+
     // Handle URLs with spaces in the middle
     processedURL = processedURL.replace(/\s+/g, '%20');
   
     // Prepend base URL if not starting with http:// or https://
     if (!processedURL.startsWith('http://') && !processedURL.startsWith('https://')) {
-      processedURL = `https://openenergy-platform.org/${processedURL}`;
+      const baseURL = window.location.origin;
+      processedURL = `${baseURL}${processedURL}`;
     }
-  
+
+    if (processedURL.startsWith('http://') && !processedURL.startsWith('http://127') && !processedURL.startsWith('http://local')){
+      processedURL = processedURL.replace('http://', 'https://');
+    }
+
     // Encode the URL to handle special characters
     try {
       const encodedURL = encodeURI(processedURL);

--- a/factsheet/views.py
+++ b/factsheet/views.py
@@ -3,14 +3,7 @@ import logging
 
 from django.contrib.auth.decorators import login_required
 from django.core import serializers
-from django.http import (
-    Http404,
-    HttpResponse,
-    HttpResponseForbidden,
-    JsonResponse,
-    StreamingHttpResponse,
-    FileResponse,
-)
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import render
 from django.utils.cache import patch_response_headers
 from rdflib import RDF, Graph, Literal, URIRef
@@ -1669,19 +1662,22 @@ def get_scenarios(request, *args, **kwargs):
 @login_required
 def get_all_factsheets_as_turtle(request, *args, **kwargs):
     all_factsheets_as_turtle = oekg.serialize(format="ttl")
-    
-    response = HttpResponse(all_factsheets_as_turtle, content_type='text/turtle')
-    response['Content-Disposition'] = 'attachment; filename="oekg.ttl"'
+
+    response = HttpResponse(all_factsheets_as_turtle, content_type="text/turtle")
+    response["Content-Disposition"] = 'attachment; filename="oekg.ttl"'
     return response
 
 
 def get_all_factsheets_as_json_ld(request, *args, **kwargs):
     all_factsheets_as_json_ld = oekg.serialize(format="json-ld")
 
-    response = HttpResponse(all_factsheets_as_json_ld, content_type='application/ld+json')
-    response['Content-Disposition'] = 'attachment; filename="oekg.jsonld"'
+    response = HttpResponse(
+        all_factsheets_as_json_ld, content_type="application/ld+json"
+    )
+    response["Content-Disposition"] = 'attachment; filename="oekg.jsonld"'
 
     return response
+
 
 def get_all_sub_classes(cls, visited=None):
     if visited is None:
@@ -1925,8 +1921,6 @@ def filter_scenario_bundles_view(request):
     html_content = render(
         request, "partials/related_oekg_scenarios.html", context
     ).content.decode("utf-8")
-    html_content = render(
-        request, "partials/related_oekg_scenarios.html", context
-    ).content.decode("utf-8")
+
     # Render the template with the context
     return HttpResponse(html_content)

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -2,6 +2,8 @@
 
 ## Changes
 
+- In the scenario bundles, the linked input and output tables often use an outdated format, which leads to inconsistent links. We mitigate the effects of this by handling the different URL variants until a data migration has taken place. [(#1740)](<https://github.com/OpenEnergyPlatform/oeplatform/pull/1740>
+
 ## Features
 
 ## Bugs


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)


### Changes

- In the scenario bundles, the linked input and output tables often use an outdated format, which leads to inconsistent links. We mitigate the effects of this by handling the different URL variants until a data migration has taken place. [(#1740)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1740)


## Workflow checklist

### Automation

Part of #1667

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
