### PR TITLE
Increase python version in docker-build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.14
+FROM python:3.11.9
 
 RUN apt-get update \
     && apt-get install -y apache2 apache2-dev libapache2-mod-wsgi-py3\


### PR DESCRIPTION
As the mod_wsgi uses already Python 3.11 the Django dependencies (and all others) are not found (see #1790). Therefore, this commit increases the python version of the base image to 3.11 which fixes the problem.

## Summary of the discussion
see #1790

## Workflow checklist

### Automation

Closes #1790

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
