### PR TITLE
Fix broken link from dataset to scenario bundle

### DIFF
--- a/.github/workflows/automated-testing.yaml
+++ b/.github/workflows/automated-testing.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # LD_PRELOAD: /lib/x86_64-linux-gnu/libSegFault.so
       # SEGFAULT_SIGNALS: all

--- a/factsheet/oekg/filters.py
+++ b/factsheet/oekg/filters.py
@@ -10,20 +10,32 @@ class OekgQuery:
 
     def serialize_table_iri(self, table_iri: str):
         """
-        The OEKG stores the full iri to link its resources.
-        Due to structural changes it also stores the iri:urn instead.
-        the serialization will function als a validation preprocessing
-        step.
+        The OEKG stores the full iri to link its resources in the OEP.
+        External IRI can occur in the OEKG but they are ignored here.
 
-        IRI Like 'dataedit/view/scenario/abbb_emob' or '
-        https://openenergyplatform.org/dataedit/view/scenario/abbb_emob'
-        becomes comparable even with more variation options.
+        Note:
+            Due to structural changes it also stores the iri:urn instead.
+            the serialization will function als a validation preprocessing
+            step.
+
+        Supported IRI formats:
+            IRI Like 'dataedit/view/scenario/abbb_emob' or '
+            https://openenergyplatform.org/dataedit/view/scenario/abbb_emob'
+            becomes comparable even with more variation options.
+
+
         """
 
         # Trim down variations of table iri´s down to harmonized part.
         id_from_url = table_iri.split("view/")
+        # check if the table_iri contains expected part
+        if len(id_from_url) == 2:
+            result = id_from_url[1]
+        else:
+            # return empty string to keep the return value consistent
+            result = ""
 
-        return id_from_url[1]
+        return result
 
     def get_related_scenarios_where_table_is_input_dataset(self, table_iri):
         """
@@ -45,13 +57,15 @@ class OekgQuery:
         # Find all scenario bundles
         for s, p, o in self.oekg.triples((None, RDF.type, namespaces.OEO.OEO_00010252)):
             # find all scenarios in any bundle
-            for s1, p1, o1 in oekg.triples((s, namespaces.OEKG["has_scenario"], None)):
+            for s1, p1, o1 in self.oekg.triples(
+                (s, namespaces.OEKG["has_scenario"], None)
+            ):
                 # # Find scenarios where the given table is the input dataset
                 for s2, p2, o1_input_ds_uid in self.oekg.triples(
                     (o1, namespaces.OEO.RO_0002233, None)
                 ):
                     if o1_input_ds_uid is not None:
-                        for s3, p3, o3_input_ds_iri in oekg.triples(
+                        for s3, p3, o3_input_ds_iri in self.oekg.triples(
                             (o1_input_ds_uid, namespaces.OEO["has_iri"], None)
                         ):
                             if (

--- a/factsheet/tests/test_oekg_query.py
+++ b/factsheet/tests/test_oekg_query.py
@@ -14,27 +14,38 @@ class TestOekgQuery(unittest.TestCase):
         self.oekg_query = OekgQuery()
         self.oekg_query.oekg = self.oekg_mock
 
-    def test_get_related_scenarios_where_table_is_input_dataset(self):
-        # Set up mock triples for testing
-        triples = [
-            (URIRef("scenario1"), RDF.type, namespaces.OEO.OEO_00000365),
-            (URIRef("scenario1"), namespaces.OEO.RO_0002233, URIRef("input_ds_uid")),
-            (URIRef("input_ds_uid"), namespaces.OEO["has_iri"], Literal("test_table")),
-            (URIRef("scenario2"), RDF.type, namespaces.OEO.OEO_00000365),
-            (URIRef("scenario2"), namespaces.OEO.RO_0002233, URIRef("input_ds_uid")),
-            (URIRef("input_ds_uid"), namespaces.OEO["has_iri"], Literal("test_table")),
-        ]
+    def test_with_real_graph(self):
+        """
+        This test uses a real RDF graph to test the functionality of the
+        OekgQuery class instead of mocking it. During writing the test i noticed
+        that there ia workarounds hassle involved when testing graphs with
+        multiple values.
 
