### PR TITLE
Call bootstrap functions for accordion hide/show

### DIFF
--- a/dataedit/static/wizard/wizard.js
+++ b/dataedit/static/wizard/wizard.js
@@ -715,8 +715,8 @@ function calculateEmbargoPeriod(embargoValue) {
   function showCreate() {
     // create default id column
     addColumn({"name": "id", "data_type": "bigint", "is_nullable": false, "is_pk": true});
-    $("#wizard-container-upload").collapse("hide");
-    $("#wizard-container-create").collapse("show");
+    new bootstrap.Collapse('#wizard-container-create', {'toggle': false}).show();
+    new bootstrap.Collapse('#wizard-container-upload', {'toggle': false}).hide();
     $("#wizard-table-delete").hide();
     $("#wizard-container-upload").find(".btn").hide();
     $("#wizard-container-upload").find("input").prop("readonly", true);
@@ -724,10 +724,11 @@ function calculateEmbargoPeriod(embargoValue) {
 
 
   function showUpload() {
-    $("#wizard-container-create").collapse("hide");
-    $("#wizard-container-upload").collapse("show");
-    $("#wizard-container-create").find(".btn").hide();
+    new bootstrap.Collapse('#wizard-container-create', {'toggle': false}).hide();
+    new bootstrap.Collapse('#wizard-container-upload', {'toggle': false}).show();
     $("#wizard-table-delete").show();
+
+    $("#wizard-container-create").find(".btn").hide();
     $("#wizard-container-create").find("input").prop("readonly", true);
     $("#wizard-container-create").find("input,select,.combobox-container").not("[type=text]").prop("disabled", true);
     if (!state.canAdd) {
@@ -830,7 +831,6 @@ function calculateEmbargoPeriod(embargoValue) {
         $('#wizard-confirm-delete').modal('hide');
       });
       $("#wizard-confirm-delete-delete").bind("click", deleteTable);
-
 
       showUpload();
     } else {

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -6,4 +6,6 @@
 
 ## Bugs
 
+- Fixed wrong calls in dataedit wizard to open collapsed items  [(#1881)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1881)
+
 ## Documentation updates


### PR DESCRIPTION
## Summary of the discussion
1. Visit dataedit for one of your tables, e.g. https://openenergyplatform.org/dataedit/wizard/model_draft/test_v2353456
2. Open developer tools, see Console
  ```
  Uncaught TypeError: $(...).collapse is not a function
   ```
3. The pane "Upload CSV" is not open as expected.

Same for adding a new dataset, https://openenergyplatform.org/dataedit/wizard/. Here Create table is not open.

### Background
While in Bootstrap 4 it have been simple functions, like hide(), this was changed in bootstrap 5.
- https://getbootstrap.com/docs/4.6/components/collapse/#collapseshow
- https://getbootstrap.com/docs/5.3/components/collapse/#methods
- see https://stackoverflow.com/a/69794286

## Type of change (CHANGELOG.md)

### Bugs

- Fixed wrong calls in dataedit wizard to open collapsed items  [(#1881)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1881)

## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
