### PR TITLE
Fix wrong closing tag name (buttton)

### DIFF
--- a/dataedit/templates/dataedit/dataview.html
+++ b/dataedit/templates/dataedit/dataview.html
@@ -475,8 +475,8 @@ for row in result.json():
               Do you want to delete the table (including data and metadata)?
           </div>
           <div class="modal-body">
-              <button class="btn btn-sm btn-dark mr-2" id="dataview-confirm-delete-delete">delete</buttton>
-              <button class="btn btn-sm btn-light" id="dataview-confirm-delete-cancel">cancel</buttton>
+              <button class="btn btn-sm btn-dark mr-2" id="dataview-confirm-delete-delete">delete</button>
+              <button class="btn btn-sm btn-light" id="dataview-confirm-delete-cancel">cancel</button>
           </div>
       </div>
   </di>


### PR DESCRIPTION
## Summary of the discussion
Those two lines had a wrong closing tag (buttton, with 3 t), while opening correctly with button.

## Type of change (CHANGELOG.md)
too mini

## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
