### PR TITLE
Tags success message: fix typos and font size

### DIFF
--- a/dataedit/templates/messages.html
+++ b/dataedit/templates/messages.html
@@ -2,12 +2,12 @@
   {% for message in messages %}
     <div class="alert alert-dismissible alert-success">
       <h4>
-        Sucessuflly updated table tags!
+        Successfully updated table tags!
       </h4>
       <button type="button" class="btn-close" data-bs-dismiss="alert">
       ×
       </button>
-      <p class="mb-0" style="font-size: 30px;">
+      <p class="mb-0">
       {{message}}
       </p>
     </div>

--- a/dataedit/views.py
+++ b/dataedit/views.py
@@ -1555,7 +1555,7 @@ def update_table_tags(request):
                 table=table, schema=schema, metadata=metadata, cursor=con
             )
 
-    messasge = messages.success(
+    message = messages.success(
         request,
         'Please note that OEMetadata keywords and table tags are synchronized. When submitting new tags, you may notice automatic changes to the table tags on the OEP and/or the "Keywords" field in the metadata.',  # noqa
         # noqa
@@ -1564,7 +1564,7 @@ def update_table_tags(request):
     return render(
         request,
         "dataedit/dataview.html",
-        {"messages": messasge, "table": table, "schema": schema},
+        {"messages": message, "table": table, "schema": schema},
     )
 
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -2,6 +2,8 @@
 
 ## Changes
 
+- Fix typo and font-size after tag assignment update [(#1880)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1880)
+
 ## Features
 
 ## Bugs


### PR DESCRIPTION
## Summary of the discussion
When adding or removing a tag, you got the following message:
![Bildschirmfoto vom 2024-10-01 15-27-23](https://github.com/user-attachments/assets/47123b2c-2efd-4aef-a7fd-19629b15ac32)

This PR changes it to:
![Bildschirmfoto vom 2024-10-01 15-27-47](https://github.com/user-attachments/assets/d4437dda-2999-4781-aee0-1d73add2f324)

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Changes

- Fix typo and font-size after tag assignment update [(#1880)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1880)

## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
