### PR TITLE
fix(dataedit): deterministic resource order in dataset metadata (#1971)

### DIFF
--- a/dataedit/models.py
+++ b/dataedit/models.py
@@ -487,10 +487,12 @@ class Dataset(models.Model):
         The list is never persisted on the dataset: tables own their
         resource metadata and every read assembles the current state, so
         dataset reads can not go stale after table metadata edits.
+
+        Ordered by table name, matching the dataset detail page.
         """
         return [
             table.oemetadata["resources"][0]
-            for table in self.tables.all()
+            for table in self.tables.order_by("name")
             if table.oemetadata and table.oemetadata.get("resources")
         ]
 

--- a/dataedit/tests/test_dataset_detail.py
+++ b/dataedit/tests/test_dataset_detail.py
@@ -122,9 +122,10 @@ class DatasetDetailTests(TestCase):
         self.assertEqual(response.status_code, 200)
         document = response.json()
         self.assertEqual(document["title"], "Detailed Dataset")
+        # resource_entries orders by table name
         self.assertEqual(
             [resource["name"] for resource in document["resources"]],
-            ["t_heat_published", "t_heat_draft"],
+            ["t_heat_draft", "t_heat_published"],
         )
 
     def test_created_dataset_document_conforms_to_oemetadata_spec(self):

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -116,6 +116,12 @@ SPDX-License-Identifier: CC0-1.0
   `ReferenceError` under strict mode. The downloaded file now also gets a
   sensible name in the standalone tool instead of `undefined.metadata.json`.
 
+- Fix nondeterministic resource order in the dataset metadata document: the
+  resources list assembled live from a dataset's member tables is now ordered by
+  table name (matching the dataset detail page) instead of database-dependent
+  order, which also made a dataset detail test flaky on CI.
+  ([#1971](https://github.com/OpenEnergyPlatform/oeplatform/issues/1971))
+
 ## Documentation updates
 
 - Updated the OE Family Steering Committee


### PR DESCRIPTION
Part of #2362 (Slice 4 — id contract). Clients may include or omit the id
column in a bulk upload:

Omitted: the table's id sequence assigns ids as usual.
Included: after COPY, still inside the upload's transaction, the id sequence is advanced to the table's max(id) (setval(GREATEST(…))), so a subsequent row-API insert can't hit a duplicate key. A pg_advisory_xact_lock on the sequence serializes concurrent uploads — setval is non-transactional, and two racing reads could otherwise move the sequence backwards. The sequence never moves backwards.
Sanity bound: uploads that raise the table's max(id) above 2^48 are rejected and rolled back, so one upload can't exhaust the sequence for every writer of a shared table. The bound judges only ids introduced by the upload itself — a pre-existing high id (the row API enforces no bound) does not poison the table for future bulk uploads.
The review pass caught two real defects before commit: the bound originally
judged the whole table's max(id) (a table with one legitimately huge
pre-existing id would reject every future id-bearing upload), and the
unserialized setval race. Both fixed and tested.

Tests: module grows to 25 HTTP-seam tests (no-id sequence assignment,
explicit-ids-then-row-insert collision check, bound rejection with
rollback, monotonic sequence, pre-existing-high-id regression). Full suite
green. Changelog entry included.