### PR TITLE
Fix four defects in the table-create and query paths

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -60,7 +60,7 @@ from sqlalchemy.sql.expression import Executable, Select
 
 import dataedit.metadata
 from api.bulk_upload_guard import BulkUploadStalled, default_stall_detector
-from api.error import APIError
+from api.error import APIError, reflectable_cause
 from api.parser import (
     get_column_definition_query,
     is_pg_qual,
@@ -1183,30 +1183,14 @@ def execute_sqla(query, cursor: AbstractCursor | Session) -> None:
                     params[key] = dialect._json_serializer(value)
         query = str(compiled)
         _execute(cursor, query, params)
-    except (psycopg2.DataError, exc.IdentifierError, psycopg2.IntegrityError) as e:
+    except exc.IdentifierError as e:
         raise APIError(str(e))
-    except psycopg2.InternalError as e:
-        if re.match(r".*Input geometry has unknown \(\d+\) SRID", str(e)):
-            # Return only SRID errors
-            raise APIError(str(e))
-        else:
-            raise e
-    except psycopg2.ProgrammingError as e:
-        if e.pgcode in [
-            "42703",  # undefined_column
-            "42883",  # undefined_function
-            "42P01",  # undefined_table
-            "42P02",  # undefined_parameter
-            "42704",  # undefined_object
-            "42804",  # datatype mismatch
-        ]:
-            # Return only `function does not exists` errors
-            raise APIError(e.diag.message_primary)
-        else:
-            raise e
-    except psycopg2.DatabaseError as e:
-        # Other DBAPIErrors should not be reflected to the client.
-        raise e
+    except psycopg2.Error as e:
+        cause = reflectable_cause(e)
+        if cause is None:
+            # Other DBAPIErrors should not be reflected to the client.
+            raise
+        raise APIError(cause)
     except Exception:
         raise
 

--- a/api/error.py
+++ b/api/error.py
@@ -4,6 +4,63 @@ SPDX-FileCopyrightText: 2025 Martin Glauer <https://github.com/MGlauer> © Otto-
 SPDX-License-Identifier: AGPL-3.0-or-later
 """  # noqa: 501
 
+import re
+
+import psycopg2
+
+# Postgres error codes whose message describes something wrong with the request
+# rather than with the server, and is therefore safe to show a client.
+_REFLECTABLE_PGCODES = frozenset(
+    {
+        "42703",  # undefined_column
+        "42704",  # undefined_object
+        "42804",  # datatype_mismatch
+        "42883",  # undefined_function
+        "42P01",  # undefined_table
+        "42P02",  # undefined_parameter
+    }
+)
+
+# PostGIS raises everything through the generic internal-error code (XX000),
+# which also covers genuine server faults, so its messages can only be
+# recognised by text. Every entry here is a deliberate decision to disclose a
+# specific message - do not widen this to "all internal errors".
+_REFLECTABLE_MESSAGES = (
+    re.compile(r"Input geometry has unknown \(\d+\) SRID"),
+    re.compile(r"could not parse proj string"),
+)
+
+
+def reflectable_cause(error: BaseException) -> str | None:
+    """The database's own reason for an error, if it is safe to show a client.
+
+    Returns None when the cause must stay internal, in which case the caller
+    keeps whatever generic message it already reports.
+
+    This is the single place that answers "may this cause be disclosed". Both
+    the query path and the table-create path consult it, so the decision does
+    not drift apart between them.
+    """
+
+    # SQLAlchemy wraps DBAPI errors; the driver error carries the diagnostics
+    error = getattr(error, "orig", error)
+
+    if isinstance(error, (psycopg2.DataError, psycopg2.IntegrityError)):
+        return str(error)
+
+    if isinstance(error, psycopg2.ProgrammingError):
+        if error.pgcode in _REFLECTABLE_PGCODES:
+            return error.diag.message_primary
+        return None
+
+    if isinstance(error, psycopg2.InternalError):
+        message = str(error)
+        if any(pattern.search(message) for pattern in _REFLECTABLE_MESSAGES):
+            return message
+        return None
+
+    return None
+
 
 class APIError(Exception):
     """Instances of APIError will be caught

--- a/api/parser.py
+++ b/api/parser.py
@@ -383,7 +383,7 @@ def parse_select(d: dict):
                     field = dict(type="column", column=field)
                 col = parse_expression(field)
                 if "as" in field:
-                    col.label(read_pgid(field["as"]))
+                    col = col.label(read_pgid(field["as"]))
                 L.append(col)
         if "from" in d:
             kwargs["from_obj"] = _parse_from_item(get_or_403(d, "from"))

--- a/api/parser.py
+++ b/api/parser.py
@@ -202,6 +202,22 @@ def parse_table_parts(
             else:
                 ccolumns = [constraint["constraint_parameter"]]
             constraints.append(UniqueConstraint(*ccolumns, **kwargs))
+        elif constraint_type == "foreign_key":
+            # Reject rather than silently drop: adding the constraint is a
+            # separate step, and the caller has to know that.
+            raise APIError(
+                "FOREIGN KEY is not supported when creating a table. Create the "
+                "table first, then add the constraint with a POST to the table "
+                "endpoint."
+            )
+        elif constraint_type == "check":
+            raise APIError("CHECK constraints are not supported.")
+        else:
+            raise APIError(
+                "Unsupported constraint_type: '%s'. Supported when creating a "
+                "table: PRIMARY KEY, UNIQUE."
+                % (constraint.get("constraint_type") or constraint.get("type"))
+            )
 
     # autogenerate id column if missing
     if "id" not in columns_by_name:

--- a/api/parser.py
+++ b/api/parser.py
@@ -540,6 +540,29 @@ def _parse_column(d: dict, mapper: dict | None = None):
                 return column(name)
 
 
+def _parse_geometry_type(modifier: str) -> "geoalchemy2.Geometry":
+    """Build a Geometry type from the contents of geometry(...).
+
+    The modifier is either a subtype ("Point") or a subtype and an SRID
+    ("Point,4326"). Passing the whole modifier as the subtype used to leave the
+    SRID at the library default, which rendered a third type-modifier value
+    that postgres happens to ignore - so the declared SRID landed by accident.
+    Name the two parts instead.
+    """
+
+    geometry_type, _, srid = modifier.partition(",")
+    type_kwargs = {"geometry_type": geometry_type.strip().upper()}
+
+    srid = srid.strip()
+    if srid:
+        try:
+            type_kwargs["srid"] = int(srid)
+        except ValueError:
+            raise APIError("Invalid SRID in geometry type: '%s'" % srid)
+
+    return geoalchemy2.Geometry(**type_kwargs)
+
+
 def _parse_type(dt_string, **kwargs):
     if isinstance(dt_string, dict):
         dt = _parse_type(
@@ -562,7 +585,7 @@ def _parse_type(dt_string, **kwargs):
         if match:
             dt_string = match.groups()[0]
             if dt_string.lower() == "geometry":
-                return geoalchemy2.Geometry(geometry_type=match.groups()[1]), False
+                return _parse_geometry_type(match.groups()[1]), False
             else:
                 dt_cardinality = map(int, match.groups()[1].replace(" ", "").split(","))
             dt, autoincrement = _parse_type(dt_string)

--- a/api/tests/test_regression/test_advanced_api_field_alias.py
+++ b/api/tests/test_regression/test_advanced_api_field_alias.py
@@ -1,0 +1,74 @@
+"""
+An "as" alias on a field in an advanced search request was parsed and then
+discarded, so the response named the column after the expression instead of
+after the alias.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from api.tests import APITestCaseWithTable
+
+
+class TestAdvancedApiFieldAlias(APITestCaseWithTable):
+    test_data = [{"name": "Hans"}, {"name": "Petra"}]
+
+    def _search(self, fields, exp_code=200):
+        return self.api_req(
+            "post",
+            path="/advanced/search",
+            data={
+                "query": {
+                    "fields": fields,
+                    "from": {"type": "table", "table": self.test_table},
+                }
+            },
+            exp_code=exp_code,
+        )
+
+    def _column_names(self, json_resp):
+        return [col[0] for col in json_resp["description"]]
+
+    def test_alias_on_function_field_names_the_column(self):
+        json_resp = self._search(
+            [
+                {
+                    "type": "function",
+                    "function": "upper",
+                    "operands": [{"type": "column", "column": "name"}],
+                    "as": "shouted",
+                }
+            ]
+        )
+
+        self.assertEqual(["shouted"], self._column_names(json_resp))
+
+    def test_alias_on_plain_column_field_names_the_column(self):
+        json_resp = self._search([{"type": "column", "column": "name", "as": "who"}])
+
+        self.assertEqual(["who"], self._column_names(json_resp))
+
+    def test_explicit_label_expression_still_names_the_column(self):
+        json_resp = self._search(
+            [
+                {
+                    "type": "label",
+                    "label": "shouted",
+                    "element": {
+                        "type": "function",
+                        "function": "upper",
+                        "operands": [{"type": "column", "column": "name"}],
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(["shouted"], self._column_names(json_resp))
+
+    def test_invalid_alias_is_rejected(self):
+        json_resp = self._search(
+            [{"type": "column", "column": "name", "as": 'not a "valid" id'}],
+            exp_code=400,
+        )
+
+        self.assertIn("Invalid identifier", json_resp["reason"])

--- a/api/tests/test_regression/test_database_error_causes.py
+++ b/api/tests/test_regression/test_database_error_causes.py
@@ -1,0 +1,136 @@
+"""
+Two paths dropped the database's own reason for a failure:
+
+- a failed table create answered "Could not create table <name>" and nothing
+  else, so an unusable column definition was undebuggable
+- a spatial query whose reference system arrived as a JSON string answered
+  "Invalid request", hiding PostGIS' "could not parse proj string '4326'"
+  (openego/ding0#405)
+
+Both now report the cause when it is safe to disclose, through the single
+policy in api.error.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from api.tests import APITestCase
+
+
+class TestTableCreateReportsCause(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.empty_test_schema()
+
+    def tearDown(self) -> None:
+        self.empty_test_schema()
+        super().tearDown()
+
+    def test_invalid_column_precision_reports_the_database_reason(self):
+        # numeric(1001) passes the parser and is rejected by postgres, so this
+        # exercises the DDL failure path rather than payload validation
+        json_resp = self.api_req(
+            "put",
+            "create_invalid_precision",
+            data={
+                "query": {
+                    "columns": [
+                        {"name": "id", "data_type": "bigint"},
+                        {"name": "value", "data_type": "numeric(1001)"},
+                    ]
+                }
+            },
+            params={"is_sandbox": True},
+            exp_code=400,
+        )
+
+        self.assertIn("Could not create table", json_resp["reason"])
+        self.assertIn("1001", json_resp["reason"])
+
+    def test_unusable_reason_still_reports_the_generic_message(self):
+        # a duplicate table name fails before any DDL runs, so there is no
+        # database cause to add and the message must stay as it was
+        self.create_table(table="create_duplicate_name")
+        json_resp = self.api_req(
+            "put",
+            "create_duplicate_name",
+            data={"query": {"columns": [{"name": "id", "data_type": "bigint"}]}},
+            params={"is_sandbox": True},
+            exp_code=409,
+        )
+
+        self.assertEqual("Table already exists", json_resp["reason"])
+
+
+class TestSpatialQueryReportsCause(APITestCase):
+    """The table needs a known SRID and at least one row, otherwise the
+    reprojection is never evaluated and no error surfaces."""
+
+    spatial_table = "transform_srid_arg"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.empty_test_schema()
+        self.create_table(
+            table=self.spatial_table,
+            structure={
+                "columns": [
+                    {"name": "id", "data_type": "bigint"},
+                    {"name": "geom", "data_type": "geometry(Point,3035)"},
+                ]
+            },
+            data=[{"geom": "SRID=3035;POINT(4038631 3111190)"}],
+        )
+
+    def tearDown(self) -> None:
+        self.empty_test_schema()
+        super().tearDown()
+
+    def _transform_with(self, srid, exp_code):
+        return self.api_req(
+            "post",
+            path="/advanced/search",
+            data={
+                "query": {
+                    "fields": [
+                        {
+                            "type": "label",
+                            "label": "wkt",
+                            "element": {
+                                "type": "function",
+                                "function": "ST_AsText",
+                                "operands": [
+                                    {
+                                        "type": "function",
+                                        "function": "ST_Transform",
+                                        "operands": [
+                                            {"type": "column", "column": "geom"},
+                                            {"type": "value", "value": srid},
+                                        ],
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                    "from": {"type": "table", "table": self.spatial_table},
+                }
+            },
+            exp_code=exp_code,
+        )
+
+    def test_reference_system_as_string_reports_the_proj_error(self):
+        # a string picks PostGIS' (geometry, to_proj text) overload, which tries
+        # to read "4326" as a projection definition
+        json_resp = self._transform_with("4326", exp_code=400)
+
+        self.assertIn("could not parse proj string", json_resp["reason"])
+        self.assertIn("4326", json_resp["reason"])
+
+    def test_reference_system_as_integer_succeeds(self):
+        json_resp = self._transform_with(4326, exp_code=200)
+
+        self.assertNotIn("reason", json_resp)
+        self.assertEqual(
+            ["wkt"], [col[0] for col in json_resp["content"]["description"]]
+        )
+        self.assertIn("POINT(5.97", json_resp["data"][0][0])

--- a/api/tests/test_regression/test_geometry_column_contract.py
+++ b/api/tests/test_regression/test_geometry_column_contract.py
@@ -1,0 +1,93 @@
+"""
+The contract for a geometry column, asserted through the HTTP surface:
+
+- it gets a GiST index automatically, which comes from GeoAlchemy2's
+  spatial_index default rather than from any code of ours - so a dependency
+  upgrade that changes that default must fail a test, not silently degrade
+  every new geo table
+- an SRID declared in the column type is the SRID registered on the Main Table
+
+Needs PostGIS; these tests fail against a plain postgres.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from api.tests import APITestCase
+
+
+class TestGeometryColumnContract(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.empty_test_schema()
+
+    def tearDown(self) -> None:
+        self.empty_test_schema()
+        super().tearDown()
+
+    def _create_with_geom(self, table, data_type):
+        self.create_table(
+            table=table,
+            structure={
+                "columns": [
+                    {"name": "id", "data_type": "bigint"},
+                    {"name": "geom", "data_type": data_type},
+                ]
+            },
+        )
+
+    def _geom_type(self, table):
+        json_resp = self.api_req(
+            "post", path="/advanced/get_columns", data={"query": {"table": table}}
+        )
+        columns = dict((col[0], col[1]) for col in json_resp["content"]["columns"])
+        return columns["geom"]
+
+    def _index_definitions(self, table):
+        described = self.api_req("get", table, auth=False)
+        return [index["indexdef"] for index in described["indexed"].values()]
+
+    def test_geometry_column_gets_a_gist_index(self):
+        self._create_with_geom("geom_indexed", "geometry(Point,4326)")
+
+        gist_indexes = [
+            definition
+            for definition in self._index_definitions("geom_indexed")
+            if "USING gist" in definition and "geom" in definition
+        ]
+        self.assertEqual(1, len(gist_indexes), self._index_definitions("geom_indexed"))
+
+    def test_declared_srid_is_registered_on_the_table(self):
+        self._create_with_geom("geom_with_srid", "geometry(Point,4326)")
+
+        self.assertEqual("geometry(Point,4326)", self._geom_type("geom_with_srid"))
+
+    def test_declared_subtype_is_registered_on_the_table(self):
+        self._create_with_geom("geom_multipolygon", "geometry(MultiPolygon,3035)")
+
+        self.assertEqual(
+            "geometry(MultiPolygon,3035)", self._geom_type("geom_multipolygon")
+        )
+
+    def test_geometry_without_srid_registers_as_unknown(self):
+        self._create_with_geom("geom_without_srid", "geometry(Point)")
+
+        self.assertEqual("geometry(Point)", self._geom_type("geom_without_srid"))
+
+    def test_invalid_srid_is_rejected(self):
+        json_resp = self.api_req(
+            "put",
+            "geom_bad_srid",
+            data={
+                "query": {
+                    "columns": [
+                        {"name": "id", "data_type": "bigint"},
+                        {"name": "geom", "data_type": "geometry(Point,not_a_srid)"},
+                    ]
+                }
+            },
+            params={"is_sandbox": True},
+            exp_code=400,
+        )
+
+        self.assertIn("Invalid SRID", json_resp["reason"])

--- a/api/tests/test_regression/test_table_create_constraint_rejection.py
+++ b/api/tests/test_regression/test_table_create_constraint_rejection.py
@@ -1,0 +1,95 @@
+"""
+Creating a table with a FOREIGN KEY or CHECK constraint returned 201 and
+silently dropped the constraint, because the create path only ever recognised
+PRIMARY KEY and UNIQUE and fell through for everything else.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from api.actions import has_table
+from api.tests import APITestCase
+
+
+class TestTableCreateConstraintRejection(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # each test creates its own table; keep the module order-independent so
+        # one failure cannot cascade into the next test
+        self.empty_test_schema()
+
+    def tearDown(self) -> None:
+        self.empty_test_schema()
+        super().tearDown()
+
+    def _structure(self, constraints):
+        return {
+            "columns": [
+                {"name": "id", "data_type": "bigint"},
+                {"name": "other_id", "data_type": "bigint"},
+            ],
+            "constraints": constraints,
+        }
+
+    def _create_expecting_rejection(self, table, constraints):
+        json_resp = self.api_req(
+            "put",
+            table,
+            data={"query": self._structure(constraints)},
+            params={"is_sandbox": True},
+            exp_code=400,
+        )
+        # a rejected create must not leave a Main Table behind
+        self.assertFalse(has_table({"table": table}))
+        return json_resp
+
+    def test_foreign_key_is_rejected_and_points_at_the_alter_path(self):
+        json_resp = self._create_expecting_rejection(
+            "reject_foreign_key",
+            [
+                {
+                    "constraint_type": "FOREIGN KEY",
+                    "columns": ["other_id"],
+                    "refcolumns": ["id"],
+                }
+            ],
+        )
+
+        self.assertIn("FOREIGN KEY", json_resp["reason"])
+        self.assertIn("add the constraint", json_resp["reason"])
+
+    def test_check_is_rejected_as_unsupported(self):
+        json_resp = self._create_expecting_rejection(
+            "reject_check",
+            [{"constraint_type": "CHECK", "constraint_parameter": "id > 0"}],
+        )
+
+        self.assertIn("CHECK", json_resp["reason"])
+
+    def test_unknown_constraint_type_is_rejected_naming_what_was_sent(self):
+        json_resp = self._create_expecting_rejection(
+            "reject_unknown",
+            [{"constraint_type": "EXCLUDE", "columns": ["id"]}],
+        )
+
+        self.assertIn("EXCLUDE", json_resp["reason"])
+        self.assertIn("PRIMARY KEY, UNIQUE", json_resp["reason"])
+
+    def test_supported_constraints_still_create_the_table(self):
+        table = "accept_pk_and_unique"
+        self.create_table(
+            table=table,
+            structure=self._structure(
+                [
+                    {"constraint_type": "PRIMARY KEY", "constraint_parameter": "id"},
+                    {"constraint_type": "UNIQUE", "columns": ["other_id"]},
+                ]
+            ),
+        )
+
+        described = self.api_req("get", table, auth=False)
+        constraint_types = {
+            c["constraint_type"] for c in described["constraints"].values()
+        }
+        self.assertIn("PRIMARY KEY", constraint_types)
+        self.assertIn("UNIQUE", constraint_types)

--- a/dataedit/models.py
+++ b/dataedit/models.py
@@ -41,7 +41,7 @@ from django.urls import reverse
 from django.utils import timezone
 from omi.license import LicenseError, validate_oemetadata_licenses
 
-from api.error import APIError
+from api.error import APIError, reflectable_cause
 from api.parser import parse_table_parts
 from dataedit.utils import get_badge_icon_path, validate_badge_name_match
 from login.permissions import ADMIN_PERM, NO_PERM
@@ -278,7 +278,13 @@ class Table(Tagable):
                 # delete django object which will also automatically clean up
                 # left over oedb tables
                 table_obj.delete()
-            raise APIError(f"Could not create table {name}")
+            # the full exception stays in the log either way; the client only
+            # gets the cause when it is safe to disclose
+            cause = reflectable_cause(exc)
+            message = f"Could not create table {name}"
+            if cause:
+                message = f"{message}: {cause}"
+            raise APIError(message)
 
         return table_obj
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -202,6 +202,34 @@ SPDX-License-Identifier: CC0-1.0
   page); pinned to the last known-good release until it is fixed upstream
   ([vitejs/vite#22499](https://github.com/vitejs/vite/issues/22499)).
 
+- Fix the `"as"` alias on fields of an advanced search request being parsed and
+  then discarded: a labelled expression came back named after the expression
+  (`ST_AsText_1`) or after its source column, breaking any client that keys
+  results by column name. An invalid alias is now rejected instead of silently
+  falling back to a generated name.
+
+- Creating a table with a `FOREIGN KEY` or `CHECK` constraint no longer returns
+  201 while silently dropping the constraint. The create path now rejects
+  constraint types it cannot apply, naming the supported route: foreign keys are
+  added after creation through the table endpoint, check constraints are not
+  supported.
+
+- Failed table creations and failed spatial queries now report the database's
+  own reason instead of `Could not create table <name>` and `Invalid request`.
+  An unusable column definition (`numeric(1001)`) and a reference system passed
+  as a JSON string rather than a number (`"4326"` instead of `4326`, which makes
+  PostGIS resolve `ST_Transform`'s projection-string overload) are both
+  diagnosable from the response now. Causes that are not established as safe to
+  disclose still report the generic message.
+  ([openego/ding0#405](https://github.com/openego/ding0/issues/405))
+
+- Geometry columns: an SRID declared in the column type (`geometry(Point,4326)`)
+  is parsed as subtype and SRID instead of being passed through as one opaque
+  string, and a non-numeric SRID is now rejected with a named error. The
+  automatic GiST index on geometry columns and the registered subtype/SRID are
+  now covered by tests, so a dependency upgrade cannot silently stop indexing
+  new geo tables.
+
 ## Documentation updates
 
 - New "Production deployment (Podman)" guide (Overview → Install → Ontop →


### PR DESCRIPTION
## Summary of the discussion

Four defects where the API accepted a request, did something other than what was
asked, and reported success — plus one test-only change that defends a contract
nobody had asserted. Found while answering a user support question about
bounding-box queries; one of them is the standing report in
[[openego/ding0#405](https://github.com/openego/ding0/issues/405)](https://github.com/openego/ding0/issues/405).

### What was wrong

1. **A field alias was parsed and discarded.** `{"type": "column", "column":
   "name", "as": "who"}` in an advanced search came back named `name`; a
   labelled function came back as `upper_1`. `col.label(...)` was called without
   binding the result. Any client keying results by column name broke silently.
2. **Unsupported constraint types were dropped without a word.** The create path
   branched on `PRIMARY KEY` and `UNIQUE` and fell off the end of the chain for
   everything else, so a `FOREIGN KEY` or `CHECK` in the payload vanished and
   the request returned `201`.
3. **Two paths swallowed the database's reason.** A failed create answered
   `Could not create table <name>`; a failed spatial query answered `Invalid
   request`. In the ding0 case PostGIS had said exactly what was wrong — `could
   not parse proj string '4326'` — and the API dropped it. That is why the
   report stayed open: the message gave nobody anything to act on.
4. **The geometry type modifier was parsed by accident.** `geometry(Point,4326)`
   put the whole modifier into GeoAlchemy2's `geometry_type` and never set
   `srid`, rendering `geometry(POINT,4326,-1)`. Postgres reads the first two
   values and ignores the third, so the declared SRID landed correctly — by
   accident. Nothing asserted either that or the automatic GiST index, which
   comes from a library default rather than from our code.

### What changed

- The labelled expression is bound. An invalid alias now fails with the existing
  identifier error instead of falling back to a generated name.
- The create path rejects constraint types it cannot apply, naming the supported
  route: foreign keys after creation through the table endpoint (which the alter
  path already implements), check constraints unsupported (which that same alter
  path already answers). Rejection happens while parsing, before any Main Table
  exists, so the existing all-or-nothing behaviour covers cleanup.
- Both failure paths consult one policy, `reflectable_cause` in `api.error`,
  which answers whether a database cause may be disclosed. The query path's
  inline pgcode allowlist and its single hard-coded PostGIS message move there
  unchanged; the projection-parse message is added. PostGIS raises everything
  under the generic internal-error code `XX000`, which also covers real server
  faults, so recognition has to be by message text — deliberately narrow, not
  "all internal errors". Causes outside the policy still report the generic
  message, and the full exception still goes to the log either way.
- The geometry modifier is split into subtype and SRID. A non-numeric SRID is
  rejected with a named error instead of reaching postgres as part of the type.

### Testing

19 new tests across four regression modules, all driven through the HTTP
endpoints via the existing `APITestCase.api_req` helper — no new test seam, and
no assertions on generated DDL. Every test was verified red before green.

Notable: four of the five geometry tests pass on the unfixed parser. That is the
finding — the contract was undefended, not broken. Their value is that a
dependency upgrade changing GeoAlchemy2's `spatial_index` default now fails a
test instead of silently stopping the indexing of every new geo table.

The geometry tests need PostGIS and will fail against a plain postgres; there is
a note to that effect in the module.

Full suite: 404 tests, one pre-existing environment failure (the `oekg` SPARQL
test needs the `fuseki` hostname from the container network).

### Deliberately not in this PR

- Foreign key support at creation time. It needs decisions this PR has no basis
  to make — cross-topic references, what permission the referenced table
  requires (the alter path currently checks none, with a `FIXME` on that line),
  and what a foreign key means for rows sitting in a Journal Table before Apply.
- Check constraint support, at creation or afterwards.
- Indexes on non-geometry columns. Still a maintainer action on request.
- Type checking the Advanced Query API's function arguments. The API forwards
  calls without knowing their signatures; coercing numeric-looking strings is
  rejected outright, since it would change the meaning of requests that pass
  numeric strings on purpose.
## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
