### PR TITLE
feat(api): bulk upload id contract — sequence advance and sanity bound (#2362)

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -28,6 +28,7 @@ import io
 import json
 import logging
 import re
+from collections import Counter
 from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, cast
@@ -1881,6 +1882,8 @@ def _read_csv_header(stream) -> tuple[bytes, bytes]:
             raise APIError("CSV header line too long", 400)
     if not buffer:
         raise APIError("Bulk upload requires a non-empty CSV body", 400)
+    if buffer.startswith(b"\xef\xbb\xbf"):  # strip UTF-8 BOM (e.g. Excel exports)
+        buffer = buffer[3:]
     header, _sep, remainder = buffer.partition(b"\n")
     return header.rstrip(b"\r"), remainder
 
@@ -1896,12 +1899,36 @@ def _parse_bulk_upload_columns(
     columns = [c.strip() for c in columns if c.strip()]
     if not columns:
         raise APIError("CSV header contains no column names", 400)
-    table_columns = set(describe_columns(table_obj).keys())
+
+    duplicates = sorted(c for c, n in Counter(columns).items() if n > 1)
+    if duplicates:
+        raise APIError(
+            "CSV header contains duplicate column names: %s" % ", ".join(duplicates),
+            400,
+        )
+
+    table_columns = describe_columns(table_obj)
     unknown = [c for c in columns if c not in table_columns]
     if unknown:
         raise APIError(
             "CSV header names columns that do not exist in table '%s': %s"
             % (table_obj.name, ", ".join(unknown)),
+            400,
+        )
+
+    # NOT NULL columns without a default must be present in the CSV,
+    # otherwise the upload is doomed - reject before streaming the body
+    missing_required = sorted(
+        name
+        for name, info in table_columns.items()
+        if name not in columns
+        and not info.get("is_nullable")
+        and not info.get("column_default")
+    )
+    if missing_required:
+        raise APIError(
+            "CSV header is missing required columns (NOT NULL without default): %s"
+            % ", ".join(missing_required),
             400,
         )
     return columns
@@ -1930,11 +1957,14 @@ def bulk_upload_csv(table_obj: Table, stream, delimiter_name: str | None) -> int
     # identifiers are safe: whitelisted against the table's actual columns
     column_list = ", ".join('"%s"' % c.replace('"', '""') for c in columns)
     sa_table = table_obj.get_oedb_table_proxy(user=None)._main_table.get_sa_table()
-    copy_sql = 'COPY "%s"."%s" (%s) FROM STDIN WITH (FORMAT csv, DELIMITER \'%s\')' % (
-        sa_table.schema,
-        sa_table.name,
-        column_list,
-        delimiter,
+    # FORCE_NULL on all uploaded columns: an empty field is NULL whether
+    # quoted or not. Deliberate deviation from COPY's native CSV rule
+    # (quoted "" = empty string) - many writers quote every field and would
+    # silently store empty strings instead of NULLs otherwise.
+    copy_sql = (
+        'COPY "%s"."%s" (%s) FROM STDIN WITH '
+        "(FORMAT csv, DELIMITER '%s', FORCE_NULL (%s))"
+        % (sa_table.schema, sa_table.name, column_list, delimiter, column_list)
     )
 
     engine = _get_engine()
@@ -1949,14 +1979,33 @@ def bulk_upload_csv(table_obj: Table, stream, delimiter_name: str | None) -> int
         connection.commit()
     except psycopg2.Error as e:
         connection.rollback()
-        raise APIError(
-            "Bulk upload failed, nothing was inserted: %s"
-            % (getattr(e, "pgerror", None) or str(e)).strip(),
-            400,
-        )
+        raise APIError(_bulk_upload_error_message(e), 400)
     finally:
         connection.close()
     return row_count
+
+
+def _bulk_upload_error_message(e: psycopg2.Error) -> str:
+    """Data-level error message with the CSV location - never raw SQL,
+    server context dumps, or internal paths."""
+    diag = getattr(e, "diag", None)
+    primary = getattr(diag, "message_primary", None)
+    if not primary:
+        # no server diagnostics (e.g. connection lost mid-COPY): str(e) may
+        # contain socket paths or other internals - keep it generic instead
+        primary = "a database error occurred"
+    primary = primary.strip().splitlines()[0]
+    context = getattr(diag, "context", None) or ""
+    location = ""
+    match = re.search(r"COPY [^,]+, line (\d+)(?:, column ([^:]+))?", context)
+    if match:
+        # +1 because postgres counts data lines and the CSV's line 1 is
+        # the header (which never reaches COPY)
+        location = " (CSV line %d" % (int(match.group(1)) + 1)
+        if match.group(2):
+            location += ", column %s" % match.group(2).strip()
+        location += ")"
+    return "Bulk upload failed, nothing was inserted: %s%s" % (primary, location)
 
 
 def has_table(request: dict, context: dict | None = None) -> bool:

--- a/api/actions.py
+++ b/api/actions.py
@@ -1843,6 +1843,10 @@ def data_update(request: dict, context: dict) -> dict:
 BULK_UPLOAD_DELIMITERS = {"comma": ",", "semicolon": ";", "tab": "\t"}
 _BULK_UPLOAD_HEADER_CHUNK = 8192
 _BULK_UPLOAD_MAX_HEADER_BYTES = 1024 * 1024
+# generous sanity bound for explicitly uploaded ids: far above any real
+# dataset, far below the bigint maximum - a single upload must not be able
+# to exhaust a table's id sequence for every future insert
+BULK_UPLOAD_MAX_ID = 2**48
 
 
 class _ChainedStream:
@@ -1957,14 +1961,15 @@ def bulk_upload_csv(table_obj: Table, stream, delimiter_name: str | None) -> int
     # identifiers are safe: whitelisted against the table's actual columns
     column_list = ", ".join('"%s"' % c.replace('"', '""') for c in columns)
     sa_table = table_obj.get_oedb_table_proxy(user=None)._main_table.get_sa_table()
+    qualified_table = _quoted_table_name(sa_table)
     # FORCE_NULL on all uploaded columns: an empty field is NULL whether
     # quoted or not. Deliberate deviation from COPY's native CSV rule
     # (quoted "" = empty string) - many writers quote every field and would
     # silently store empty strings instead of NULLs otherwise.
     copy_sql = (
-        'COPY "%s"."%s" (%s) FROM STDIN WITH '
+        "COPY %s (%s) FROM STDIN WITH "
         "(FORMAT csv, DELIMITER '%s', FORCE_NULL (%s))"
-        % (sa_table.schema, sa_table.name, column_list, delimiter, column_list)
+        % (qualified_table, column_list, delimiter, column_list)
     )
 
     engine = _get_engine()
@@ -1972,17 +1977,82 @@ def bulk_upload_csv(table_obj: Table, stream, delimiter_name: str | None) -> int
     try:
         cursor = connection.cursor()
         try:
+            id_uploaded = ID_COLUMN_NAME in columns
+            pre_upload_max_id = None
+            if id_uploaded:
+                pre_upload_max_id = _bulk_upload_table_max_id(cursor, qualified_table)
             cursor.copy_expert(copy_sql, _ChainedStream(remainder, stream))
             row_count = cursor.rowcount
+            if id_uploaded:
+                _enforce_bulk_upload_id_contract(
+                    cursor, qualified_table, pre_upload_max_id
+                )
         finally:
             cursor.close()
         connection.commit()
+    except APIError:
+        connection.rollback()
+        raise
     except psycopg2.Error as e:
         connection.rollback()
         raise APIError(_bulk_upload_error_message(e), 400)
     finally:
         connection.close()
     return row_count
+
+
+def _quoted_table_name(sa_table: "SATable") -> str:
+    return '"%s"."%s"' % (
+        str(sa_table.schema).replace('"', '""'),
+        sa_table.name.replace('"', '""'),
+    )
+
+
+def _bulk_upload_table_max_id(cursor, qualified_table: str):
+    cursor.execute('SELECT max("%s") FROM %s' % (ID_COLUMN_NAME, qualified_table))
+    return cursor.fetchone()[0]
+
+
+def _enforce_bulk_upload_id_contract(
+    cursor, qualified_table: str, pre_upload_max_id
+) -> None:
+    """After an id-bearing upload: reject absurd ids, then advance the id
+    sequence past the loaded ids so subsequent row inserts cannot collide.
+
+    Runs inside the upload's transaction on the table's state including the
+    freshly copied rows. The sanity bound only judges ids introduced by THIS
+    upload (a pre-existing id above the bound must not block future uploads).
+    The sequence never moves backwards.
+    """
+    cursor.execute(
+        "SELECT pg_get_serial_sequence(%s, %s)", (qualified_table, ID_COLUMN_NAME)
+    )
+    row = cursor.fetchone()
+    sequence = row[0] if row else None
+    if not sequence:
+        return
+    max_id = _bulk_upload_table_max_id(cursor, qualified_table)
+    if max_id is None:
+        return
+    upload_raised_max = pre_upload_max_id is None or max_id > pre_upload_max_id
+    if max_id > BULK_UPLOAD_MAX_ID and upload_raised_max:
+        raise APIError(
+            "Bulk upload rejected: id %d exceeds the allowed maximum of %d - "
+            "ids this large would exhaust the table's id sequence"
+            % (max_id, BULK_UPLOAD_MAX_ID),
+            400,
+        )
+    # serialize concurrent bulk uploads on this sequence: setval is
+    # non-transactional, so two racing GREATEST reads could otherwise move
+    # the sequence backwards; the advisory lock is released on commit/rollback
+    cursor.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", (sequence,))
+    # sequence name comes from postgres itself (pg_get_serial_sequence),
+    # safe to interpolate; GREATEST keeps the sequence from moving backwards
+    cursor.execute(
+        "SELECT setval(%%s, GREATEST(%%s::bigint, (SELECT last_value FROM %s)))"
+        % sequence,
+        (sequence, max_id),
+    )
 
 
 def _bulk_upload_error_message(e: psycopg2.Error) -> str:

--- a/api/tests/test_bulk_upload.py
+++ b/api/tests/test_bulk_upload.py
@@ -180,6 +180,50 @@ class TestBulkUpload(APITestCaseWithTable):
         self.assertNotIn("STDIN", message)
         self.assertEqual(self.get_rows(), [])
 
+    def test_upload_without_id_column_uses_sequence(self):
+        self.bulk_upload("name\nfirst\nsecond\n", exp_code=201)
+        ids = sorted(r["id"] for r in self.get_rows())
+        self.assertEqual(len(set(ids)), 2)
+
+    def test_explicit_ids_then_row_upload_does_not_collide(self):
+        self.bulk_upload("id,name\n10,a\n11,b\n", exp_code=201)
+        # a subsequent Row Upload must get a fresh id beyond the bulk ids
+        self.api_req(
+            "post", path="rows/new", data={"query": {"name": "after"}}, exp_code=201
+        )
+        rows = self.get_rows()
+        self.assertEqual(len(rows), 3)
+        new_id = next(r["id"] for r in rows if r["name"] == "after")
+        self.assertGreater(new_id, 11)
+
+    def test_id_above_sanity_bound_rejected(self):
+        huge = 2**48 + 1
+        result = self.bulk_upload(f"id,name\n{huge},x\n", exp_code=400)
+        self.assertIn(str(2**48), json.dumps(result))  # error names the bound
+        self.assertEqual(self.get_rows(), [])  # fully rolled back
+
+    def test_preexisting_high_id_does_not_block_uploads(self):
+        # a huge id inserted via the row API (which enforces no bound) must
+        # not poison the table for id-bearing bulk uploads afterwards
+        huge = 2**48 + 5
+        self.api_req(
+            "post",
+            path="rows/new",
+            data={"query": {"id": huge, "name": "old"}},
+            exp_code=201,
+        )
+        self.bulk_upload("id,name\n1,new\n", exp_code=201)
+        self.assertEqual(len(self.get_rows()), 2)
+
+    def test_sequence_never_moves_backwards(self):
+        self.bulk_upload("id,name\n50,a\n", exp_code=201)
+        self.bulk_upload("id,name\n20,b\n", exp_code=201)  # lower ids afterwards
+        self.api_req(
+            "post", path="rows/new", data={"query": {"name": "c"}}, exp_code=201
+        )
+        ids = {r["name"]: r["id"] for r in self.get_rows()}
+        self.assertGreater(ids["c"], 50)
+
     def test_no_journal_rows_written(self):
         self.bulk_upload("id,name\n1,x\n2,y\n", exp_code=201)
         engine = _get_engine()

--- a/api/tests/test_bulk_upload.py
+++ b/api/tests/test_bulk_upload.py
@@ -117,6 +117,69 @@ class TestBulkUpload(APITestCaseWithTable):
     def test_nonexistent_table_rejected(self):
         self.bulk_upload("id\n1\n", table="no_such_table", exp_code=404)
 
+    def test_column_order_is_free(self):
+        self.bulk_upload("name,id\nswapped,7\n", exp_code=201)
+        rows = self.get_rows()
+        self.assertEqual(rows[0]["id"], 7)
+        self.assertEqual(rows[0]["name"], "swapped")
+
+    def test_duplicate_header_columns_rejected(self):
+        result = self.bulk_upload("id,name,name\n1,x,y\n", exp_code=400)
+        self.assertIn("name", json.dumps(result))
+        self.assertEqual(self.get_rows(), [])
+
+    def test_missing_required_column_rejected(self):
+        required_table = "test_table_required"
+        self.create_table(
+            structure={
+                "columns": [
+                    {"name": "id", "data_type": "bigserial", "is_nullable": False},
+                    {
+                        "name": "req_col",
+                        "data_type": "character varying",
+                        "is_nullable": False,
+                        "character_maximum_length": 50,
+                    },
+                    {
+                        "name": "opt_col",
+                        "data_type": "character varying",
+                        "is_nullable": True,
+                        "character_maximum_length": 50,
+                    },
+                ]
+            },
+            table=required_table,
+        )
+        # without req_col: rejected before streaming, names the column
+        result = self.bulk_upload(
+            "id,opt_col\n1,x\n", table=required_table, exp_code=400
+        )
+        self.assertIn("req_col", json.dumps(result))
+        # with req_col (id omitted is fine - bigserial has a default): accepted
+        self.bulk_upload("req_col\nfilled\n", table=required_table, exp_code=201)
+        self.drop_table(table=required_table)
+
+    def test_bom_header_parses(self):
+        self.bulk_upload("\ufeffid,name\n1,bommed\n", exp_code=201)
+        self.assertEqual(self.get_rows()[0]["name"], "bommed")
+
+    def test_empty_fields_are_null_quoted_or_not(self):
+        self.bulk_upload('id,name,address\n1,,""\n', exp_code=201)
+        row = self.get_rows()[0]
+        self.assertIsNone(row["name"])  # unquoted empty field
+        self.assertIsNone(row["address"])  # quoted empty field (FORCE_NULL)
+
+    def test_error_names_csv_line_and_column_without_internals(self):
+        result = self.bulk_upload("id,name\n1,ok\nboom,bad\n", exp_code=400)
+        message = json.dumps(result)
+        self.assertIn("line 3", message)  # header is line 1, bad row is line 3
+        self.assertIn("id", message)
+        self.assertIn("boom", message)  # the offending value helps debugging
+        self.assertNotIn("Traceback", message)
+        self.assertNotIn("COPY ", message)  # no raw SQL / context dump
+        self.assertNotIn("STDIN", message)
+        self.assertEqual(self.get_rows(), [])
+
     def test_no_journal_rows_written(self):
         self.bulk_upload("id,name\n1,x\n2,y\n", exp_code=201)
         engine = _get_engine()

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,6 +13,13 @@ SPDX-License-Identifier: CC0-1.0
 
 ### Features
 
+- Harden the bulk upload CSV contract: header preflight rejects duplicate,
+  unknown, and missing required (NOT NULL without default) columns before the
+  body streams; a UTF-8 BOM is stripped; empty fields are always NULL whether
+  quoted or not; failure responses carry the CSV line number and column with the
+  database's data-level message and never internal details.
+  [(#2362)](https://github.com/OpenEnergyPlatform/oeplatform/issues/2362)
+
 - New bulk upload endpoint
   `POST /api/v0/tables/<table>/bulk-upload?delimiter=comma|semicolon|tab`:
   streams a CSV request body directly into the table via PostgreSQL COPY for

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,6 +13,12 @@ SPDX-License-Identifier: CC0-1.0
 
 ### Features
 
+- Bulk upload id contract: after an id-bearing upload the table's id sequence is
+  advanced past the loaded ids (so subsequent row inserts cannot collide) and
+  never moves backwards; uploads introducing ids above a generous sanity bound
+  are rejected to protect the sequence for all writers of the table.
+  [(#2362)](https://github.com/OpenEnergyPlatform/oeplatform/issues/2362)
+
 - Harden the bulk upload CSV contract: header preflight rejects duplicate,
   unknown, and missing required (NOT NULL without default) columns before the
   body streams; a UTF-8 BOM is stripped; empty fields are always NULL whether


### PR DESCRIPTION
## Summary of the discussion

This PR stacks ontop of https://github.com/OpenEnergyPlatform/oeplatform/pull/2364 and https://github.com/OpenEnergyPlatform/oeplatform/pull/2366 wait until both are merged and rebase this PR.

Part of #2362 (Slice 4 — id contract). Clients may include or omit the id
column in a bulk upload:

- **Omitted**: the table's id sequence assigns ids as usual.
- **Included**: after COPY, still inside the upload's transaction, the id
  sequence is advanced to the table's `max(id)` (`setval(GREATEST(…))`), so
  a subsequent row-API insert can't hit a duplicate key. A
  `pg_advisory_xact_lock` on the sequence serializes concurrent uploads —
  `setval` is non-transactional, and two racing reads could otherwise move
  the sequence backwards. The sequence never moves backwards.
- **Sanity bound**: uploads that *raise* the table's `max(id)` above 2^48
  are rejected and rolled back, so one upload can't exhaust the sequence
  for every writer of a shared table. The bound judges only ids introduced
  by the upload itself — a pre-existing high id (the row API enforces no
  bound) does not poison the table for future bulk uploads.

The review pass caught two real defects before commit: the bound originally
judged the whole table's max(id) (a table with one legitimately huge
pre-existing id would reject every future id-bearing upload), and the
unserialized setval race. Both fixed and tested.

**Tests:** module grows to 25 HTTP-seam tests (no-id sequence assignment,
explicit-ids-then-row-insert collision check, bound rejection with
rollback, monotonic sequence, pre-existing-high-id regression). Full suite
green. Changelog entry included.

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
