### PR TITLE
docker compose: dont expose ports outside of internal network (except…

### DIFF
--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -42,6 +42,7 @@ services:
         source: ..
         target: /home/appuser/app
     ports:
+      - "8000:8000" # expose web
       - "5678:5678" # add debugpy port
     command:
       - python

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -13,9 +13,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - pgdata:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+      - pgdata:/var/lib/postgresql/data    
 
   fuseki:
     image: stain/jena-fuseki:5.1.0
@@ -26,8 +24,6 @@ services:
     volumes:
       - fuseki_databases:/home/fuseki/databases
       # - ./fuseki/config:/home/fuseki/configuration
-    ports:
-      - "3030:3030"
     restart: unless-stopped
 
   web:
@@ -46,7 +42,6 @@ services:
         source: ..
         target: /home/appuser/app
     ports:
-      - "8000:8000"
       - "5678:5678" # add debugpy port
     command:
       - python
@@ -102,8 +97,6 @@ services:
       - type: bind
         source: ..
         target: /home/appuser/app
-    ports:
-      - "5173:5173"
     environment:
       CHOKIDAR_USEPOLLING: "false"
       HOST: "0.0.0.0"

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -14,6 +14,8 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - pgdata:/var/lib/postgresql/data    
+    ports:
+      - "${OEP_DEV_PORT_POSTGRES:-5432}:5432"
 
   fuseki:
     image: stain/jena-fuseki:5.1.0
@@ -42,8 +44,8 @@ services:
         source: ..
         target: /home/appuser/app
     ports:
-      - "8000:8000" # expose web
-      - "5678:5678" # add debugpy port
+      - "${OEP_DEV_PORT_WEB:-8000}:8000" # expose web
+      - "${OEP_DEV_PORT_DEBUGPY:-5678}:5678" # add debugpy port
     command:
       - python
       - -m

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -27,6 +27,8 @@ services:
       - fuseki_databases:/home/fuseki/databases
       # - ./fuseki/config:/home/fuseki/configuration
     restart: unless-stopped
+    ports:
+      - "${OEP_DEV_PORT_FUSEKI:-3030}:3030"
 
   web:
     build:

--- a/docs/installation/guides/installation-docker-dev.md
+++ b/docs/installation/guides/installation-docker-dev.md
@@ -45,6 +45,8 @@ You can set these environment variablesto override defaults:
 - `OEP_DEV_PORT_POSTGRES`: public port to postgres database, defaults to 5432
 - `OEP_DEV_PORT_WEB`: public port to web interface, defaults to 8000
 - `OEP_DEV_PORT_DEBUGPY`: public port to python debugger, defaults to 5678
+- `OEP_DEV_PORT_FUSEKI`: public port to fuseki server, defaults to 3030
+
 
 #### Docker compose command
 

--- a/docs/installation/guides/installation-docker-dev.md
+++ b/docs/installation/guides/installation-docker-dev.md
@@ -38,6 +38,14 @@ For development this also offers great tooling as you want to be able to use the
 
 The docker setup is created based on several configuration files and scripts. Together they enable us to install every module of the infrastructure with one single command. This section will give an overview of the setup and also provide commands and any pre-installation steps which will lead to a successful installation of the oeplatform especially and only for development purposes.
 
+#### Docker compose (optional) environment variables
+
+You can set these environment variablesto override defaults:
+
+- `OEP_DEV_PORT_POSTGRES`: public port to postgres database, defaults to 5432
+- `OEP_DEV_PORT_WEB`: public port to web interface, defaults to 8000
+- `OEP_DEV_PORT_DEBUGPY`: public port to python debugger, defaults to 5678
+
 #### Docker compose command
 
 !!! Info

--- a/oeplatform/securitysettings.py.default
+++ b/oeplatform/securitysettings.py.default
@@ -118,7 +118,5 @@ SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
 
 CORS_ORIGIN_ALLOW_ALL = True
 
-OEKG_SPARQL_ENDPOINT_URL = "http://localhost:3030/ds/sparql"
-
 DJANGO_VITE = {"default": {"dev_mode": os.environ.get("VITE_DEV_MODE", DEBUG)}}
 VITE_DEV_SERVER_URL = os.environ.get("VITE_DEV_SERVER_URL" "http://vite:5173")

--- a/oeplatform/securitysettings.py.default
+++ b/oeplatform/securitysettings.py.default
@@ -74,7 +74,7 @@ ONTOLOGY_ROOT = Path(BASE_DIR, ONTOLOGY_FOLDER)
 # For example scenario bundle data is stored there
 RDF_DATABASES = {
     "knowledge": {
-        "host": os.environ.get("RDF_DATABASE_HOST", "fuseki"),
+        "host": os.environ.get("RDF_DATABASE_HOST", "localhost"),
         "port": os.environ.get("RDF_DATABASE_PORT", "3030"),
         "name": os.environ.get("RDF_DATABASE_NAME", "ds"),
         "user": os.getenv("RDF_DATABASE_USER", "admin"),


### PR DESCRIPTION
It seems you don't need to expose ports in docker compose, unless you explicitly need them outside the docker compose network (like debugpy and, obviously, web 8000). 

With these changes. there is no more conflict with my local postgres and its still working.

@jh-RLI what do you think?