### PR TITLE
Open Peer Review: tab status update taking into account empty fields

### DIFF
--- a/dataedit/static/peer_review/opr_reviewer.js
+++ b/dataedit/static/peer_review/opr_reviewer.js
@@ -901,15 +901,13 @@ function updateTabClasses() {
 
     let fields = Array.from(document.querySelectorAll('#' + tabName + ' .field'));
 
-    let allOk = true;
-    for (let j = 0; j < fields.length; j++) {
-      let fieldState = getFieldState(fields[j].id.replace('field_', ''));
-      if (fieldState !== 'ok') {
-        allOk = false;
-        break;
-      }
-    }
-    if (allOk) {
+    let allOkOrEmpty = fields.every(field => {
+      let fieldValue = $(field).find('.value').text().replace(/\s+/g, ' ').trim();
+      let fieldState = getFieldState(field.id.replace('field_', ''));
+      return isEmptyValue(fieldValue) || fieldState === 'ok';
+    });
+
+    if (allOkOrEmpty) {
       tab.classList.add('status');
       tab.classList.add('status--done');
     } else {
@@ -917,6 +915,8 @@ function updateTabClasses() {
     }
   }
 }
+
+
 window.addEventListener('DOMContentLoaded', function() {
   updateTabClasses();
   // updatePercentageDisplay() ;
@@ -960,12 +960,13 @@ function updateTabProgressIndicatorClasses() {
     let fieldsInTab = Array.from(document.querySelectorAll('#' + tabName + ' .field'));
     let values = getAllFieldsAndValues();
 
-    let allOk = fieldsInTab.every((field, index) => {
-        let currentValue = values[index].fieldValue;
-        return isEmptyValue(currentValue) || field.classList.contains('field-ok');
+    let allOkOrEmpty = fieldsInTab.every((field, index) => {
+      let currentValue = values[index].fieldValue;
+      let fieldState = getFieldState(field.id.replace('field_', ''));
+      return isEmptyValue(currentValue) || fieldState === 'ok';
     });
 
-    if (allOk) {
+    if (allOkOrEmpty) {
       tab.classList.add('status--done');
     } else {
       tab.classList.add('status');

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -6,4 +6,6 @@
 
 ## Bugs
 
+- Open peer review, reviewer page: correctly determines the status of fields on the tab with a small dot, taking into account empty fields. [(#1783)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1783)
+
 ## Documentation updates


### PR DESCRIPTION
## Summary of the discussion

Fix integrated tab status update taking into account empty fields when loading a page on the reviewer page 

## Type of change (CHANGELOG.md)

### Bugs

- Open peer review, reviewer page: correctly determines the status of fields on the tab with a small dot, taking into account empty fields. [(#1783)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1783)

## Workflow checklist

### Automation

Part of #1650

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
