### PR TITLE
Extend oeo check at startup for oeo-ext 

### DIFF
--- a/docs/install-and-documentation/install/installation.md
+++ b/docs/install-and-documentation/install/installation.md
@@ -267,7 +267,7 @@ The oeo-viewer is a visualization tool for our OEO ontology and it is under deve
 2. Get the ontology files (see [Section 3](#3-setup-the-openenergyontology-integration))
 
 3. Build the oeo-viewer:
-    ```
+    ```bash
     cd oep-website/oeplatform/oeo_viewer/client
     npm install
     npm run build
@@ -285,11 +285,11 @@ To get started you can copy the template OEO-extended owl file form [`oeplatform
 
 Below you can find the desired structure using the default setting values:
 
-    ```bash
-    media/
-    └── oeo_ext
-        └── oeo_ext.owl
-    ```
+```bash
+media/
+└── oeo_ext
+    └── oeo_ext.owl
+```
 
 ## 7 Setup the Scenario-Bundles app
 

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -104,6 +104,7 @@ EXTERNAL_URLS = {
 # TODO move to EXTERNAL_URLS if possible
 DOCUMENTATION_LINKS = {
     "oeo_setup": "https://openenergyplatform.github.io/oeplatform/install-and-documentation/install/installation/#3-setup-the-openenergyontology-integration",  # noqa:E501
+    "oeo_ext_setup": "https://openenergyplatform.github.io/oeplatform/install-and-documentation/install/installation/#62-setup-the-oeo-extended-app",  # noqa:E501
     "oemetabuilder": "https://openenergyplatform.github.io/oeplatform/install-and-documentation/oeplatform-code/features/metaBuilder/",  # noqa:E501
 }
 

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -103,7 +103,7 @@ EXTERNAL_URLS = {
 # Kept this separate for now to avoid messing with the other list ...
 # TODO move to EXTERNAL_URLS if possible
 DOCUMENTATION_LINKS = {
-    "oeo_setup": "https://openenergyplatform.github.io/oeplatform/install-and-documentation/install/installation/#4-setup-the-openenergyontology-integation",  # noqa:E501
+    "oeo_setup": "https://openenergyplatform.github.io/oeplatform/install-and-documentation/install/installation/#3-setup-the-openenergyontology-integration",  # noqa:E501
     "oemetabuilder": "https://openenergyplatform.github.io/oeplatform/install-and-documentation/oeplatform-code/features/metaBuilder/",  # noqa:E501
 }
 

--- a/ontology/apps.py
+++ b/ontology/apps.py
@@ -3,40 +3,38 @@ import os
 
 from django.apps import AppConfig
 
-from oeplatform.settings import DOCUMENTATION_LINKS, OPEN_ENERGY_ONTOLOGY_FOLDER
+from oeplatform.settings import DOCUMENTATION_LINKS, OPEN_ENERGY_ONTOLOGY_FOLDER, OEO_EXT_OWL_PATH
 
 
 class OntologyConfig(AppConfig):
     name = "ontology"
+
+    # Configure the logging module
+    logging.basicConfig(level=logging.WARNING)
+    logger = logging.getLogger(__name__)
 
     def ready(self):
         """
         Check if the necessary oeo release files are available. This check is
         strict to the expected directory structure that is defined in
         the settings / secSettings.
-        It is not checked weather the files actually exists but it is checked
+        It is not checked whether the files actually exists, but it is checked
         if the oeo folder is available. This folder should only be available
         if it was downloaded before.
 
-        Returns a understandable error massage that also links to the related
+        Returns an understandable error message that also links to the related
         documentation.
         """
         # Specify the file to check
-        file_to_check = OPEN_ENERGY_ONTOLOGY_FOLDER
+        self.check_file(OPEN_ENERGY_ONTOLOGY_FOLDER, 'oeo release', 'oeo_setup')
+        self.check_file(OEO_EXT_OWL_PATH, 'oeo extended', 'oeo_ext_setup')
 
-        # Configure the logging module
-        logging.basicConfig(level=logging.WARNING)
-        logger = logging.getLogger(__name__)
-
+    def check_file(self, file_to_check, file_label, documentation_key):
         # Check if the file exists during app startup
-        # file_path = os.path.(file_to_check)
         if not os.path.exists(file_to_check):
-            logger.error(
-                f"The oeo release files in '{file_to_check}' are missing! "
-                "The app can`t start.!"
-            )
-            raise ImportError(
-                f"The oeo release files in '{file_to_check}' are missing! "
-                "The app can`t start. Please refer to the documentation: "
-                f"{DOCUMENTATION_LINKS.get('oeo_setup')}"
-            )
+            msg = f"The {file_label} files in '{file_to_check}' are missing! "
+            "The app can`t start. Please refer to the documentation: "
+            f"{DOCUMENTATION_LINKS.get(documentation_key)}"
+
+            self.logger.error(msg)
+            raise ImportError(msg)

--- a/ontology/apps.py
+++ b/ontology/apps.py
@@ -32,8 +32,8 @@ class OntologyConfig(AppConfig):
     def check_file(self, file_to_check, file_label, documentation_key):
         # Check if the file exists during app startup
         if not os.path.exists(file_to_check):
-            msg = f"The {file_label} files in '{file_to_check}' are missing! "
-            "The app can`t start. Please refer to the documentation: "
+            msg = f"The {file_label} files in '{file_to_check}' are missing! " \
+            "The app can`t start. Please refer to the documentation: " \
             f"{DOCUMENTATION_LINKS.get(documentation_key)}"
 
             self.logger.error(msg)

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -2,6 +2,8 @@
 
 ## Changes
 
+- Include check for oeo-ext on startup [(#1879)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1879)
+
 ## Features
 
 ## Bugs


### PR DESCRIPTION
## Summary of the discussion
Like the oeo is checking whether the oeo files are there, this PR extends this by applying the check also to the oeo ext file and throwing a corresponding error message, including a link to the corresponding part in the docs. And both error messages now include the link.

```
ERROR:ontology.apps:The oeo extended files in '/home/me/OEP/media/oeo_ext/oeo_ext.owl' are missing! The app can`t start. Please refer to the documentation: https://openenergyplatform.github.io/oeplatform/install-and-documentation/install/installation/#62-setup-the-oeo-extended-app
```

Previously, this was not checked, but noticed on startup as the file was missing. But no supportive message about how to fix that:

```me@local: $ python manage.py runserver 
Watching for file changes with StatReloader
INFO:django.utils.autoreload:Watching for file changes with StatReloader
Performing system checks...

Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/core/management/commands/runserver.py", line 118, in inner_run
    self.check(display_num_errors=True)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/core/management/base.py", line 419, in check
    all_issues = checks.run_checks(
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/core/checks/registry.py", line 76, in run_checks
    new_errors = check(app_configs=app_configs, databases=databases)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/core/checks/urls.py", line 13, in check_url_config
    return check_resolver(resolver)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/core/checks/urls.py", line 23, in check_resolver
    return check_method()
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/urls/resolvers.py", line 416, in check
    for pattern in self.url_patterns:
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/urls/resolvers.py", line 602, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/urls/resolvers.py", line 595, in urlconf_module
    return import_module(self.urlconf_name)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/me/OEP/oeplatform/urls.py", line 30, in <module>
    url(r"^oeo_ext/", include("oeo_ext.urls")),
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/django/urls/conf.py", line 34, in include
    urlconf_module = import_module(urlconf_module)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/me/OEP/oeo_ext/urls.py", line 4, in <module>
    from oeo_ext import views
  File "/home/me/OEP/oeo_ext/views.py", line 8, in <module>
    from oeo_ext.forms import ComposedUnitFormWrapper, UnitEntryForm
  File "/home/me/OEP/oeo_ext/forms.py", line 3, in <module>
    from oeo_ext.oeo_extended_store.connection import oeo_owl
  File "/home/me/OEP/oeo_ext/oeo_extended_store/connection.py", line 43, in <module>
    oeo_ext.parse(OEO_EXT_OWL_PATH.as_uri())
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/rdflib/graph.py", line 1062, in parse
    source = create_input_source(
  File "/home/me/OEP/oep-venv/lib/python3.10/site-packages/rdflib/parser.py", line 191, in create_input_source
    file = open(filename, "rb")
FileNotFoundError: [Errno 2] No such file or directory: '/home/me/OEP/media/oeo_ext/oeo_ext.owl'
```

## Type of change (CHANGELOG.md)

### Changes

- Include check for oeo-ext on startup [(#1879)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1879)

## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
