### PR TITLE
Fix metadata order when downloading from data view

### DIFF
--- a/dataedit/helper.py
+++ b/dataedit/helper.py
@@ -4,6 +4,7 @@ make the codebase more modular.
 """
 
 from dataedit.models import Table
+from dataedit.metadata import TEMPLATE_V1_5
 
 ##############################################
 #          Table view related                #
@@ -53,6 +54,15 @@ def get_readable_table_name(table_obj: Table) -> str:
         raise e
     return label
 
+
+##############################################
+#            Metadata related                #
+##############################################
+
+def order_metadata(metadata: dict) -> dict:
+    """Brings metadata into consistent order based on TEMPLATE_V1_5"""
+    ordered_metadata = {key: metadata.get(key) for key in TEMPLATE_V1_5}
+    return ordered_metadata
 
 ##############################################
 #       Open Peer Review related             #

--- a/dataedit/templates/dataedit/dataview.html
+++ b/dataedit/templates/dataedit/dataview.html
@@ -191,7 +191,7 @@
           Metadata specification
         </a>
       </span>
-      <button onclick="downloadMetadata();" data-bs-toggle="tooltip" title="Download metadata in JSON format">Download JSON</button>
+      <a href="{% url 'dataedit:metadata' schema=schema table=table %}" class="btn btn-primary btn-sm" data-bs-toggle="tooltip" title="Download metadata in JSON format">Download JSON</a>
       <span {% if not can_add or opr.opr_id and not opr.is_finished %} data-bs-toggle="tooltip" title="You need write permissions on this table to edit metadata or your review is in progress, data can't be changed" {% endif %}>
     <a href="{{table}}/meta_edit" type="button" class="btn btn-primary btn-sm {% if not can_add or opr.opr_id and not opr.is_finished %} disabled {% endif %}">
       Edit
@@ -504,29 +504,6 @@ for row in result.json():
     options: JSON5.parse("{{ current_view.options | escapejs }}")
   };
   load_view(schema, table, csrftoken, view);
-
-  var downloadMetadata = function () {
-    var metaUrl = "/api/v0/schema/{{ schema }}/tables/{{ table }}/meta";
-    $.get(metaUrl).then(function (json) {
-      console.log(json);
-      // create data url
-      var json = JSON.stringify(json, null, 1);
-      console.log(json);
-      blob = new Blob([json], { type: "application/json" }),
-        dataUrl = URL.createObjectURL(blob);
-      // create link
-      var a = document.createElement("a");
-      document.body.appendChild(a);
-      // assign url and click
-      a.style = "display: none";
-      a.href = dataUrl;
-      a.download = '{{ table }}.metadata.json';
-      a.click();
-      // cleanup
-      URL.revokeObjectURL(dataUrl);
-      a.parentNode.removeChild(a);
-    })
-  };
 
   DataEdit(table=table, schema=schema);
 

--- a/dataedit/urls.py
+++ b/dataedit/urls.py
@@ -34,6 +34,13 @@ urlpatterns = [
         name="input",
     ),
     url(
+        r"^view/(?P<schema>{qual})/(?P<table>{qual})/download_metadata$".format(
+            qual=pgsql_qualifier
+        ),
+        views.get_metadata,
+        name="metadata",
+    ),
+    url(
         r"^view/(?P<schema>{qual})/(?P<table>{qual})/permissions$".format(
             qual=pgsql_qualifier
         ),

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -51,6 +51,7 @@ from dataedit.models import View as DBView
 from dataedit.structures import TableTags, Tag
 from login import models as login_models
 
+from .helper import order_metadata
 from .models import TableRevision
 from .models import View as DataViewModel
 
@@ -928,28 +929,17 @@ class DataView(View):
 
         actions.create_meta(schema, table)
         metadata = load_metadata_from_db(schema, table)
-        table_obj = Table.load(schema, table)
-        if table_obj is None:
-            raise Http404("Table object could not be loaded")
-
-        oemetadata = table_obj.oemetadata
-
-        from dataedit.metadata import TEMPLATE_V1_5
-
-        def iter_oem_key_order(metadata: dict):
-            oem_151_key_order = [key for key in TEMPLATE_V1_5.keys()]
-            for key in oem_151_key_order:
-                yield key, metadata.get(key)
-
-        ordered_oem_151 = {key: value for key, value in iter_oem_key_order(metadata)}
-        meta_widget = MetaDataWidget(ordered_oem_151)
-        revisions = []
+        ordered_metadata = order_metadata(metadata)
+        meta_widget = MetaDataWidget(ordered_metadata)
 
         api_changes = change_requests(schema, table)
         data = api_changes.get("data")
         display_message = api_changes.get("display_message")
         display_items = api_changes.get("display_items")
 
+        table_obj = Table.load(schema, table)
+        if table_obj is None:
+            raise Http404("Table object could not be loaded")
         is_admin = False
         can_add = False
         if request.user and not request.user.is_anonymous:
@@ -1001,7 +991,7 @@ class DataView(View):
                 schema=schema, table=table
             ),
             "reviewer": PeerReviewManager.load_reviewer(schema=schema, table=table),
-            "opr_enabled": oemetadata
+            "opr_enabled": metadata
             is not None,  # check if the table has the metadata
         }
 
@@ -1039,6 +1029,7 @@ class DataView(View):
         #   Construct the context object for the template       #
         #########################################################
 
+        revisions = []
         context_dict = {
             "meta_widget": meta_widget.render(),
             "revisions": revisions,
@@ -1858,6 +1849,17 @@ class StandaloneMetaEditView(LoginRequiredMixin, View):
             "dataedit/meta_edit.html",
             context=context_dict,
         )
+
+
+def get_metadata(request, schema, table):
+    """Return metadata as JSON in order consistent with MetadataBuilder"""
+    metadata = load_metadata_from_db(schema, table)
+    ordered_metadata = order_metadata(metadata)
+
+    json_data = json.dumps(ordered_metadata, indent=1)
+    response = HttpResponse(json_data, content_type='application/json')
+    response['Content-Disposition'] = f'attachment; filename="{table}.metadata.json"'
+    return response
 
 
 class PeerReviewView(LoginRequiredMixin, View):

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -1,6 +1,7 @@
 # Changes to the oeplatform code
 
 ## Changes
+- fixed metadata order when downloading metadata from data view
 
 ## Features
 


### PR DESCRIPTION
## Summary of the discussion

Fix inconsistent metadata structure

## Type of change (CHANGELOG.md)

### Changes

- Metadata order when downloading from data view

## Workflow checklist

### Automation

Closes #1696 

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