-        self.oekg_mock.triples.return_value = triples
+        The method get_related_scenarios_where_table_is_input_dataset is checked
+        if correctly retrieves scenarios where a specific table is listed as an
+        input dataset.
+        """
+        g = Graph()
 
-        # Call the method being tested
-        result = self.oekg_query.get_related_scenarios_where_table_is_input_dataset(
-            "test_table"
-        )
+        iri = "dataedit/view/scenario/test_table"
+        bundle = URIRef("bundle1")
+        scenario1 = URIRef("scenario1")
+        scenario2 = URIRef("scenario2")
+        input1 = URIRef("input1")
+        input2 = URIRef("input2")
 
-        # Assert the expected result
-        expected_result = {URIRef("scenario1"), URIRef("scenario2")}
-        self.assertEqual(result, expected_result)
+        g.add((bundle, RDF.type, namespaces.OEO.OEO_00010252))
+        g.add((bundle, namespaces.OEKG["has_scenario"], scenario1))
+        g.add((bundle, namespaces.OEKG["has_scenario"], scenario2))
+        g.add((scenario1, namespaces.OEO.RO_0002233, input1))
+        g.add((scenario2, namespaces.OEO.RO_0002233, input2))
+        g.add((input1, namespaces.OEO["has_iri"], Literal(iri)))
+        g.add((input2, namespaces.OEO["has_iri"], Literal(iri)))
+
+        self.oekg_query.oekg = g
+
+        result = self.oekg_query.get_related_scenarios_where_table_is_input_dataset(iri)
+        self.assertEqual(result, {scenario1, scenario2})
 
     def test_get_scenario_acronym(self):
         # Set up mock triples for testing

--- a/factsheet/tests/test_serialize_table_iri.py
+++ b/factsheet/tests/test_serialize_table_iri.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+
+from factsheet.oekg.filters import OekgQuery
+
+
+class OekgQueryTests(TestCase):
+    def setUp(self):
+        self.query = OekgQuery()
+
+    def test_serialize_table_iri_internal_urls(self):
+        cases = [
+            ("dataedit/view/scenario/test_scenario", "scenario/test_scenario"),
+            (
+                "https://openenergyplatform.org/dataedit/view/scenario/test_scenario",
+                "scenario/test_scenario",
+            ),
+            (
+                "https://databus.openenergyplatform.org/dataedit/view/scenario/test_scenario",  # noqa E501
+                "scenario/test_scenario",
+            ),
+            (
+                "http://example.com/dataedit/view/scenario/another_test",
+                "scenario/another_test",
+            ),
+        ]
+
+        for iri, expected in cases:
+            with self.subTest(iri=iri):
+                result = self.query.serialize_table_iri(iri)
+                self.assertEqual(result, expected)
+
+    def test_serialize_table_iri_external_urls(self):
+        cases = [
+            "https://databus.openenergyplatform.org/koubaa/LLEC_Dataset/WS_23_24",
+            "urn:example:dataset:abc",
+            "",
+            "just-a-string",
+        ]
+
+        for iri in cases:
+            with self.subTest(iri=iri):
+                result = self.query.serialize_table_iri(iri)
+                self.assertEqual(result, "")

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -2,8 +2,12 @@
 
 ## Changes
 
+- Update test related to oekg queries and avoide using Mocks to keep tests simpler and more realistic by using actual rdflib Graph [(#1980)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1980)
+
 ## Features
 
 ## Bugs
+
+- Fix the table iri serialized, which now supports external urls stored in the oekg (e.g. When scenarios link to external datasets). External datasets are ignored and return a empty string to avoid exceptions [(#1980)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1980)
 
 ## Documentation updates


### PR DESCRIPTION
## Summary of the discussion

Fix linking to scenario bundles from table detail pages in the scenario topic & enhance test implementation.

## Type of change (CHANGELOG.md)

### Changes

- Update test related to oekg queries and avoide using Mocks to keep tests simpler and more realistic by using actual rdflib Graph [(#1980)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1980)

### Bugs

- Fix the table iri serialized, which now supports external urls stored in the oekg (e.g. When scenarios link to external datasets). External datasets are ignored and return a empty string to avoid exceptions [(#1980)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1980)

## Workflow checklist

### Automation

Closes #1979

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
