### PR TITLE
Make standalone metadata builder available for non-logged-in-users

### DIFF
--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -1846,7 +1846,7 @@ class MetaEditView(LoginRequiredMixin, View):
         )
 
 
-class StandaloneMetaEditView(LoginRequiredMixin, View):
+class StandaloneMetaEditView(View):
     def get(self, request):
         context_dict = {
             "config": json.dumps(

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -1,7 +1,7 @@
 # Changes to the oeplatform code
 
 ## Changes
-- All visitors can use metadata builder in standalone version
+- All visitors can use metadata builder in standalone version  [(#1746)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1746)
 
 ## Features
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -1,6 +1,7 @@
 # Changes to the oeplatform code
 
 ## Changes
+- All visitors can use metadata builder in standalone version
 
 ## Features
 


### PR DESCRIPTION
## Summary of the discussion

Remove LoginRequiredMixin for standalone metadata builder

## Type of change (CHANGELOG.md)

### Changes

- All visitors can use metadata builder in standalone version

## Workflow checklist

### Automation

Closes #1745 

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
