### PR TITLE
Bugfix: generate readable table title from metadata

### DIFF
--- a/dataedit/helper.py
+++ b/dataedit/helper.py
@@ -12,12 +12,10 @@ from dataedit.models import PeerReview, Table
 ##############################################
 
 
-# TODO: Add py 3.10 feature to annotate the return type as str | None
-# Dev´s need to update python version first ...
-def read_label(table, oemetadata) -> str:
+def read_label_only_for_first_resource_element(table, oemetadata) -> str:
     """
-    Extracts the readable name from @comment and appends the real name in parens.
-    If comment is not a JSON-dictionary or does not contain a field 'Name' None
+    Extracts the readable name from oemetadata and appends the real name in parens.
+    If oemetadata is not a JSON-dictionary or does not contain a field 'Name' None
     is returned.
 
     :param table: Name to append
@@ -27,10 +25,10 @@ def read_label(table, oemetadata) -> str:
     :return: Readable name appended by the true table name as string or None
     """
     try:
-        if oemetadata.get("resources"):
-            return oemetadata.get("resources", {})["title"].strip() + " (" + table + ")"
-        # elif oemetadata.get("Title"):
-        #     return oemetadata["Title"].strip() + " (" + table + ")"
+        if oemetadata.get("resources")[0]:
+            return (
+                oemetadata.get("resources", [])[0]["title"].strip() + " (" + table + ")"
+            )
 
         else:
             return None
@@ -50,7 +48,9 @@ def get_readable_table_name(table_obj: Table) -> str:
     """
 
     try:
-        label = read_label(table_obj.name, table_obj.oemetadata)
+        label = read_label_only_for_first_resource_element(
+            table_obj.name, table_obj.oemetadata
+        )
     except Exception as e:
         raise e
     return label

--- a/dataedit/static/metaedit/metaedit.js
+++ b/dataedit/static/metaedit/metaedit.js
@@ -195,6 +195,17 @@ var MetaEdit = function(config) {
     }
 
     fillMissingFromSchema(config.schema.properties, json);
+    // Fix boundingBox in each resource if needed
+    if (Array.isArray(json.resources)) {
+      json.resources.forEach(resource => {
+        const bboxPath = resource?.spatial?.extent?.boundingBox;
+        if (!Array.isArray(bboxPath) || bboxPath.length !== 4 || bboxPath.some(val => typeof val !== 'number')) {
+          if (!resource.spatial) resource.spatial = {};
+          if (!resource.spatial.extent) resource.spatial.extent = {};
+          resource.spatial.extent.boundingBox = [0, 0, 0, 0]; // fallback valid default
+        }
+      });
+    }
 
     return json;
   }

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -30,6 +30,8 @@
 
 - Fixed a bug in the OEMetaBuilder tool which lead to incomplete editable metadata properties in the editor and incomplete auto-added values in the data schema section [(#1896)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1896)
 
+- Fix previously working functionality which extracts and show the table title form metadata instead of the filename when browsing table data. [(#2022)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2022)
+
 ## Documentation updates
 
 - Add documentation on how to use docker for development [(#1988)](https://github.com/OpenEnergyPlatform/oeplatform/pull/1988)


### PR DESCRIPTION
## Summary of the discussion

Fix functionality to read the human-readable table title form oemetadata if it exists. This will only look into the first resource element of an oemetadata document. 

It is triggered currently once the oemetadata is upadted / submitted.

## Type of change (CHANGELOG.md)

### Bugs

- Fix previously working functionality which extracts and show the table title form metadata instead of the filename when browsing table data. [(#2022)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2022)

## Workflow checklist

### Automation

Closes #2010

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
