### PR TITLE
Update Dockerfile for correct version of mod_wsgi

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM python:3.10.14
 
 RUN apt-get update \
-    && apt-get install -y apache2 apache2-dev libapache2-mod-wsgi-py3\
+    && apt-get install -y apache2 apache2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-
 COPY requirements.txt /app/requirements.txt
+
 RUN pip install -r requirements.txt
+
+RUN pip install mod_wsgi
+RUN mod_wsgi-express module-config >> /etc/apache2/apache2.conf
 
 COPY ./docker/apache2.conf /etc/apache2/conf-enabled/oeplatform.conf
 COPY . /app


### PR DESCRIPTION
Update Dockerfile to use mod_wsgi fitting to Python version (fixes #1790)

## Summary of the discussion
see #1790: Ensure that the correct version of mod_wgsi is used / installed in the docker image

## Type of change (CHANGELOG.md)

### Bugs

- Fixed a wrong mod_wsgi version in Dockerfile [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

## Workflow checklist

### Automation

Closes #1790

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
