### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/automated-testing.yaml
+++ b/.github/workflows/automated-testing.yaml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install linux dependencies
@@ -61,7 +61,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y postgresql-client
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -76,11 +76,11 @@ jobs:
             sleep 2
           done
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -9,11 +9,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,14 +29,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile


### PR DESCRIPTION
## Summary of the discussion

Hi, this is my first PR to the project. Please let me know, if the changes are desired.

This PR bumps the GitHub actions versions in your workflows. This change will reduce the number of warnings in CI, e.g. "The following actions uses node12 which is deprecated ..." (https://github.com/OpenEnergyPlatform/oeplatform/actions/runs/10722144730).

What do you think?

## Type of change (CHANGELOG.md)

### Features

- Add a new functionality [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

### Changes

- Update existing functionality [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

### Bugs

- Fixed a problem with [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

### Removed

- Remove a broken link [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

### Documentation updates

- Updated documentation for [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/)

## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
