### PR TITLE
Fix oemetaBuilder Download button (ReferenceError in strict mode)

### DIFF
--- a/dataedit/static/metaedit/metaedit.js
+++ b/dataedit/static/metaedit/metaedit.js
@@ -313,17 +313,17 @@ window.MetaEdit = function (config) {
       var json = config.editor.getValue();
       // create data url
       convertEmptyStringsToNull(json);
-      console.log(json);
       json = JSON.stringify(json, null, 1);
-      ((blob = new Blob([json], { type: "application/json" })),
-        (dataUrl = URL.createObjectURL(blob)));
+      var blob = new Blob([json], { type: "application/json" });
+      var dataUrl = URL.createObjectURL(blob);
       // create link
       var a = document.createElement("a");
       document.body.appendChild(a);
       // assign url and click
       a.style = "display: none";
       a.href = dataUrl;
-      a.download = config.table + ".metadata.json";
+      // config.table is empty in standalone mode; fall back to a generic name
+      a.download = (config.table || "oemetadata") + ".metadata.json";
       a.click();
       // cleanup
       URL.revokeObjectURL(dataUrl);

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -94,6 +94,10 @@ SPDX-License-Identifier: CC0-1.0
   reference to `TablePeerReviewContributorView`.
   [(#2360)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2350)
 
+- Fix the oemetaBuilder Download button, which did nothing due to a
+  `ReferenceError` under strict mode. The downloaded file now also gets a
+  sensible name in the standalone tool instead of `undefined.metadata.json`.
+
 ## Documentation updates
 
 - Updated the OE Family Steering Committee


### PR DESCRIPTION
## What

The **Download** button in the oemetaBuilder / MetaEdit tool did nothing and
logged an error to the console:

Uncaught ReferenceError: blob is not defined
at HTMLButtonElement.downloadMetadata (metaedit.js:318)



## Why

`metaedit.js` runs under `"use strict";`, and the download handler assigned
`blob` and `dataUrl` without declaring them. In strict mode, assigning to an
undeclared identifier throws a `ReferenceError`, so the handler aborted before
creating the download link. This affected **both** the standalone tool and the
per-table editor (the handler is shared).

## Changes

- Declare `blob` and `dataUrl` with `var`.
- Fall back to `oemetadata.metadata.json` when no table is attached — in
  standalone mode `config.table` is undefined, so downloads were named
  `undefined.metadata.json`.
- Remove a leftover `console.log` of the metadata on every download.

## Testing

- Standalone (`/dataedit/oemetabuilder/` — no table): Download now saves
  `oemetadata.metadata.json`, no console error.
- On an existing table: Download saves `<table>.metadata.json`.

## Notes / follow-ups (out of scope for this PR)

Spotted during review, intentionally not addressed here:
- Standalone **Submit** button still renders but has no valid save path
  (`config.columns` / `url_api_meta` absent) — should be hidden in standalone.
- `getErrorMsg` re-parses an already-parsed `responseJSON`, so submit errors
  always show a generic status text instead of the server's reason.
- ~260 lines are duplicated between the standalone and table init branches.
## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
