### PR TITLE
Divide metadata builder into sections

### DIFF
--- a/dataedit/static/metaedit/schema.json
+++ b/dataedit/static/metaedit/schema.json
@@ -4,6 +4,8 @@
   "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/master/oemetadata/latest/schema.json",
   "description": "Create & edit oemetadata json files using the OEMetadata v1.6 schema. See the Open Energy Platform metadata standard: https://github.com/OpenEnergyPlatform/oemetadata",
   "type": "object",
+  "format": "categories",
+  "basicCategoryTitle": "Main",
   "properties": {
     "name": {
       "description": "File name or database table name",

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -3,6 +3,7 @@
 ## Changes
 
 ## Features
+- divide metadata builder flow into subsections
 
 ## Bugs
 


### PR DESCRIPTION
## Summary of the discussion

Sections in metadata builder are divided into tabs.

This must wait as unfortunately, hidden sections are shown in tabs (properties are not shown though as expected). See issue at jsoneditor repo: https://github.com/json-editor/json-editor/issues/1577

## Type of change (CHANGELOG.md)

### Features

- divide metadata builder into sections


## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
