### PR TITLE
Add ontop to docker services

### DIFF
--- a/docker/Dockerfile.ontop
+++ b/docker/Dockerfile.ontop
@@ -1,0 +1,8 @@
+# Use the official Ontop image as the base
+FROM ontop/ontop:latest
+
+# Copy the PostgreSQL JDBC driver into Ontop's lib directory
+COPY serviceConfigs/ontop/postgresql.jar /opt/ontop/lib/postgresql.jar
+
+# Ensure it's world-readable (optional but safe)
+# RUN chmod 644 /opt/ontop/lib/postgresql.jar

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -110,19 +110,21 @@ services:
     depends_on:
       - web
 
-  # ontop:
-  #   image: ontop/ontop-endpoint:latest
-  #   container_name: ontop
-  #   ports:
-  #     - "8080:8080"
-  #   environment:
-  #     ONTOP_MAPPING_FILE: "/opt/ontop/mapping.obda"
-  #     ONTOP_OWL_FILE: "/opt/ontop/ontology.owl"
-  #     ONTOP_PROPERTIES_FILE: "/opt/ontop/ontop.properties"
-  #   volumes:
-  #     - ./ontop:/opt/ontop  # Mount your .obda, .owl, and .properties files here
-  #   depends_on:
-  #     - postgres
+  ontop:
+    build:
+      context: .
+      dockerfile: Dockerfile.ontop
+    container_name: ontop
+    ports:
+      - "8080:8080"
+    environment:
+      ONTOP_MAPPING_FILE: "/opt/ontop-config/mapping.obda"
+      ONTOP_OWL_FILE: "/opt/ontop-config/ontology.owl"
+      ONTOP_PROPERTIES_FILE: "/opt/ontop-config/ontop.properties"
+    volumes:
+      - ./serviceConfigs/ontop:/opt/ontop-config
+    depends_on:
+      - postgres
 
   lookup:
     restart: unless-stopped

--- a/docker/serviceConfigs/ontop/README.md
+++ b/docker/serviceConfigs/ontop/README.md
@@ -1,0 +1,7 @@
+# Complete ontop setup
+
+Download the database JDBC driver for ontop:
+
+- <https://jdbc.postgresql.org/>
+
+Add the file postgresql.jar to this directory.

--- a/docker/serviceConfigs/ontop/mapping.obda
+++ b/docker/serviceConfigs/ontop/mapping.obda
@@ -1,0 +1,18 @@
+[PrefixDeclaration]
+:           http://example.org/voc#
+owl:        http://www.w3.org/2002/07/owl#
+rdf:        http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xml:        http://www.w3.org/XML/1998/namespace
+xsd:        http://www.w3.org/2001/XMLSchema#
+foaf:       http://xmlns.com/foaf/0.1/
+obda:       https://w3id.org/obda/vocabulary#
+rdfs:       http://www.w3.org/2000/01/rdf-schema#
+oeo:        https://openenergyplatform.org/ontology/oeo/
+oekg:       http://openenergy-platform.org/ontology/oeo/oekg/
+llc:        https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/
+
+[MappingDeclaration] @collection [[
+
+
+
+]]

--- a/docker/serviceConfigs/ontop/ontology.owl
+++ b/docker/serviceConfigs/ontop/ontology.owl
@@ -1,0 +1,12 @@
+@prefix : <http://example.org/ontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://example.org/ontology> a owl:Ontology .
+
+:Person a owl:Class .
+:hasName a owl:DatatypeProperty ;
+         rdfs:domain :Person ;
+         rdfs:range xsd:string .

--- a/docker/serviceConfigs/ontop/ontop.properties
+++ b/docker/serviceConfigs/ontop/ontop.properties
@@ -1,0 +1,4 @@
+jdbc.url=jdbc:postgresql://postgres:5432/oedb
+jdbc.user=postgres
+jdbc.password=postgres
+jdbc.driver=org.postgresql.Driver

--- a/docs/installation/guides/installation-docker-dev.md
+++ b/docs/installation/guides/installation-docker-dev.md
@@ -35,6 +35,10 @@ You can set these environment variablesto override defaults:
 - `OEP_DEV_PORT_FUSEKI`: public port to fuseki server, defaults to 3030
 - `OEP_DEV_PORT_VITE`: public vite JavaScript server port, defaults to 5173
 
+#### Setup ontop service
+
+The ontop service requires a special database driver which must be [downloaded manually first](./setuo-ontop.md).
+
 #### Docker compose command
 
 !!! Info

--- a/docs/installation/guides/installation.md
+++ b/docs/installation/guides/installation.md
@@ -6,9 +6,9 @@ Below we describe the manual installation of the oeplatform code and infrastruct
     We also support [docker](https://www.docker.com/) users by providing basic oeplatform-webapp and database images . This brings an easy setup which provides an installed and ready to use locally oeplatform and additional databases.
     To support developers with getting started with the initial setup which provides a pre configured complete oeplatform software infrastructure with a docker compose setup that installs all components of the infrastructure using containers run locally in a shared virtual network. By adding convince functionality to the setup we enhance the developer experience to support the development.
 
-    We provide 2 [docker container images](https://docs.docker.com/get-started/#what-is-a-container-image) (OEP-website and OEP-database). The images are updated & published with each release. They can be pulled from [GitHub packages](https://github.com/OpenEnergyPlatform/oeplatform/pkgs/container/oeplatform).
+    [Find the installation instructions that get you started with development here](./installation-docker-dev.md)
 
-    [Here you can find instructions on how to install the docker images.](https://github.com/OpenEnergyPlatform/oeplatform/tree/develop/docker)
+    [Find the (old) instructions related to our docker image mainly used for testing as part of the CI](../../../docker/README.md)
 
 !!! danger
     Currently the docker based installation does not cover the installation of the additional database `jenna-fuseki` a triple store that stores graph data used in some of our features.

--- a/docs/installation/guides/setuo-ontop.md
+++ b/docs/installation/guides/setuo-ontop.md
@@ -1,0 +1,15 @@
+# Setup ontop service
+
+The ontop service is mainly use as enabling technology for the quantitative scenario comparison as it enables SPARQL queries on SQL databases using semantic mappings ontop on the "normal" sql like table definition.
+
+## Installation
+
+We offer the pre-configured ontop service as part of the OEP-docker setup for development. It comes with a empty semantic mapping template which can be extended based on the user needs. You still need to download the JDBC database driver to enable connection to the postgresql database OEDB.
+
+Once you downloaded the driver make sure it is available in the ontop config directory and only then build the ontop service using docker.
+
+Download the database JDBC driver for ontop:
+
+- <https://jdbc.postgresql.org/>
+
+Add the file postgresql.jar to this directory.


### PR DESCRIPTION
## Summary of the discussion

Ontop is used for the quantitative scenario comparison and should be installed when composing the docker setup.

## Type of change (CHANGELOG.md)

### Features

- Enhance the docker developer setup by adding the missing ontop service which is the backend for the scenario comparison on the oeplatform [(#2028)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2028)

### Documentation updates

- Add documentation on how to setup ontop-vkg service [#2028](https://github.com/OpenEnergyPlatform/oeplatform/pull/2028)

## Workflow checklist

### Automation

Closes #2001 

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
