### PR TITLE
Avoid caching scenario bundles related http api endpoints.

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -449,7 +449,7 @@ class Table(APIView):
         """
         Creates a new table: physical table first, then metadata row.
         Applies embargo and permissions, and sets metadata if provided.
-        
+
         REST-API endpoint used to create a new table in the database.
         The table is created with the columns and constraints specified in the
         request body. The request body must contain a JSON object with the following
@@ -1644,6 +1644,7 @@ def oevkg_search(request):
 
 
 # Energyframework, Energymodel
+@method_decorator(never_cache, name="dispatch")
 class EnergyframeworkFactsheetListAPIView(generics.ListAPIView):
     """
     Used for the scenario bundles react app to be able to select a existing
@@ -1654,6 +1655,7 @@ class EnergyframeworkFactsheetListAPIView(generics.ListAPIView):
     serializer_class = EnergyframeworkSerializer
 
 
+@method_decorator(never_cache, name="dispatch")
 class EnergymodelFactsheetListAPIView(generics.ListAPIView):
     """
     Used for the scenario bundles react app to be able to select a existing
@@ -1664,6 +1666,7 @@ class EnergymodelFactsheetListAPIView(generics.ListAPIView):
     serializer_class = EnergymodelSerializer
 
 
+@method_decorator(never_cache, name="dispatch")
 class ScenarioDataTablesListAPIView(generics.ListAPIView):
     """
     Used for the scenario bundles react app to be able to populate

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -18,6 +18,8 @@
 
 - Add NFDI AAI based login system enabled by KIT´s RegApp for Single Sign on. This enables institutional and ORCID based social login additionally to the oeplatform internal login system [(#1896)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1896)
 
+- Avoid caching scenario bundle related http-api endpoints to keep data up to date. This effects the scenario top tables list as well as the model & framework factsheet list endpoints [(#2021)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2021)
+
 ## Bugs
 
 - Fix the table iri serialized, which now supports external urls stored in the oekg (e.g. When scenarios link to external datasets). External datasets are ignored and return a empty string to avoid exceptions [(#1980)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1980)


### PR DESCRIPTION

## Summary of the discussion

Caching is not optimal for the scenario bundles related api endpoints as data tends to be outdated. If one creates a new factsheet or uploads a table and want to add this to a scenario bundle, this is not possible without manually resetting the cache. 

This PR fixes that. Effects scenario topic and model and framework factsheet list api views

## Type of change (CHANGELOG.md)

### Features

- Avoid caching scenario bundle related http-api endpoints to keep data up to date. This effects the scenario top tables list as well as the model & framework factsheet list endpoints [(#2021)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2021)

## Workflow checklist

### Automation

Closes #2017

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
