### PR TITLE
Fix outdated loep service url

### DIFF
--- a/dataedit/static/metaedit/metaedit.js
+++ b/dataedit/static/metaedit/metaedit.js
@@ -333,7 +333,7 @@ var MetaEdit = function(config) {
         window.JSONEditor.defaults.callbacks = {
           "autocomplete": {
             "search_name": function search(jseditor_editor, input) {
-              var url = "https://openenergyplatform.org/api/v0/oeo-search?query=" + input;
+              var url = "https://openenergyplatform.org/api/oeo-search?query=" + input;
 
               return new Promise(function(resolve) {
                 fetch(url, {
@@ -427,7 +427,7 @@ var MetaEdit = function(config) {
         window.JSONEditor.defaults.callbacks = {
           "autocomplete": {
             "search_name": function search(jseditor_editor, input) {
-              var url = "https://openenergyplatform.org/api/v0/oeo-search?query=" + input;
+              var url = "https://openenergyplatform.org/api/oeo-search?query=" + input;
 
               return new Promise(function(resolve) {
                 fetch(url, {

--- a/oeo_ext/templates/oeo_ext/partials/unit_element.html
+++ b/oeo_ext/templates/oeo_ext/partials/unit_element.html
@@ -41,7 +41,7 @@
             if (query.length > 0) {
                 // use static path here to always use the open (data seeded) endpoint for 
                 // all (local, deployed) client executions
-                fetch(`https://openenergyplatform.org/api/v0/oeo-search?query=${query}`, {
+                fetch(`https://openenergyplatform.org/api/oeo-search?query=${query}`, {
                     mode: 'cors',
                 })
                 .then(response => response.json())

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -8,6 +8,8 @@
 
 ## Bugs
 
+- Fix outdated service url to send requests to the LEOP from the oemetaBuilder and oeo-extended features[(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/).
+
 ## Documentation updates
 
 - Updated documentation to simplify usage of vendor software swagger ui and update the documentation on scenario bundles. Add documentation on how to use the updated OEKG web API [(#1928)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1928).

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -8,7 +8,7 @@
 
 ## Bugs
 
-- Fix outdated service url to send requests to the LEOP from the oemetaBuilder and oeo-extended features[(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/).
+- Fix outdated service url to send requests to the LEOP from the oemetaBuilder and oeo-extended features[(#1938)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1938).
 
 ## Documentation updates
 


### PR DESCRIPTION
## Summary of the discussion

The url of the LOEP which is accessible via the OEP-API was outdated. This PR fixes the issue.

## Type of change (CHANGELOG.md)


### Bugs

- Fix outdated service url to send requests to the LEOP from the oemetaBuilder and oeo-extended features[(#1938)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1938).

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
