### PR TITLE
Enhance oeox implementation

### DIFF
--- a/.github/workflows/automated-testing.yaml
+++ b/.github/workflows/automated-testing.yaml
@@ -104,8 +104,8 @@ jobs:
           mkdir -p ontologies/oeo/1/modules
           wget https://openenergyplatform.org/ontology/oeo/releases/oeo-full.owl -P ontologies/oeo/1/
 
-          mkdir -p ontologies/oeo_ext/
-          cp oeo_ext/oeo_extended_store/oeox_template/oeo_ext_template_empty.owl  ontologies/oeo_ext/oeo_ext.owl
+          mkdir -p media/oeo_ext/
+          cp oeo_ext/oeo_extended_store/oeox_template/oeo_ext_template_empty.owl  media/oeo_ext/oeo_ext.owl
       - name: Collectstatic files & compress
         run: |
           cp oeplatform/securitysettings.py.default oeplatform/securitysettings.py

--- a/dataedit/static/metaedit/schema.json
+++ b/dataedit/static/metaedit/schema.json
@@ -69,7 +69,7 @@
             "format": "button",
             "options": {
               "button": {
-                "text": "Open OEO-EXT",
+                "text": "Open OEO-extended",
                 "icon": "external-link-alt",
                 "action": "openModalAction"
               }
@@ -597,7 +597,7 @@
                             "format": "button",
                             "options": {
                               "button": {
-                                "text": "Open OEO-EXT",
+                                "text": "Open OEO-extended",
                                 "icon": "external-link-alt",
                                 "action": "openModalAction"
                               }
@@ -653,7 +653,7 @@
                             "format": "button",
                             "options": {
                               "button": {
-                                "text": "Open OEO-EXT",
+                                "text": "Open OEO-extended",
                                 "icon": "external-link-alt",
                                 "action": "openModalAction"
                               }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,8 @@ COPY ./docker/docker-entrypoint.sh /app/docker-entrypoint.sh
 
 RUN mkdir -p /app/ontologies/oeo && cd /app/ontologies/oeo && wget https://github.com/OpenEnergyPlatform/ontology/releases/download/v2.4.0/build-files.zip && unzip build-files.zip && mv build-files 2.4.0 && rm -r __MACOSX && rm build-files.zip
 
+RUN mkdir -p /app/media/oeo_ext && cp /app/oeo_ext/oeo_extended_store/oeox_template/oeo_ext_template_empty.owl /app/media/oeo_ext/oeo_ext.owl
+
 RUN cp /app/oeplatform/securitysettings.py.default /app/oeplatform/securitysettings.py && python manage.py collectstatic --noinput && rm /app/oeplatform/securitysettings.py
 
 EXPOSE 80

--- a/docs/install-and-documentation/install/installation.md
+++ b/docs/install-and-documentation/install/installation.md
@@ -275,6 +275,22 @@ The oeo-viewer is a visualization tool for our OEO ontology and it is under deve
 
 After these steps, a `static` folder inside `oep-website/oeplatform/oeo_viewer/` will be created which includes the results of the `npm run build` command. These files are necessary for the oeo-viewer.
 
+## 6.2 Setup the OEO-extended app
+
+The OEO-extended ([oeo_ext](https://github.com/OpenEnergyPlatform/oeplatform/tree/develop/oeo_ext)) app is implemented as a plugin view that can quickly be added to any page of the OEP-website. Currently it is implemented in the OEMetaBuilder to add new composed units that can be annotated in the oemetadata. The OEO-extended itself is a ontology that extends the OEO and it is stored as OWL file format inside the media directory of the oeplatform. As the app itself will write to the files once the user submits a new unit via the interface you must grant access permissions on that directory to the user that runs the oeplatform code on your specific server.
+
+Setup a new folder in the `MEDIA_ROOT` directory specified in the `securitysettings.py`. By default this directory is called `media/`. You must create the sub directory specified in the setting `OEO_EXT_PATH` and add the OEO-extended files with the name specified in the `OEO_EXT_OWL_NAME` setting from `settings.py`.
+
+To get started you can copy the template OEO-extended owl file form [`oeplatform/oeo_ext/oeo_extended_store/oeox_template/oeo_ext_template_empty.owl`](https://github.com/OpenEnergyPlatform/oeplatform/tree/develop/oeo_ext/oeo_extended_store/oeox_template).
+
+Below you can find the desired structure using the default setting values:
+
+    ```bash
+    media/
+    └── oeo_ext
+        └── oeo_ext.owl
+    ```
+
 ## 7 Setup the Scenario-Bundles app
 
 !!! note "Optional Step"

--- a/oeo_ext/templates/oeo_ext/partials/oeo-ext-plugin-ui.html
+++ b/oeo_ext/templates/oeo_ext/partials/oeo-ext-plugin-ui.html
@@ -16,8 +16,8 @@
     </span>
     <div>
         This feature is still a research prototype and offers only a minimal user experience. 
-        Currently Once you create a new composed unit, you need to copy the URL, which then becomes
-        visible. You can access the URL and copy the name and URL into the oemetadata fields 
+        After you successfully create a new composed unit, you need to copy the URL, which then becomes
+        visible. You can access the URL in your browser and copy the name and URL into the oemetadata fields 
         for "Name" and "Path" as soon as you close this overlay. 
     </div>
     <div class="result-section mt-4">

--- a/oeo_ext/templates/oeo_ext/partials/oeo-ext-plugin-ui.html
+++ b/oeo_ext/templates/oeo_ext/partials/oeo-ext-plugin-ui.html
@@ -1,6 +1,25 @@
 {% load django_bootstrap5 %}
 
 <div class="htmxComponent">
+    <div>
+        With the extended OEO functionality, you can expand the terms found in the OEO.     
+        Currently we only offer the possibility to create additional units. As it is possible 
+        to create any combination of existing terms using the form below, the OEO extended module 
+        will be stored on the OEP but also made available on <a href="{{oeox_github_link}}" target="_blank">GitHub</a>. 
+        Before each release, we will review the content of the OEO extended with all newly composed entities 
+        contributed by the Open Energy Family community.<br>
+        We are about to publish an paper describing the approach used here and will provide the link shortly.
+    </div>
+    <br>
+    <span class="early-access">
+        Early Access
+    </span>
+    <div>
+        This feature is still a research prototype and offers only a minimal user experience. 
+        Currently Once you create a new composed unit, you need to copy the URL, which then becomes
+        visible. You can access the URL and copy the name and URL into the oemetadata fields 
+        for "Name" and "Path" as soon as you close this overlay. 
+    </div>
     <div class="result-section mt-4">
         <h3>Result</h3>
         <div id="result-expression">

--- a/oeo_ext/views.py
+++ b/oeo_ext/views.py
@@ -7,6 +7,7 @@ from django.views.generic import View
 
 from oeo_ext.forms import ComposedUnitFormWrapper, UnitEntryForm
 from oeo_ext.utils import create_new_unit
+from oeplatform.settings import EXTERNAL_URLS
 
 
 # Suggested views maybe you will use other ones @adel
@@ -21,6 +22,7 @@ class OeoExtPluginView(View, LoginRequiredMixin):
             "form": form,
             "nominator_forms": [],
             "denominator_forms": [],
+            "oeox_github_link": EXTERNAL_URLS["oeo_extended_github"],
         }
         return render(request, "oeo_ext/partials/oeo-ext-plugin-ui.html", context)
 

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -152,6 +152,12 @@ try:
 except NameError:
     BASE_DIR = ""
 
+# from security settings
+try:
+    MEDIA_ROOT  # noqa F405
+except NameError:
+    MEDIA_ROOT = "/media"
+
 try:
     ONTOLOGY_ROOT  # noqa F405
 except NameError:
@@ -165,7 +171,8 @@ if ONTOLOGY_ROOT:
     )
     OPEN_ENERGY_ONTOLOGY_FULL_OWL_NAME = "oeo-full.owl"
 
-    OEO_EXT_PATH = Path(ONTOLOGY_ROOT, "oeo_ext")
+if MEDIA_ROOT:
+    OEO_EXT_PATH = Path(MEDIA_ROOT, "oeo_ext")
     OEO_EXT_NAME = "oeox"
     OEO_EXT_OWL_NAME = "oeo_ext.owl"
     OEO_EXT_OWL_PATH = OEO_EXT_PATH / OEO_EXT_OWL_NAME

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -97,6 +97,7 @@ EXTERNAL_URLS = {
     "tib_ts_oeo": "https://terminology.tib.eu/ts/ontologies/oeo",
     "spdx_licenses": "https://spdx.github.io/license-list-data/",
     "oemetadata_key_description": "https://github.com/OpenEnergyPlatform/oemetadata/blob/master/metadata/latest/metadata_key_description.md",  # noqa E501
+    "oeo_extended_github": "https://github.com/OpenEnergyPlatform/oeo-extended",  # noqa E501
 }
 
 # Kept this separate for now to avoid messing with the other list ...

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -39,4 +39,7 @@
 ## Documentation updates
 
 - Improved OpenAPI documentation of oeplatform REST-API [(#1793)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1793)
+
 - Updated documentation for docker to include how to restart oeplatform [(#1830)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1830)
+
+- Enhance installation instruction with information on how to setup the OEO-extended feature [(#1857)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1857).

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -16,7 +16,7 @@
 
 - Update existing ontology layout [(#1850)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1850)
 
-- The oeox owl file is now stored in the media directory to avoid writing to insecure directory. [](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
+- Add the Early access indicator to oeox plugin view buttons & The oeox owl file is now stored in the media directory to avoid writing to insecure directory. [](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
 
 ## Features
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,7 +13,10 @@
 - Enhance the ontology pages, remove the modules page and fully rework the about page and oeo download capabilities. Additionally add the oeox and make its URIs available, also add more cases where a Http404 is raised to make [(#1807)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1807)
 
 - Update the OpenEnergyFamily group picture on the about page [(#1816)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1816)
+
 - Update existing ontology layout [(#1850)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1850)
+
+- The oeox owl file is now stored in the media directory to avoid writing to insecure directory. [](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
 
 ## Features
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -16,7 +16,7 @@
 
 - Update existing ontology layout [(#1850)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1850)
 
-- Add the Early access indicator to oeox plugin view buttons & The oeox owl file is now stored in the media directory to avoid writing to insecure directory. [](https://github.com/OpenEnergyPlatform/oeplatform/pull/)
+- Add the Early access indicator to oeox plugin view buttons & The oeox owl file is now stored in the media directory to avoid writing to insecure directory. [(#1857)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1857)
 
 ## Features
 


### PR DESCRIPTION
## Summary of the discussion

Display an "early access" indicator for the oeox plugin and save the oeo_ext.owl file in a storage directory to avoid security concerns. 

## Type of change (CHANGELOG.md)

### Changes

- Add the Early access indicator to oeox plugin view buttons & The oeox owl file is now stored in the media directory to avoid writing to insecure directory. [(#1857)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1857)

## Documentation updates

- Enhance installation instruction with information on how to setup the OEO-extended feature [(#1857)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1857).

## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
