### PR TITLE
feat(api): harden the bulk upload CSV contract (#2362)

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -28,6 +28,7 @@ import io
 import json
 import logging
 import re
+from collections import Counter
 from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, cast
@@ -1881,6 +1882,8 @@ def _read_csv_header(stream) -> tuple[bytes, bytes]:
             raise APIError("CSV header line too long", 400)
     if not buffer:
         raise APIError("Bulk upload requires a non-empty CSV body", 400)
+    if buffer.startswith(b"\xef\xbb\xbf"):  # strip UTF-8 BOM (e.g. Excel exports)
+        buffer = buffer[3:]
     header, _sep, remainder = buffer.partition(b"\n")
     return header.rstrip(b"\r"), remainder
 
@@ -1896,12 +1899,36 @@ def _parse_bulk_upload_columns(
     columns = [c.strip() for c in columns if c.strip()]
     if not columns:
         raise APIError("CSV header contains no column names", 400)
-    table_columns = set(describe_columns(table_obj).keys())
+
+    duplicates = sorted(c for c, n in Counter(columns).items() if n > 1)
+    if duplicates:
+        raise APIError(
+            "CSV header contains duplicate column names: %s" % ", ".join(duplicates),
+            400,
+        )
+
+    table_columns = describe_columns(table_obj)
     unknown = [c for c in columns if c not in table_columns]
     if unknown:
         raise APIError(
             "CSV header names columns that do not exist in table '%s': %s"
             % (table_obj.name, ", ".join(unknown)),
+            400,
+        )
+
+    # NOT NULL columns without a default must be present in the CSV,
+    # otherwise the upload is doomed - reject before streaming the body
+    missing_required = sorted(
+        name
+        for name, info in table_columns.items()
+        if name not in columns
+        and not info.get("is_nullable")
+        and not info.get("column_default")
+    )
+    if missing_required:
+        raise APIError(
+            "CSV header is missing required columns (NOT NULL without default): %s"
+            % ", ".join(missing_required),
             400,
         )
     return columns
@@ -1930,11 +1957,14 @@ def bulk_upload_csv(table_obj: Table, stream, delimiter_name: str | None) -> int
     # identifiers are safe: whitelisted against the table's actual columns
     column_list = ", ".join('"%s"' % c.replace('"', '""') for c in columns)
     sa_table = table_obj.get_oedb_table_proxy(user=None)._main_table.get_sa_table()
-    copy_sql = 'COPY "%s"."%s" (%s) FROM STDIN WITH (FORMAT csv, DELIMITER \'%s\')' % (
-        sa_table.schema,
-        sa_table.name,
-        column_list,
-        delimiter,
+    # FORCE_NULL on all uploaded columns: an empty field is NULL whether
+    # quoted or not. Deliberate deviation from COPY's native CSV rule
+    # (quoted "" = empty string) - many writers quote every field and would
+    # silently store empty strings instead of NULLs otherwise.
+    copy_sql = (
+        'COPY "%s"."%s" (%s) FROM STDIN WITH '
+        "(FORMAT csv, DELIMITER '%s', FORCE_NULL (%s))"
+        % (sa_table.schema, sa_table.name, column_list, delimiter, column_list)
     )
 
     engine = _get_engine()
@@ -1949,14 +1979,33 @@ def bulk_upload_csv(table_obj: Table, stream, delimiter_name: str | None) -> int
         connection.commit()
     except psycopg2.Error as e:
         connection.rollback()
-        raise APIError(
-            "Bulk upload failed, nothing was inserted: %s"
-            % (getattr(e, "pgerror", None) or str(e)).strip(),
-            400,
-        )
+        raise APIError(_bulk_upload_error_message(e), 400)
     finally:
         connection.close()
     return row_count
+
+
+def _bulk_upload_error_message(e: psycopg2.Error) -> str:
+    """Data-level error message with the CSV location - never raw SQL,
+    server context dumps, or internal paths."""
+    diag = getattr(e, "diag", None)
+    primary = getattr(diag, "message_primary", None)
+    if not primary:
+        # no server diagnostics (e.g. connection lost mid-COPY): str(e) may
+        # contain socket paths or other internals - keep it generic instead
+        primary = "a database error occurred"
+    primary = primary.strip().splitlines()[0]
+    context = getattr(diag, "context", None) or ""
+    location = ""
+    match = re.search(r"COPY [^,]+, line (\d+)(?:, column ([^:]+))?", context)
+    if match:
+        # +1 because postgres counts data lines and the CSV's line 1 is
+        # the header (which never reaches COPY)
+        location = " (CSV line %d" % (int(match.group(1)) + 1)
+        if match.group(2):
+            location += ", column %s" % match.group(2).strip()
+        location += ")"
+    return "Bulk upload failed, nothing was inserted: %s%s" % (primary, location)
 
 
 def has_table(request: dict, context: dict | None = None) -> bool:

--- a/api/tests/test_bulk_upload.py
+++ b/api/tests/test_bulk_upload.py
@@ -117,6 +117,69 @@ class TestBulkUpload(APITestCaseWithTable):
     def test_nonexistent_table_rejected(self):
         self.bulk_upload("id\n1\n", table="no_such_table", exp_code=404)
 
+    def test_column_order_is_free(self):
+        self.bulk_upload("name,id\nswapped,7\n", exp_code=201)
+        rows = self.get_rows()
+        self.assertEqual(rows[0]["id"], 7)
+        self.assertEqual(rows[0]["name"], "swapped")
+
+    def test_duplicate_header_columns_rejected(self):
+        result = self.bulk_upload("id,name,name\n1,x,y\n", exp_code=400)
+        self.assertIn("name", json.dumps(result))
+        self.assertEqual(self.get_rows(), [])
+
+    def test_missing_required_column_rejected(self):
+        required_table = "test_table_required"
+        self.create_table(
+            structure={
+                "columns": [
+                    {"name": "id", "data_type": "bigserial", "is_nullable": False},
+                    {
+                        "name": "req_col",
+                        "data_type": "character varying",
+                        "is_nullable": False,
+                        "character_maximum_length": 50,
+                    },
+                    {
+                        "name": "opt_col",
+                        "data_type": "character varying",
+                        "is_nullable": True,
+                        "character_maximum_length": 50,
+                    },
+                ]
+            },
+            table=required_table,
+        )
+        # without req_col: rejected before streaming, names the column
+        result = self.bulk_upload(
+            "id,opt_col\n1,x\n", table=required_table, exp_code=400
+        )
+        self.assertIn("req_col", json.dumps(result))
+        # with req_col (id omitted is fine - bigserial has a default): accepted
+        self.bulk_upload("req_col\nfilled\n", table=required_table, exp_code=201)
+        self.drop_table(table=required_table)
+
+    def test_bom_header_parses(self):
+        self.bulk_upload("\ufeffid,name\n1,bommed\n", exp_code=201)
+        self.assertEqual(self.get_rows()[0]["name"], "bommed")
+
+    def test_empty_fields_are_null_quoted_or_not(self):
+        self.bulk_upload('id,name,address\n1,,""\n', exp_code=201)
+        row = self.get_rows()[0]
+        self.assertIsNone(row["name"])  # unquoted empty field
+        self.assertIsNone(row["address"])  # quoted empty field (FORCE_NULL)
+
+    def test_error_names_csv_line_and_column_without_internals(self):
+        result = self.bulk_upload("id,name\n1,ok\nboom,bad\n", exp_code=400)
+        message = json.dumps(result)
+        self.assertIn("line 3", message)  # header is line 1, bad row is line 3
+        self.assertIn("id", message)
+        self.assertIn("boom", message)  # the offending value helps debugging
+        self.assertNotIn("Traceback", message)
+        self.assertNotIn("COPY ", message)  # no raw SQL / context dump
+        self.assertNotIn("STDIN", message)
+        self.assertEqual(self.get_rows(), [])
+
     def test_no_journal_rows_written(self):
         self.bulk_upload("id,name\n1,x\n2,y\n", exp_code=201)
         engine = _get_engine()

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,6 +13,13 @@ SPDX-License-Identifier: CC0-1.0
 
 ### Features
 
+- Harden the bulk upload CSV contract: header preflight rejects duplicate,
+  unknown, and missing required (NOT NULL without default) columns before the
+  body streams; a UTF-8 BOM is stripped; empty fields are always NULL whether
+  quoted or not; failure responses carry the CSV line number and column with the
+  database's data-level message and never internal details.
+  [(#2362)](https://github.com/OpenEnergyPlatform/oeplatform/issues/2362)
+
 - New bulk upload endpoint
   `POST /api/v0/tables/<table>/bulk-upload?delimiter=comma|semicolon|tab`:
   streams a CSV request body directly into the table via PostgreSQL COPY for


### PR DESCRIPTION
## Summary of the discussion

This PR stacks ontop of https://github.com/OpenEnergyPlatform/oeplatform/pull/2364 wait until its merged and rebase this PR.

Part of #2362 (Slice 3 — CSV contract hardening). Implements the explicit
CSV contract on top of the bulk upload tracer bullet:

- **Header preflight, before the body streams**: duplicate column names,
  names not in the table, and missing required columns (NOT NULL without a
  default) are each rejected with a 400 naming the offending columns —
  a wrong column mapping costs milliseconds, not gigabytes.
- **UTF-8 BOM stripped** from the header, so Excel exports work unmodified.
- **Empty field = NULL, always** (`FORCE_NULL` on all uploaded columns),
  whether the field is quoted or not. Deliberate deviation from COPY's
  native CSV rule (quoted `""` = empty string): many common writers quote
  every field and would otherwise have their NULLs silently stored as empty
  strings. Do not "fix" this back to Postgres defaults — it would silently
  corrupt NULL handling for clients.
- **Sanitized, located errors**: failures return the database's data-level
  message plus the CSV line number (header-adjusted) and column — e.g.
  `invalid input syntax for type bigint: "boom" (CSV line 3, column id)` —
  and never raw SQL, server context dumps, or internal paths. When the
  server provides no diagnostics (connection lost mid-COPY), the message
  stays generic instead of echoing socket paths.

Known minor limitation (accepted): Postgres reports COPY *records*; a quoted
field containing embedded newlines earlier in the file shifts the reported
line relative to physical file lines.

**Tests:** module grows to 20 HTTP-seam tests — one per contract rule
(duplicates, missing-required incl. serial-default interplay, BOM, column
order freedom, quoted/unquoted NULL, line+column error shape with
no-internals assertions). Full suite green. Changelog entry included.

## Workflow checklist

### Automation

Closes #

Part of #2362

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
