### PR TITLE
Add a committed, re-runnable Bulk Upload benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ saio/
 
 # local docs symlink
 .claude-docs
+
+# benchmark output: slices live in --work-dir (default /tmp); the map's
+# real result rows live in the wayfinder assets folder, not in the repo
+benchmarks/results/

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3547,3 +3547,11 @@ SPDX-License-Identifier = "AGPL-3.0-or-later"
 SPDX-FileCopyrightText = [
   "2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut",
 ]
+
+[[annotations]]
+path = "benchmarks/**"
+precedence = "override"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-FileCopyrightText = [
+  "2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut",
+]

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,7 @@
+"""Re-runnable benchmarks for the Open Energy Platform.
+
+Deliberately dependency-free (standard library only) and independent of
+Django settings: a benchmark must be runnable from a machine that has the
+uplink and the reference data, not only from a machine that can boot the
+platform.
+"""

--- a/benchmarks/bulk_upload/__init__.py
+++ b/benchmarks/bulk_upload/__init__.py
@@ -1,0 +1,10 @@
+"""Benchmark harness for the Bulk Upload path (issue #2362).
+
+Measures the LIVE endpoint - `POST /api/v0/tables/<table>/bulk-upload` -
+end to end from a client, one "rung" (one target payload size) at a time:
+slice a rung-sized CSV out of a reference file, create a fresh sandbox
+table, upload it gzipped, time the phases, append a result row, drop the
+table.
+
+See `run.py` for the command line. Nothing here imports Django.
+"""

--- a/benchmarks/bulk_upload/arms_wf05.json
+++ b/benchmarks/bulk_upload/arms_wf05.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "fat",
+    "source": "/home/jh/github/oep-upload/data/datapackages/example/data/open_modex_bsf_timeseries.csv",
+    "delimiter": "comma",
+    "columns": [
+      {
+        "name": "id",
+        "data_type": "bigint",
+        "primary_key": true,
+        "is_nullable": false
+      },
+      { "name": "timeindex_start", "data_type": "timestamp" },
+      { "name": "timeindex_stop", "data_type": "timestamp" },
+      { "name": "timeindex_resolution", "data_type": "interval" },
+      { "name": "series", "data_type": "varchar" }
+    ],
+    "note": "WF-05 decided schema. series=varchar is the HEADLINE arm; the json control is arm 'fat_json'. PK on id is mandatory (api/parser.py auto-adds and rejects any other)."
+  },
+  {
+    "name": "fat_json",
+    "source": "/home/jh/github/oep-upload/data/datapackages/example/data/open_modex_bsf_timeseries.csv",
+    "delimiter": "comma",
+    "columns": [
+      {
+        "name": "id",
+        "data_type": "bigint",
+        "primary_key": true,
+        "is_nullable": false
+      },
+      { "name": "timeindex_start", "data_type": "timestamp" },
+      { "name": "timeindex_stop", "data_type": "timestamp" },
+      { "name": "timeindex_resolution", "data_type": "interval" },
+      { "name": "series", "data_type": "json" }
+    ],
+    "note": "WF-05 control arm: identical to 'fat' except series=json, so Postgres validates every ~111 KB array. Run at ONE mid rung (~100 MB) only; the delta prices JSON validation."
+  },
+  {
+    "name": "narrow",
+    "source": "/home/jh/github/oep-upload/data/datapackages/example/data/open_modex_bsf_data.csv",
+    "delimiter": "comma",
+    "columns": [
+      {
+        "name": "id",
+        "data_type": "bigint",
+        "primary_key": true,
+        "is_nullable": false
+      },
+      { "name": "scenario_id", "data_type": "integer" },
+      { "name": "region", "data_type": "varchar" },
+      { "name": "input_energy_vector", "data_type": "varchar" },
+      { "name": "output_energy_vector", "data_type": "varchar" },
+      { "name": "parameter_name", "data_type": "varchar" },
+      { "name": "technology", "data_type": "varchar" },
+      { "name": "technology_type", "data_type": "varchar" },
+      { "name": "type", "data_type": "varchar" },
+      { "name": "unit", "data_type": "varchar" },
+      { "name": "tags", "data_type": "varchar" },
+      { "name": "method", "data_type": "varchar" },
+      { "name": "source", "data_type": "varchar" },
+      { "name": "comment", "data_type": "varchar" }
+    ],
+    "note": "WF-05 decided schema. region/tags MUST stay varchar: \"['DE']\" is a Python list literal, not valid JSON. unit contains '€/MW', so UTF-8 is required end to end."
+  }
+]

--- a/benchmarks/bulk_upload/client.py
+++ b/benchmarks/bulk_upload/client.py
@@ -19,6 +19,7 @@ keys on the response BODY FORMAT so a finding blames the right layer.
 from __future__ import annotations
 
 import http.client
+import io
 import json
 import select
 import ssl
@@ -29,6 +30,87 @@ from urllib.parse import urlsplit
 
 SEND_CHUNK = 1 << 20  # 1 MiB per socket write
 MAX_BODY_CAPTURE = 64 * 1024
+#: how long to wait for the rest of an early rejection once one is detected
+EARLY_DRAIN_SECONDS = 5.0
+
+
+class _BytesSocket:
+    """Socket-shaped wrapper over a buffer, for parsing a response we already read.
+
+    `http.client.HTTPResponse` only ever calls `makefile("rb")` on its socket,
+    so this is all that is needed to reuse the stdlib parser on bytes that were
+    consumed from the wire before `getresponse()` could run.
+    """
+
+    def __init__(self, raw: bytes):
+        self._raw = raw
+
+    def makefile(self, mode="rb", *args, **kwargs):  # noqa: D102
+        return io.BufferedReader(io.BytesIO(self._raw))
+
+
+def peek_early_response(sock) -> bytes:
+    """Return real HTTP bytes if the peer has already answered, else b"".
+
+    `select()` reporting a socket readable does NOT mean an HTTP response is
+    waiting. On a TLS 1.3 connection the server sends `NewSessionTicket`
+    records right after the handshake: the file descriptor goes readable while
+    the SSL layer has no *application* data at all.
+
+    Trusting `select()` alone is what deadlocked this client -- it stopped
+    sending after one chunk, then blocked in `getresponse()` forever while the
+    server waited for the rest of the declared `Content-Length`. Measured
+    against production on 2026-08-10: chunk 1 readable, `SSLWantReadError`;
+    chunks 2-5 not readable.
+
+    So ask the SSL layer itself. `SSLWantReadError` (or `BlockingIOError` on a
+    plain socket) means "TLS bookkeeping only, keep sending".
+    """
+    sock.setblocking(False)
+    try:
+        return sock.recv(MAX_BODY_CAPTURE)
+    except (ssl.SSLWantReadError, ssl.SSLWantWriteError, BlockingIOError):
+        return b""
+    except OSError:
+        # peer reset while we were still writing: treat as an early answer so
+        # the caller stops sending and reports bytes_sent at the failure point
+        return b""
+    finally:
+        try:
+            sock.setblocking(True)
+        except OSError:
+            pass
+
+
+def drain_response(sock, first: bytes, deadline: float = EARLY_DRAIN_SECONDS) -> bytes:
+    """Read the remainder of an early response that `peek_early_response` started."""
+    chunks = [first]
+    total = len(first)
+    end = time.perf_counter() + deadline
+    sock.settimeout(0.5)
+    try:
+        while total < MAX_BODY_CAPTURE and time.perf_counter() < end:
+            try:
+                more = sock.recv(MAX_BODY_CAPTURE - total)
+            except (OSError, ssl.SSLError):
+                break
+            if not more:
+                break
+            chunks.append(more)
+            total += len(more)
+            if b"\r\n\r\n" in b"".join(chunks[-2:]) and total > 0:
+                # headers complete; one more short read is enough for the body
+                try:
+                    tail = sock.recv(MAX_BODY_CAPTURE - total)
+                except (OSError, ssl.SSLError):
+                    tail = b""
+                if tail:
+                    chunks.append(tail)
+                break
+    finally:
+        pass
+    return b"".join(chunks)
+
 
 PLATFORM = "platform"  # a Django/DRF JSON answer
 PROXY = "proxy"  # an Apache/nginx HTML error page
@@ -176,6 +258,33 @@ class BenchClient:
         )
         return result
 
+    def _finish_from_bytes(self, raw: bytes, result: HttpResult) -> HttpResult:
+        """Fill `result` from response bytes already taken off the socket.
+
+        Used only on the early-rejection path, where the peer answered mid-body
+        and `getresponse()` can no longer be used because the first bytes of the
+        response are already consumed.
+        """
+        try:
+            response = http.client.HTTPResponse(_BytesSocket(raw))
+            response.begin()
+            body = response.read(MAX_BODY_CAPTURE)
+            result.status = response.status
+            result.reason = response.reason
+            result.headers = {k: v for k, v in response.getheaders()}
+            result.body = body.decode("utf-8", "replace")
+        except (http.client.HTTPException, OSError, ValueError) as exc:
+            # keep the raw bytes rather than lose the evidence
+            result.body = raw[:MAX_BODY_CAPTURE].decode("utf-8", "replace")
+            result.error += " | unparseable early response: %s: %s" % (
+                type(exc).__name__,
+                exc,
+            )
+        result.responder = classify_responder(
+            result.status, result.headers, result.body
+        )
+        return result
+
     def request(
         self,
         method: str,
@@ -267,6 +376,18 @@ class BenchClient:
         answered (a proxy 413, an Apache 408), sending stops there and the
         answer is read, so the result records how many bytes actually went
         out before the rejection.
+
+        The poll is two-stage on purpose. `select()` alone reports a TLS 1.3
+        socket readable as soon as the server sends a `NewSessionTicket`, with
+        no HTTP response behind it; believing that truncated the body after one
+        chunk and deadlocked every upload above `SEND_CHUNK`. See
+        `peek_early_response`.
+
+        Caveat on `send_seconds`: `conn.send()` returns once the kernel accepts
+        the bytes, so for payloads that fit in the socket buffers this measures
+        buffer fill, not wire time, and understates transfer. It approaches real
+        transfer time once the payload is large enough to keep the buffers full.
+        Treat `connect + send + wait` as the honest end-to-end figure.
         """
         size = payload_path.stat().st_size
         path = "/api/v0/tables/%s/bulk-upload?delimiter=%s" % (table, delimiter)
@@ -289,6 +410,7 @@ class BenchClient:
             send_started = time.perf_counter()
             sent = 0
             early_answer = False
+            early_bytes = b""
             with open(payload_path, "rb") as fh:
                 while True:
                     chunk = fh.read(chunk_size)
@@ -308,16 +430,28 @@ class BenchClient:
                     sent += len(chunk)
                     if on_progress is not None:
                         on_progress(sent, size)
-                    readable, _, _ = select.select([conn.sock], [], [], 0)
-                    if readable:
-                        # the server answered before we finished sending
-                        result.error = (
-                            "server answered after %d/%d bytes sent" % (sent, size)
-                        ).strip()
-                        early_answer = True
-                        break
+                    if not select.select([conn.sock], [], [], 0)[0]:
+                        continue
+                    # Readable does NOT mean answered -- see peek_early_response.
+                    # A TLS 1.3 NewSessionTicket makes the fd readable with no
+                    # application data behind it. Confirm with the SSL layer
+                    # before believing it, or we truncate the body and hang.
+                    peeked = peek_early_response(conn.sock)
+                    if not peeked:
+                        continue  # TLS bookkeeping only: keep sending
+                    result.error = "server answered after %d/%d bytes sent" % (
+                        sent,
+                        size,
+                    )
+                    early_answer = True
+                    early_bytes = drain_response(conn.sock, peeked)
+                    break
             result.send_seconds = time.perf_counter() - send_started
             result.bytes_sent = sent
+            if early_bytes:
+                # the response was consumed off the socket already, so the
+                # stdlib parser has to be pointed at those bytes, not at conn
+                return self._finish_from_bytes(early_bytes, result)
             try:
                 return self._finish(conn, result)
             except (OSError, http.client.HTTPException) as exc:

--- a/benchmarks/bulk_upload/client.py
+++ b/benchmarks/bulk_upload/client.py
@@ -1,0 +1,384 @@
+"""HTTP client for the bulk-upload benchmark: phase-timed, honest.
+
+Uses `http.client` rather than `requests` on purpose:
+
+* the upload body must be written from disk in chunks so a 1.95 GB rung
+  is never materialised in the client's memory - the client's own
+  allocation would land inside the measurement;
+* the send phase and the wait-for-response phase have to be timed
+  separately, which a one-call library API cannot express;
+* a server that rejects mid-body (Apache 408, a proxy 413) must be
+  noticed while the body is still being written, not after.
+
+STANDING RULE, from the map: never read a status code alone. Apache
+answers with its own HTML 408 after ~10 s of an idle request body, and
+the platform's stall guard answers 408 as JSON. `classify_responder`
+keys on the response BODY FORMAT so a finding blames the right layer.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import select
+import ssl
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlsplit
+
+SEND_CHUNK = 1 << 20  # 1 MiB per socket write
+MAX_BODY_CAPTURE = 64 * 1024
+
+PLATFORM = "platform"  # a Django/DRF JSON answer
+PROXY = "proxy"  # an Apache/nginx HTML error page
+UNKNOWN = "unknown"
+
+
+@dataclass
+class HttpResult:
+    """One HTTP exchange, with enough context to be a finding by itself."""
+
+    method: str
+    path: str
+    status: int | None
+    reason: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+    body: str = ""
+    responder: str = UNKNOWN
+    connect_seconds: float = 0.0
+    send_seconds: float = 0.0
+    wait_seconds: float = 0.0
+    read_seconds: float = 0.0
+    bytes_sent: int = 0
+    error: str = ""  # transport-level failure, not an HTTP status
+
+    @property
+    def total_seconds(self) -> float:
+        return (
+            self.connect_seconds
+            + self.send_seconds
+            + self.wait_seconds
+            + self.read_seconds
+        )
+
+    @property
+    def ok(self) -> bool:
+        return self.status is not None and 200 <= self.status < 300
+
+    def json(self) -> dict | list | None:
+        try:
+            return json.loads(self.body)
+        except (ValueError, TypeError):
+            return None
+
+    def summary(self) -> str:
+        if self.error and self.status is None:
+            return "%s %s -> TRANSPORT FAILURE %s" % (
+                self.method,
+                self.path,
+                self.error,
+            )
+        return "%s %s -> %s %s [%s] %.3fs" % (
+            self.method,
+            self.path,
+            self.status,
+            self.reason,
+            self.responder,
+            self.total_seconds,
+        )
+
+
+def classify_responder(status: int | None, headers: dict, body: str) -> str:
+    """Who answered: the platform, or a hop in front of it?
+
+    Body format decides. A JSON object/array is the platform (Django and
+    DRF answer JSON on every path this harness touches). An HTML document
+    is a front-end server's own error page. Anything else is UNKNOWN and
+    must be reported as such rather than guessed.
+    """
+    stripped = (body or "").lstrip()
+    if stripped[:1] in "{[":
+        try:
+            json.loads(body)
+            return PLATFORM
+        except ValueError:
+            pass
+    lowered = stripped[:400].lower()
+    if lowered.startswith("<!doctype html") or lowered.startswith("<html"):
+        return PROXY
+    if "<title>" in lowered and "</title>" in lowered:
+        return PROXY
+    content_type = ""
+    for key, value in (headers or {}).items():
+        if key.lower() == "content-type":
+            content_type = value.lower()
+    if "json" in content_type:
+        return PLATFORM
+    if "html" in content_type:
+        return PROXY
+    return UNKNOWN
+
+
+class BenchClient:
+    """Minimal API client for the benchmark's five calls."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        timeout: float = 3600.0,
+        insecure: bool = False,
+    ):
+        parts = urlsplit(base_url)
+        if parts.scheme not in ("http", "https"):
+            raise ValueError("base_url must be http(s): %r" % base_url)
+        self.base_url = base_url.rstrip("/")
+        self.scheme = parts.scheme
+        self.host = parts.hostname
+        self.port = parts.port
+        self.token = token
+        self.timeout = timeout
+        self.insecure = insecure
+
+    # -- plumbing ---------------------------------------------------------
+
+    def _connect(self) -> http.client.HTTPConnection:
+        if self.scheme == "https":
+            context = ssl.create_default_context()
+            if self.insecure:
+                context.check_hostname = False
+                context.verify_mode = ssl.CERT_NONE
+            return http.client.HTTPSConnection(
+                self.host, self.port or 443, timeout=self.timeout, context=context
+            )
+        return http.client.HTTPConnection(
+            self.host, self.port or 80, timeout=self.timeout
+        )
+
+    def _finish(
+        self,
+        conn: http.client.HTTPConnection,
+        result: HttpResult,
+    ) -> HttpResult:
+        wait_started = time.perf_counter()
+        response = conn.getresponse()
+        result.wait_seconds = time.perf_counter() - wait_started
+        read_started = time.perf_counter()
+        raw = response.read(MAX_BODY_CAPTURE)
+        result.read_seconds = time.perf_counter() - read_started
+        result.status = response.status
+        result.reason = response.reason
+        result.headers = {k: v for k, v in response.getheaders()}
+        result.body = raw.decode("utf-8", "replace")
+        result.responder = classify_responder(
+            result.status, result.headers, result.body
+        )
+        return result
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+        authenticated: bool = True,
+    ) -> HttpResult:
+        """A small request: body (if any) is sent in one go."""
+        result = HttpResult(method=method, path=path, status=None)
+        conn = self._connect()
+        try:
+            started = time.perf_counter()
+            conn.connect()
+            result.connect_seconds = time.perf_counter() - started
+            # NOTE: putrequest emits its own Host header. Adding a second
+            # one makes the stack answer a blanket 400 (learned the hard
+            # way by assets/probe_body_limit.py) - so never set it here.
+            conn.putrequest(method, path, skip_accept_encoding=True)
+            for key, value in (headers or {}).items():
+                conn.putheader(key, value)
+            if authenticated:
+                if not self.token:
+                    raise ValueError("no token: set OEP_BENCH_TOKEN")
+                conn.putheader("Authorization", "Token %s" % self.token)
+            conn.putheader("Content-Length", str(len(body or b"")))
+            send_started = time.perf_counter()
+            conn.endheaders(body) if body else conn.endheaders()
+            result.send_seconds = time.perf_counter() - send_started
+            result.bytes_sent = len(body or b"")
+            return self._finish(conn, result)
+        except (OSError, http.client.HTTPException) as exc:
+            result.error = "%s: %s" % (type(exc).__name__, exc)
+            return result
+        finally:
+            conn.close()
+
+    # -- the calls the benchmark makes ------------------------------------
+
+    def check_token(self) -> HttpResult:
+        """Read-only credential check.
+
+        `GET /api/v0/datasets/` authenticates before it authorises (DRF
+        runs authentication ahead of IsAuthenticatedOrReadOnly), so a dead
+        token yields 401 {"detail": "Invalid token."} and a live one 200 -
+        without writing anything.
+        """
+        return self.request("GET", "/api/v0/datasets/")
+
+    def create_table(
+        self, table: str, columns: list[dict], constraints: list[dict] | None = None
+    ) -> HttpResult:
+        """Create `table` in the `sandbox` schema.
+
+        `?is_sandbox=1` is what puts it in `sandbox`; without it the table
+        is created in `data` (api/views.py, TableAPIView.put). A benchmark
+        must never land in `data`.
+        """
+        payload = {"query": {"columns": columns, "constraints": constraints or []}}
+        return self.request(
+            "PUT",
+            "/api/v0/tables/%s/?is_sandbox=1" % table,
+            body=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+
+    def describe_table(self, table: str) -> HttpResult:
+        return self.request("GET", "/api/v0/tables/%s/" % table)
+
+    def drop_table(self, table: str) -> HttpResult:
+        return self.request("DELETE", "/api/v0/tables/%s/" % table)
+
+    def row_count(self, table: str) -> HttpResult:
+        return self.request("GET", "/api/v0/tables/%s/rowcount" % table)
+
+    def upload(
+        self,
+        table: str,
+        payload_path: Path,
+        delimiter: str = "comma",
+        gzipped: bool = True,
+        chunk_size: int = SEND_CHUNK,
+        on_progress=None,
+    ) -> HttpResult:
+        """Stream `payload_path` into the bulk-upload endpoint.
+
+        The file is written to the socket in chunks and never read whole.
+        Between chunks the socket is polled: if the server has already
+        answered (a proxy 413, an Apache 408), sending stops there and the
+        answer is read, so the result records how many bytes actually went
+        out before the rejection.
+        """
+        size = payload_path.stat().st_size
+        path = "/api/v0/tables/%s/bulk-upload?delimiter=%s" % (table, delimiter)
+        result = HttpResult(method="POST", path=path, status=None)
+        conn = self._connect()
+        try:
+            started = time.perf_counter()
+            conn.connect()
+            result.connect_seconds = time.perf_counter() - started
+            conn.putrequest("POST", path, skip_accept_encoding=True)
+            if not self.token:
+                raise ValueError("no token: set OEP_BENCH_TOKEN")
+            conn.putheader("Authorization", "Token %s" % self.token)
+            conn.putheader("Content-Type", "text/csv")
+            if gzipped:
+                conn.putheader("Content-Encoding", "gzip")
+            conn.putheader("Content-Length", str(size))
+            conn.endheaders()
+
+            send_started = time.perf_counter()
+            sent = 0
+            early_answer = False
+            with open(payload_path, "rb") as fh:
+                while True:
+                    chunk = fh.read(chunk_size)
+                    if not chunk:
+                        break
+                    try:
+                        conn.send(chunk)
+                    except (OSError, http.client.HTTPException) as exc:
+                        result.error = "send aborted after %d/%d bytes: %s: %s" % (
+                            sent,
+                            size,
+                            type(exc).__name__,
+                            exc,
+                        )
+                        early_answer = True
+                        break
+                    sent += len(chunk)
+                    if on_progress is not None:
+                        on_progress(sent, size)
+                    readable, _, _ = select.select([conn.sock], [], [], 0)
+                    if readable:
+                        # the server answered before we finished sending
+                        result.error = (
+                            "server answered after %d/%d bytes sent" % (sent, size)
+                        ).strip()
+                        early_answer = True
+                        break
+            result.send_seconds = time.perf_counter() - send_started
+            result.bytes_sent = sent
+            try:
+                return self._finish(conn, result)
+            except (OSError, http.client.HTTPException) as exc:
+                if early_answer and result.error:
+                    result.error += " | and no response could be read: %s: %s" % (
+                        type(exc).__name__,
+                        exc,
+                    )
+                else:
+                    result.error = "%s: %s" % (type(exc).__name__, exc)
+                return result
+        except (OSError, http.client.HTTPException, ValueError) as exc:
+            result.error = "%s: %s" % (type(exc).__name__, exc)
+            return result
+        finally:
+            conn.close()
+
+    def probe_body_limit(self, sizes: list[tuple[str, int]]) -> list[dict]:
+        """Headers-only request-body ceiling probe (folded in from
+        `assets/probe_body_limit.py`).
+
+        Sends `Content-Length` plus `Expect: 100-continue` and reads what
+        comes back BEFORE any body is written: zero payload bytes cross
+        the wire. Unauthenticated and aimed at a table that does not
+        exist, so no code path can write anything - safe against any
+        target, production included.
+
+        100 -> the whole chain will accept a body that big
+        413 -> some hop caps below this size; that hop is the ceiling
+        4xx -> the app answered before any hop looked at Content-Length
+        """
+        path = "/api/v0/tables/does_not_exist_bench_probe/bulk-upload?delimiter=comma"
+        findings = []
+        for label, size in sizes:
+            row = {"label": label, "declared_bytes": size}
+            conn = self._connect()
+            try:
+                conn.timeout = min(self.timeout, 30)
+                conn.putrequest("POST", path, skip_accept_encoding=True)
+                conn.putheader("Content-Type", "text/csv")
+                conn.putheader("Content-Length", str(size))
+                conn.putheader("Expect", "100-continue")
+                conn.endheaders()  # no body
+                response = conn.getresponse()
+                body = response.read(600).decode("utf-8", "replace").strip()
+                headers = {k: v for k, v in response.getheaders()}
+                row.update(
+                    status=response.status,
+                    reason=response.reason,
+                    server=headers.get("Server", ""),
+                    responder=classify_responder(response.status, headers, body),
+                    body=body[:300],
+                )
+            except (OSError, http.client.HTTPException) as exc:
+                row.update(status=None, error="%s: %s" % (type(exc).__name__, exc))
+            finally:
+                conn.close()
+            findings.append(row)
+        return findings
+
+    def server_header(self) -> tuple[str, HttpResult]:
+        """What the target says it is served by (unauthenticated GET /)."""
+        result = self.request("GET", "/", authenticated=False)
+        return result.headers.get("Server", ""), result

--- a/benchmarks/bulk_upload/config.py
+++ b/benchmarks/bulk_upload/config.py
@@ -1,0 +1,208 @@
+"""Targets, arms and rungs - everything a run is described by.
+
+Column definitions are DATA here, not code, and can be replaced wholesale
+from a JSON file (`--arms-file`). They are a deliberate input to the
+measurement: typing the fat file's `series` column as `text` measures raw
+ingest, typing it as `json`/`jsonb` measures validated-JSON ingest, and
+those are different benchmarks. The values below are PROVISIONAL until
+the schema decision lands; whoever changes them must re-run every rung
+that is meant to be comparable.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --- targets -------------------------------------------------------------
+
+DEFAULT_REFERENCE_DIR = Path(
+    "/home/jh/github/oep-upload/data/datapackages/example/data"
+)
+
+
+@dataclass(frozen=True)
+class Target:
+    """One deployment the harness can be pointed at."""
+
+    name: str
+    base_url: str
+    is_production: bool = False
+
+
+TARGETS: dict[str, Target] = {
+    "prod": Target(
+        name="prod",
+        base_url="https://openenergyplatform.org",
+        is_production=True,
+    ),
+    # NOTE (measured 2026-08-07): toep serves an INCOMPLETE TLS chain - the
+    # leaf only, without its Let's Encrypt intermediate - so curl, requests
+    # and this harness all fail with "unable to get local issuer
+    # certificate". Until the host serves the full chain, runs against toep
+    # need --insecure. Its `Server` header is otherwise byte-identical to
+    # production's (Apache/2.4.52 Ubuntu, OpenSSL 3.0.2, mod_wsgi 4.9.0,
+    # Python 3.10), which is what makes it a fair rehearsal surface.
+    "toep": Target(name="toep", base_url="https://toep.iks.cs.ovgu.de"),
+    "local": Target(name="local", base_url="http://127.0.0.1:8000"),
+}
+
+
+# --- arms ----------------------------------------------------------------
+
+
+@dataclass
+class Arm:
+    """One shape of data: which file, which columns, which table."""
+
+    name: str
+    source: Path
+    delimiter: str = "comma"  # the API's delimiter parameter name
+    #: table-create payload, sent as {"query": {"columns": [...],
+    #: "constraints": [...]}} to PUT /api/v0/tables/<name>/
+    columns: list[dict] = field(default_factory=list)
+    constraints: list[dict] = field(default_factory=list)
+    #: columns removed from every sliced record before upload
+    drop_columns: tuple[str, ...] = ()
+    #: rewrite `id` with a fresh counter (required when repeating a source)
+    renumber_id: bool = False
+    #: cycle the source file when a rung is larger than it
+    repeat: bool = False
+    note: str = ""
+
+    @property
+    def csv_delimiter(self) -> str:
+        return {"comma": ",", "semicolon": ";", "tab": "\t"}[self.delimiter]
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "source": str(self.source),
+            "delimiter": self.delimiter,
+            "columns": self.columns,
+            "constraints": self.constraints,
+            "drop_columns": list(self.drop_columns),
+            "renumber_id": self.renumber_id,
+            "repeat": self.repeat,
+            "note": self.note,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Arm":
+        return cls(
+            name=data["name"],
+            source=Path(data["source"]),
+            delimiter=data.get("delimiter", "comma"),
+            columns=data.get("columns", []),
+            constraints=data.get("constraints", []),
+            drop_columns=tuple(data.get("drop_columns", ())),
+            renumber_id=bool(data.get("renumber_id", False)),
+            repeat=bool(data.get("repeat", False)),
+            note=data.get("note", ""),
+        )
+
+
+# NOTE ON `id` AND THE PRIMARY KEY (verified against api/parser.py):
+# the table-create endpoint ALWAYS ends up with a primary key on `id` - if
+# no `id` column is given it invents one (BigInteger, autoincrement), and
+# if no primary key is given it adds PRIMARY KEY (id); a primary key on
+# anything other than `id` is rejected outright. So "no index during COPY"
+# is not an option the API offers, and every rung pays the pk index cost.
+# The only real choice is whether the CSV SUPPLIES ids (exercising the
+# slice-4 id contract) or omits them (letting the sequence generate them).
+
+ARMS: dict[str, Arm] = {
+    "fat": Arm(
+        name="fat",
+        source=DEFAULT_REFERENCE_DIR / "open_modex_bsf_timeseries.csv",
+        columns=[
+            {"name": "id", "data_type": "bigint"},
+            {"name": "timeindex_start", "data_type": "text"},
+            {"name": "timeindex_stop", "data_type": "text"},
+            {"name": "timeindex_resolution", "data_type": "text"},
+            {"name": "series", "data_type": "text"},
+        ],
+        note=(
+            "PROVISIONAL pending the schema decision: `series` as text "
+            "measures raw ingest, not validated-JSON ingest"
+        ),
+    ),
+    "narrow": Arm(
+        name="narrow",
+        source=DEFAULT_REFERENCE_DIR / "open_modex_bsf_data.csv",
+        columns=[
+            {"name": "id", "data_type": "bigint"},
+            {"name": "scenario_id", "data_type": "bigint"},
+            {"name": "region", "data_type": "text"},
+            {"name": "input_energy_vector", "data_type": "text"},
+            {"name": "output_energy_vector", "data_type": "text"},
+            {"name": "parameter_name", "data_type": "text"},
+            {"name": "technology", "data_type": "text"},
+            {"name": "technology_type", "data_type": "text"},
+            {"name": "type", "data_type": "text"},
+            {"name": "unit", "data_type": "text"},
+            {"name": "tags", "data_type": "text"},
+            {"name": "method", "data_type": "text"},
+            {"name": "source", "data_type": "text"},
+            {"name": "comment", "data_type": "text"},
+        ],
+        note="PROVISIONAL pending the schema decision",
+    ),
+}
+
+
+def load_arms(path: Path) -> dict[str, Arm]:
+    """Replace/extend the built-in arms from a JSON file.
+
+    The file is a list of arm dicts (see `Arm.to_dict`), which is how the
+    schema decision plugs in without touching this module.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        data = [data]
+    arms = dict(ARMS)
+    for entry in data:
+        arm = Arm.from_dict(entry)
+        arms[arm.name] = arm
+    return arms
+
+
+# --- rungs ---------------------------------------------------------------
+
+_UNITS = {
+    "": 1,
+    "b": 1,
+    "kb": 10**3,
+    "mb": 10**6,
+    "gb": 10**9,
+    "kib": 1024,
+    "mib": 1024**2,
+    "gib": 1024**3,
+}
+
+_SIZE_RE = re.compile(r"^\s*([0-9]*\.?[0-9]+)\s*([a-zA-Z]*)\s*$")
+
+#: the staircase fixed when this map was charted
+DEFAULT_RUNGS = ["1MB", "10MB", "100MB", "1GB", "1.95GB"]
+
+
+def parse_size(text: str) -> int:
+    """`"1.95GB"` -> bytes. Decimal MB/GB, binary MiB/GiB, both explicit."""
+    match = _SIZE_RE.match(text)
+    if not match:
+        raise ValueError("cannot parse size %r" % text)
+    number, unit = match.groups()
+    key = unit.lower()
+    if key not in _UNITS:
+        raise ValueError(
+            "unknown size unit %r in %r (use %s)"
+            % (unit, text, ", ".join(sorted(u for u in _UNITS if u)))
+        )
+    return int(float(number) * _UNITS[key])
+
+
+def rung_label(text: str) -> str:
+    """A table-name-safe label for a rung, e.g. `1.95GB` -> `1_95gb`."""
+    return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")

--- a/benchmarks/bulk_upload/results.py
+++ b/benchmarks/bulk_upload/results.py
@@ -1,0 +1,144 @@
+"""The results file: one row per rung attempt, append-only.
+
+Failures get a row too. A 413/408/429/500 is a measurement, not an
+absence of one, and the row carries what it takes to tell a proxy's
+refusal from the platform's: the status, who answered, the server
+header, the bytes that made it out and the response body itself.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from dataclasses import asdict, dataclass, fields
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: server-side phase timings (slice 8) are logged on the host, not
+#: returned to the client; a rung says so rather than dropping the column
+SERVER_TIMINGS_UNAVAILABLE = "n/a client-side (host log: oeplatform.bulk_upload)"
+
+
+@dataclass
+class ResultRow:
+    run_id: str = ""
+    timestamp_utc: str = ""
+    target: str = ""
+    base_url: str = ""
+    arm: str = ""
+    rung: str = ""
+    table: str = ""
+    schema: str = "sandbox"
+    delimiter: str = "comma"
+    source_file: str = ""
+    schema_fingerprint: str = ""  # rungs with different fingerprints do not compare
+    # slice
+    target_bytes: int = 0
+    slice_bytes: int = 0
+    slice_rows: int = 0
+    slice_rewritten: bool = False
+    slice_passes: int = 1
+    slice_seconds: float = 0.0
+    slice_verified: str = ""
+    # transport
+    gzip_level: str = ""
+    wire_bytes: int = 0  # what the payload weighs
+    wire_bytes_sent: int = 0  # what actually left the client
+    compress_seconds: float = 0.0
+    compress_ratio: float = 0.0
+    # phases (client side)
+    connect_seconds: float = 0.0
+    send_seconds: float = 0.0
+    wait_seconds: float = 0.0
+    read_seconds: float = 0.0
+    upload_seconds: float = 0.0
+    rung_wall_seconds: float = 0.0
+    # outcome
+    http_status: str = ""
+    responder: str = ""
+    server_header: str = ""
+    rows_reported: str = ""
+    event_id: str = ""
+    id_min: str = ""
+    id_max: str = ""
+    rowcount_after: str = ""
+    # derived
+    mb_per_s_uncompressed: float = 0.0
+    mb_per_s_wire: float = 0.0
+    rows_per_s: float = 0.0
+    # lifecycle
+    table_created: bool = False
+    table_dropped: bool = False
+    drop_verified: str = ""
+    # provenance
+    server_timings: str = SERVER_TIMINGS_UNAVAILABLE
+    outcome: str = ""
+    error: str = ""
+    response_body: str = ""
+    notes: str = ""
+    detail_file: str = ""
+
+    def compute_derived(self) -> None:
+        """Throughput exists only where a load actually completed.
+
+        A rung that was refused mid-body moved a fraction of its payload
+        in a fraction of the time; dividing one by the other invents a
+        headline number out of a failure. Those cells stay 0 and
+        `wire_bytes_sent` carries what really went out.
+        """
+        if self.wire_bytes and self.slice_bytes:
+            self.compress_ratio = round(self.slice_bytes / self.wire_bytes, 4)
+        if self.outcome != "success" or self.upload_seconds <= 0:
+            self.mb_per_s_uncompressed = 0.0
+            self.mb_per_s_wire = 0.0
+            self.rows_per_s = 0.0
+            return
+        self.mb_per_s_uncompressed = round(
+            self.slice_bytes / self.upload_seconds / 1e6, 3
+        )
+        self.mb_per_s_wire = round(self.wire_bytes / self.upload_seconds / 1e6, 3)
+        self.rows_per_s = round(self.slice_rows / self.upload_seconds, 1)
+
+
+FIELD_NAMES = [f.name for f in fields(ResultRow)]
+
+
+def schema_fingerprint(columns: list, constraints: list) -> str:
+    """Short hash of the exact table definition a rung was loaded into.
+
+    Two rungs are only comparable if this matches - the column typing
+    decision changes what is being measured, not just how it is stored.
+    """
+    blob = json.dumps(
+        {"columns": columns, "constraints": constraints}, sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:12]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def append_row(path: Path, row: ResultRow) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    is_new = not path.exists() or path.stat().st_size == 0
+    with open(path, "a", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=FIELD_NAMES)
+        if is_new:
+            writer.writeheader()
+        data = asdict(row)
+        for key, value in data.items():
+            if isinstance(value, str):
+                data[key] = value.replace("\r", " ").replace("\n", " ")[:2000]
+        writer.writerow(data)
+
+
+def write_detail(directory: Path, run_id: str, payload: dict) -> Path:
+    """Full, untruncated record of one rung - bodies, headers, config."""
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / ("%s.json" % run_id)
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    return path

--- a/benchmarks/bulk_upload/run.py
+++ b/benchmarks/bulk_upload/run.py
@@ -1,0 +1,676 @@
+"""Command line for the bulk-upload benchmark.
+
+    # nothing leaves the machine: slice, compress, print the payloads
+    python -m benchmarks.bulk_upload.run --target toep --arm narrow \
+        --rungs 1MB,10MB --dry-run
+
+    # is the credential live, and may it create and drop in sandbox?
+    export OEP_BENCH_TOKEN=...            # never a literal in this repo
+    python -m benchmarks.bulk_upload.run --target toep --check-auth
+
+    # what body size will the chain accept? (unauthenticated, zero payload)
+    python -m benchmarks.bulk_upload.run --target prod --probe-body-limit
+
+    # the real thing: a staircase that stops at the first hard limit
+    python -m benchmarks.bulk_upload.run --target toep --arm fat \
+        --rungs 1MB,10MB,100MB,1GB,1.95GB --results path/to/results.csv
+
+Production is write-protected: any call that writes to a target marked
+`is_production` refuses unless `--i-am-a-human-confirming-production` is
+given, because the map keeps prod writes human-in-the-loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from benchmarks.bulk_upload import config as cfg
+from benchmarks.bulk_upload import results as res
+from benchmarks.bulk_upload import slicing
+from benchmarks.bulk_upload.client import PLATFORM, PROXY, BenchClient, HttpResult
+
+TOKEN_ENV = "OEP_BENCH_TOKEN"
+TABLE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,49}$")
+DEFAULT_RESULTS = Path("benchmarks/results/bulk_upload_results.csv")
+PROBE_SIZES = [
+    ("100 MiB", 100 * 1024**2),
+    ("1 GiB", 1024**3),
+    ("1.90 GiB (the fat file)", 2_040_220_631),
+    ("2 GiB", 2 * 1024**3),
+    ("10 GiB (BULK_UPLOAD_MAX_BYTES default)", 10 * 1024**3),
+]
+
+
+class BenchError(RuntimeError):
+    """A run cannot proceed - configuration, not a measurement."""
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+def read_token(required: bool = True) -> str | None:
+    token = os.environ.get(TOKEN_ENV, "").strip()
+    if not token:
+        if required:
+            raise BenchError(
+                "%s is not set. The harness never contains a token literal; "
+                "export the account's API token (OEP user settings -> Show "
+                "token) into %s for this shell only." % (TOKEN_ENV, TOKEN_ENV)
+            )
+        return None
+    return token
+
+
+def table_name(arm: str, rung: str, stamp: str) -> str:
+    name = "bench_%s_%s_%s" % (arm, cfg.rung_label(rung), stamp)
+    if not TABLE_NAME_RE.match(name):
+        raise BenchError(
+            "generated table name %r is not a valid OEP identifier "
+            "(^[a-z][a-z0-9_]{0,49}$)" % name
+        )
+    return name
+
+
+def slice_path(work_dir: Path, arm: cfg.Arm, target_bytes: int) -> Path:
+    tag = "%s_%d%s%s%s" % (
+        arm.name,
+        target_bytes,
+        "_drop-" + "-".join(arm.drop_columns) if arm.drop_columns else "",
+        "_renum" if arm.renumber_id else "",
+        "_rep" if arm.repeat else "",
+    )
+    return work_dir / ("slice_%s.csv" % tag)
+
+
+def make_slice(
+    arm: cfg.Arm, target_bytes: int, work_dir: Path, use_cache: bool
+) -> tuple[slicing.SliceResult, float, bool]:
+    """Slice (or reuse) a rung. Returns (result, seconds, was_cached)."""
+    dest = slice_path(work_dir, arm, target_bytes)
+    meta = dest.with_name(dest.name + ".meta.json")
+    if use_cache and dest.exists() and meta.exists():
+        data = json.loads(meta.read_text(encoding="utf-8"))
+        if data.get("actual_bytes") == dest.stat().st_size:
+            data["path"] = dest
+            return slicing.SliceResult(**data), 0.0, True
+    started = time.perf_counter()
+    result = slicing.slice_csv(
+        arm.source,
+        dest,
+        target_bytes,
+        delimiter=arm.csv_delimiter,
+        drop_columns=arm.drop_columns,
+        renumber_id=arm.renumber_id,
+        repeat=arm.repeat,
+    )
+    seconds = time.perf_counter() - started
+    payload = asdict(result)
+    payload["path"] = str(result.path)
+    meta.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return result, seconds, False
+
+
+def compress(source: Path, dest: Path, level: int) -> tuple[int, float]:
+    """gzip a slice to disk, streaming. Returns (bytes, seconds).
+
+    Pre-compressing rather than compressing on the fly is deliberate:
+    gzip -6 runs at roughly 20 MB/s on this data, so compressing inside
+    the upload would fold ~100 s of client CPU into a 1.9 GB transfer
+    measurement and quietly become the bottleneck being measured.
+    """
+    started = time.perf_counter()
+    with open(source, "rb") as src, open(dest, "wb") as raw:
+        with gzip.GzipFile(
+            filename="", mode="wb", fileobj=raw, compresslevel=level, mtime=0
+        ) as out:
+            shutil.copyfileobj(src, out, length=1 << 20)
+    seconds = time.perf_counter() - started
+    return dest.stat().st_size, seconds
+
+
+def guard_production(target: cfg.Target, confirmed: bool, what: str) -> None:
+    if target.is_production and not confirmed:
+        raise BenchError(
+            "refusing to %s against production (%s). Prod writes are "
+            "human-in-the-loop on this map: re-run with "
+            "--i-am-a-human-confirming-production if a human really is "
+            "driving." % (what, target.base_url)
+        )
+
+
+def describe_http(result: HttpResult) -> str:
+    if result.status is None:
+        return "TRANSPORT FAILURE: %s" % result.error
+    tail = " %s" % result.error if result.error else ""
+    return "%s %s [answered by: %s]%s :: %s" % (
+        result.status,
+        result.reason,
+        result.responder,
+        tail,
+        result.body[:300].replace("\n", " "),
+    )
+
+
+# --- preflights ----------------------------------------------------------
+
+
+def probe_body_limit(client: BenchClient) -> list[dict]:
+    """Declare a huge body, send none of it, see who objects.
+
+    Reading the result on the Apache + mod_wsgi stack the OEP actually
+    runs on: `100 Continue` is NOT what acceptance looks like there.
+    Apache does not answer the Expect header up front, it waits for the
+    body, and after ~10 s of silence answers its own HTML **408**. So
+
+      413            -> a hop caps below this size; THAT is the ceiling
+      408 from proxy -> the declared length was accepted, the body simply
+                        never came (this probe never sends one)
+      4xx from platform -> the app answered before any hop looked at
+                        Content-Length
+
+    A run of 408s with no 413 anywhere therefore means: no proxy body cap
+    up to the largest size probed.
+    """
+    log("\n== request-body ceiling (headers only, no payload, unauthenticated)")
+    findings = client.probe_body_limit(PROBE_SIZES)
+    log("%-42s %-8s %-9s %s" % ("declared size", "status", "answered", "server"))
+    for row in findings:
+        log(
+            "%-42s %-8s %-9s %s %s"
+            % (
+                row["label"],
+                row.get("status", "ERR"),
+                row.get("responder", "-"),
+                row.get("server", ""),
+                row.get("error", ""),
+            )
+        )
+    capped = [r for r in findings if r.get("status") == 413]
+    reached = [r for r in findings if r.get("status") is not None]
+    if capped:
+        log("  VERDICT: body ceiling below %s (first 413)" % capped[0]["label"])
+    elif reached:
+        log(
+            "  VERDICT: no 413 at any probed size - no proxy body cap up to %s"
+            % reached[-1]["label"]
+        )
+    else:
+        log("  VERDICT: nothing was reached; see the errors above")
+    return findings
+
+
+def check_auth(
+    client: BenchClient, target: cfg.Target, confirmed: bool, keep: bool = False
+) -> dict:
+    """Preflight: token live? sandbox create/drop permitted? body ceiling?"""
+    report: dict = {"target": target.name, "base_url": target.base_url}
+
+    server, root = client.server_header()
+    log("\n== target identity")
+    log("  base url      : %s" % target.base_url)
+    log("  Server header : %s" % (server or "(none sent)"))
+    log("  GET /         : %s" % describe_http(root)[:120])
+    report["server_header"] = server
+    report["root"] = asdict(root)
+
+    log("\n== token (read-only check: GET /api/v0/datasets/)")
+    token_result = client.check_token()
+    log("  %s" % describe_http(token_result))
+    report["token_check"] = asdict(token_result)
+    if token_result.status == 401:
+        raise BenchError(
+            "token rejected (401). Nothing further can be checked. Get the "
+            "live value from OEP user settings -> Show token; do NOT reset "
+            "the token, OEP issues one per user and a reset is destructive."
+        )
+    if not token_result.ok:
+        raise BenchError(
+            "unexpected answer to the token check: %s" % describe_http(token_result)
+        )
+    log("  token is LIVE")
+
+    report["probe"] = probe_body_limit(client)
+
+    log("\n== sandbox round-trip (create -> confirm -> drop -> confirm gone)")
+    guard_production(target, confirmed, "create a table")
+    name = table_name("auth", "probe", time.strftime("%Y%m%d%H%M%S"))
+    columns = [
+        {"name": "id", "data_type": "bigint"},
+        {"name": "value", "data_type": "text"},
+    ]
+    steps: dict[str, dict] = {}
+    created = client.create_table(name, columns)
+    steps["create"] = asdict(created)
+    log("  create %s: %s" % (name, describe_http(created)))
+    if not created.ok:
+        report["sandbox_roundtrip"] = {"verdict": "CREATE DENIED", "steps": steps}
+        log("  VERDICT: this account may NOT create tables in sandbox here.")
+        return report
+    confirm = client.describe_table(name)
+    steps["confirm"] = asdict(confirm)
+    log("  confirm      : %s" % describe_http(confirm)[:160])
+    if keep:
+        report["sandbox_roundtrip"] = {"verdict": "CREATED, KEPT", "steps": steps}
+        return report
+    dropped = client.drop_table(name)
+    steps["drop"] = asdict(dropped)
+    log("  drop         : %s" % describe_http(dropped)[:160])
+    gone = client.describe_table(name)
+    steps["confirm_gone"] = asdict(gone)
+    log("  confirm gone : %s" % describe_http(gone)[:160])
+    verdict = (
+        "CREATE+DROP OK"
+        if created.ok and dropped.ok and gone.status == 404
+        else "INCOMPLETE - inspect the steps"
+    )
+    log("  VERDICT: %s" % verdict)
+    report["sandbox_roundtrip"] = {"verdict": verdict, "steps": steps}
+    return report
+
+
+# --- one rung ------------------------------------------------------------
+
+
+def run_rung(
+    client: BenchClient,
+    target: cfg.Target,
+    arm: cfg.Arm,
+    rung: str,
+    args: argparse.Namespace,
+) -> res.ResultRow:
+    started_wall = time.perf_counter()
+    target_bytes = cfg.parse_size(rung)
+    stamp = time.strftime("%Y%m%d%H%M%S")
+    run_id = "%s_%s_%s_%s" % (target.name, arm.name, cfg.rung_label(rung), stamp)
+    row = res.ResultRow(
+        run_id=run_id,
+        timestamp_utc=res.utc_now(),
+        target=target.name,
+        base_url=target.base_url,
+        arm=arm.name,
+        rung=rung,
+        delimiter=arm.delimiter,
+        source_file=str(arm.source),
+        schema_fingerprint=res.schema_fingerprint(arm.columns, arm.constraints),
+        target_bytes=target_bytes,
+        notes=arm.note,
+    )
+    detail: dict = {"arm": arm.to_dict(), "rung": rung, "target": asdict(target)}
+
+    log("\n=== rung %s (%s arm, target %s)" % (rung, arm.name, target.name))
+    if not arm.source.exists():
+        raise BenchError("reference file missing: %s" % arm.source)
+
+    # 1. slice, CSV-aware
+    sliced, slice_seconds, cached = make_slice(
+        arm, target_bytes, Path(args.work_dir), not args.no_cache
+    )
+    row.slice_bytes = sliced.actual_bytes
+    row.slice_rows = sliced.rows
+    row.slice_rewritten = sliced.rewritten
+    row.slice_passes = sliced.source_passes
+    row.slice_seconds = round(slice_seconds, 3)
+    log(
+        "  slice: %d rows, %d bytes (%.1f%% of target)%s in %.1fs"
+        % (
+            sliced.rows,
+            sliced.actual_bytes,
+            100 * sliced.fill_ratio,
+            " [cached]" if cached else "",
+            slice_seconds,
+        )
+    )
+    detail["slice"] = asdict(sliced)
+
+    # 2. prove the slice is valid CSV rather than assume it
+    expected_columns = len(arm.columns) if arm.columns else None
+    if args.verify_slice and expected_columns:
+        if sliced.actual_bytes <= args.verify_max_bytes:
+            v_rows, counts = slicing.verify_slice(
+                sliced.path, expected_columns, arm.csv_delimiter
+            )
+            if v_rows != sliced.rows or counts != {expected_columns}:
+                raise BenchError(
+                    "slice verification FAILED: re-parsed %d rows (expected %d), "
+                    "field counts %s (expected {%d})"
+                    % (v_rows, sliced.rows, sorted(counts), expected_columns)
+                )
+            row.slice_verified = "reparsed ok: %d rows x %d cols" % (
+                v_rows,
+                expected_columns,
+            )
+        else:
+            row.slice_verified = "skipped (>%d bytes)" % args.verify_max_bytes
+        log("  verify: %s" % row.slice_verified)
+
+    # 3. transport: pre-compress so client CPU is not inside the transfer
+    payload = sliced.path
+    if args.gzip:
+        gz = sliced.path.with_name(sliced.path.name + ".gz")
+        if args.no_cache or not gz.exists():
+            wire_bytes, compress_seconds = compress(sliced.path, gz, args.gzip_level)
+        else:
+            wire_bytes, compress_seconds = gz.stat().st_size, 0.0
+        payload = gz
+        row.gzip_level = str(args.gzip_level)
+        row.wire_bytes = wire_bytes
+        row.compress_seconds = round(compress_seconds, 3)
+        log(
+            "  gzip -%d: %d -> %d bytes (%.2f:1) in %.1fs"
+            % (
+                args.gzip_level,
+                sliced.actual_bytes,
+                wire_bytes,
+                sliced.actual_bytes / max(wire_bytes, 1),
+                compress_seconds,
+            )
+        )
+    else:
+        row.gzip_level = "none"
+        row.wire_bytes = sliced.actual_bytes
+
+    if args.dry_run:
+        would_be = table_name(arm.name, rung, stamp)
+        row.outcome = "dry-run"
+        row.table = would_be
+        row.notes = ("%s | table NOT created (dry run)" % arm.note).strip(" |")
+        row.compute_derived()
+        row.rung_wall_seconds = round(time.perf_counter() - started_wall, 3)
+        log("  DRY RUN: nothing is sent.")
+        log(
+            "  would PUT %s/api/v0/tables/%s/?is_sandbox=1 with %s"
+            % (
+                target.base_url,
+                would_be,
+                json.dumps(
+                    {"query": {"columns": arm.columns, "constraints": arm.constraints}}
+                ),
+            )
+        )
+        log(
+            "  would POST %s (%d bytes, Content-Encoding: %s) to "
+            "%s/api/v0/tables/%s/bulk-upload?delimiter=%s"
+            % (
+                payload.name,
+                row.wire_bytes,
+                "gzip" if args.gzip else "identity",
+                target.base_url,
+                would_be,
+                arm.delimiter,
+            )
+        )
+        log("  would then DELETE the table and confirm it is gone")
+        return row
+
+    # 4. fresh table for this rung
+    guard_production(target, args.i_am_a_human_confirming_production, "create a table")
+    name = table_name(arm.name, rung, stamp)
+    row.table = name
+    created = client.create_table(name, arm.columns, arm.constraints)
+    detail["create"] = asdict(created)
+    log("  create %s: %s" % (name, describe_http(created)[:200]))
+    if not created.ok:
+        row.outcome = "create-failed"
+        row.http_status = str(created.status)
+        row.responder = created.responder
+        row.error = created.error or created.body[:500]
+        row.response_body = created.body[:1000]
+        row.rung_wall_seconds = round(time.perf_counter() - started_wall, 3)
+        return row
+    row.table_created = True
+
+    # 5. upload, and always clean up afterwards
+    try:
+        log("  uploading %d bytes ..." % row.wire_bytes)
+        upload = client.upload(
+            name,
+            payload,
+            delimiter=arm.delimiter,
+            gzipped=bool(args.gzip),
+        )
+        detail["upload"] = asdict(upload)
+        row.connect_seconds = round(upload.connect_seconds, 3)
+        row.send_seconds = round(upload.send_seconds, 3)
+        row.wait_seconds = round(upload.wait_seconds, 3)
+        row.read_seconds = round(upload.read_seconds, 3)
+        row.upload_seconds = round(upload.total_seconds, 3)
+        row.http_status = str(upload.status) if upload.status is not None else "none"
+        row.responder = upload.responder
+        row.server_header = upload.headers.get("Server", "")
+        row.response_body = upload.body[:1500]
+        row.error = upload.error
+        row.wire_bytes_sent = upload.bytes_sent
+        log("  upload: %s" % describe_http(upload))
+        body = upload.json()
+        if upload.ok and isinstance(body, dict):
+            row.rows_reported = str(body.get("rows", ""))
+            row.event_id = str(body.get("event_id", ""))
+            id_range = body.get("id_range") or [None, None]
+            row.id_min, row.id_max = str(id_range[0]), str(id_range[1])
+            row.outcome = "success"
+        else:
+            row.outcome = _failure_label(upload)
+            log("  !! %s" % row.outcome)
+
+        if upload.ok and args.rowcount:
+            counted = client.row_count(name)
+            detail["rowcount"] = asdict(counted)
+            data = counted.json()
+            if isinstance(data, dict):
+                try:
+                    row.rowcount_after = str(data["data"][0][0])
+                except (KeyError, IndexError, TypeError):
+                    row.rowcount_after = counted.body[:80]
+    finally:
+        # cleanup is part of the run, never deferred (map standing rule)
+        if row.table_created and not args.keep_table:
+            dropped = client.drop_table(name)
+            detail["drop"] = asdict(dropped)
+            row.table_dropped = bool(dropped.ok)
+            gone = client.describe_table(name)
+            detail["confirm_gone"] = asdict(gone)
+            row.drop_verified = (
+                "gone (404)" if gone.status == 404 else "STILL THERE: %s" % gone.status
+            )
+            log(
+                "  drop %s: %s / %s"
+                % (name, describe_http(dropped)[:80], row.drop_verified)
+            )
+        elif args.keep_table:
+            row.drop_verified = "KEPT (--keep-table): drop it by hand"
+            log("  !! table %s kept on purpose - drop it by hand" % name)
+
+    row.compute_derived()
+    row.rung_wall_seconds = round(time.perf_counter() - started_wall, 3)
+    detail["row"] = asdict(row)
+    row.detail_file = str(
+        res.write_detail(Path(args.results).parent / "detail", run_id, detail)
+    )
+    return row
+
+
+def _failure_label(upload: HttpResult) -> str:
+    """Name the failure by WHO answered, never by the status alone."""
+    if upload.status is None:
+        return "transport-failure"
+    who = {PLATFORM: "platform", PROXY: "proxy/front-end"}.get(
+        upload.responder, "unidentified responder"
+    )
+    return "HTTP %s from %s" % (upload.status, who)
+
+
+# --- main ----------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m benchmarks.bulk_upload.run",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--target",
+        default="toep",
+        help="named target (%s) or a base URL" % ", ".join(cfg.TARGETS),
+    )
+    parser.add_argument(
+        "--arm", default="narrow", help="arm name (%s)" % ", ".join(cfg.ARMS)
+    )
+    parser.add_argument(
+        "--arms-file",
+        help="JSON file of arm definitions; how a schema decision plugs in",
+    )
+    parser.add_argument(
+        "--rungs",
+        default="1MB",
+        help="comma separated sizes, e.g. 1MB,10MB,100MB,1GB,1.95GB",
+    )
+    parser.add_argument("--results", default=str(DEFAULT_RESULTS))
+    parser.add_argument(
+        "--work-dir",
+        default=str(Path(tempfile.gettempdir()) / "oep_bulk_bench"),
+        help="where slices and their .gz live (they are large)",
+    )
+    parser.add_argument("--no-cache", action="store_true", help="re-slice every time")
+    parser.add_argument("--gzip", action="store_true", default=True)
+    parser.add_argument(
+        "--no-gzip", dest="gzip", action="store_false", help="send the CSV uncompressed"
+    )
+    parser.add_argument("--gzip-level", type=int, default=6)
+    parser.add_argument("--timeout", type=float, default=3600.0)
+    parser.add_argument("--insecure", action="store_true", help="skip TLS verification")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="everything but the send"
+    )
+    parser.add_argument("--check-auth", action="store_true")
+    parser.add_argument("--probe-body-limit", action="store_true")
+    parser.add_argument("--keep-table", action="store_true")
+    parser.add_argument("--rowcount", action="store_true", default=True)
+    parser.add_argument("--no-rowcount", dest="rowcount", action="store_false")
+    parser.add_argument("--verify-slice", action="store_true", default=True)
+    parser.add_argument("--no-verify-slice", dest="verify_slice", action="store_false")
+    parser.add_argument(
+        "--verify-max-bytes",
+        type=int,
+        default=2 * 10**9,
+        help=(
+            "above this, skip re-parsing the slice (measured: re-parsing the "
+            "full 1.95 GB fat slice costs ~12 s, so the default covers every "
+            "rung on this map's staircase)"
+        ),
+    )
+    parser.add_argument(
+        "--i-am-a-human-confirming-production",
+        action="store_true",
+        help="required for any write against a production target",
+    )
+    return parser
+
+
+def resolve_target(name: str) -> cfg.Target:
+    if name in cfg.TARGETS:
+        return cfg.TARGETS[name]
+    if "://" in name:
+        parts = urlsplit(name)
+        # the short name ends up in run ids and file names, so it must not
+        # carry a scheme or a colon
+        short = re.sub(r"[^a-z0-9]+", "_", (parts.netloc or name).lower()).strip("_")
+        return cfg.Target(name=short or "custom", base_url=name, is_production=False)
+    raise BenchError(
+        "unknown target %r: use one of %s or a full base URL"
+        % (name, ", ".join(cfg.TARGETS))
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        target = resolve_target(args.target)
+        if args.insecure and target.is_production:
+            raise BenchError(
+                "--insecure against production is refused: it would send the "
+                "account's token over a connection nobody authenticated. "
+                "Production's certificate chain is valid; if it stopped "
+                "verifying, that is an incident, not a flag to pass."
+            )
+        # the probe is unauthenticated and a dry run never sends anything,
+        # so only a real run (or --check-auth) needs the credential
+        probe_only = args.probe_body_limit and not args.check_auth
+        token = read_token(required=not (probe_only or args.dry_run))
+        client = BenchClient(
+            target.base_url,
+            token=token,
+            timeout=args.timeout,
+            insecure=args.insecure,
+        )
+        if args.insecure:
+            log(
+                "!! --insecure: TLS certificates are NOT verified. The token "
+                "will be sent to whoever answers %s. Only acceptable because "
+                "toep.iks.cs.ovgu.de serves an incomplete certificate chain; "
+                "never use it against production." % target.base_url
+            )
+
+        if args.probe_body_limit and not args.check_auth:
+            probe_body_limit(client)
+            return 0
+
+        if args.check_auth:
+            report = check_auth(client, target, args.i_am_a_human_confirming_production)
+            out = Path(args.results).parent / "detail"
+            path = res.write_detail(
+                out, "checkauth_%s_%s" % (target.name, uuid.uuid4().hex[:8]), report
+            )
+            log("\nfull preflight record: %s" % path)
+            return 0
+
+        arms = cfg.load_arms(Path(args.arms_file)) if args.arms_file else cfg.ARMS
+        if args.arm not in arms:
+            raise BenchError(
+                "unknown arm %r: known arms are %s" % (args.arm, ", ".join(arms))
+            )
+        arm = arms[args.arm]
+        rungs = [r.strip() for r in args.rungs.split(",") if r.strip()]
+
+        log("target      : %s (%s)" % (target.name, target.base_url))
+        log("arm         : %s <- %s" % (arm.name, arm.source))
+        log("schema hash : %s" % res.schema_fingerprint(arm.columns, arm.constraints))
+        log("rungs       : %s" % ", ".join(rungs))
+        log("results     : %s" % args.results)
+        if arm.note:
+            log("arm note    : %s" % arm.note)
+
+        exit_code = 0
+        for rung in rungs:
+            row = run_rung(client, target, arm, rung, args)
+            res.append_row(Path(args.results), row)
+            log("  recorded: %s %s" % (row.outcome, row.detail_file))
+            if row.outcome not in ("success", "dry-run"):
+                log(
+                    "\nSTOPPING the staircase at %s: %s. That failure IS the "
+                    "finding - read the response body above and say which "
+                    "layer answered before climbing further." % (rung, row.outcome)
+                )
+                exit_code = 2
+                break
+        return exit_code
+    except BenchError as exc:
+        log("\nERROR: %s" % exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bulk_upload/slicing.py
+++ b/benchmarks/bulk_upload/slicing.py
@@ -1,0 +1,316 @@
+"""CSV-aware slicing of a reference file into rung-sized benchmark inputs.
+
+Why this module exists at all: the fat reference file
+(`open_modex_bsf_timeseries.csv`) carries a ~111 KB quoted JSON array per
+row, and that array is full of commas. Cutting it with `head -c` splits a
+record, COPY fails on the truncated line, and the run measures a rollback
+instead of a load. So slices are cut on RECORD boundaries, found with a
+quote-aware scanner, and the target byte size is a target: the actual
+bytes and the actual row count are measured, never assumed.
+
+The scanner works on bytes and hands back the original record bytes, so
+the default path copies records verbatim - no decode/re-encode, no change
+in what is being measured. Only the optional projection path (dropping or
+renumbering columns) rewrites records, and it says so in its result.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+READ_CHUNK = 1 << 20  # 1 MiB
+
+# CSV fields can legally be far larger than the stdlib default 128 KiB
+# limit - the fat file's `series` column is already ~111 KB.
+csv.field_size_limit(64 * 1024 * 1024)
+
+_QUOTE = 0x22
+
+
+class SliceError(RuntimeError):
+    """Raised when a slice cannot be produced as configured."""
+
+
+def iter_records(fh, chunk_size: int = READ_CHUNK) -> Iterator[tuple[int, int, bytes]]:
+    """Yield `(start, end, data)` for each RFC 4180 record in `fh`.
+
+    A record ends at the first newline that is NOT inside a quoted field;
+    doubled quotes (`""`) inside a quoted field are handled. `data` is the
+    record exactly as written, terminating newline (and the CR of a CRLF
+    pair) included, so writing it out reproduces the source byte for byte.
+    The header is simply the first record.
+
+    `fh` must be binary and positioned at the start, and must not be
+    touched by the caller while iterating: this generator owns the file
+    position. Memory stays bounded by one record plus one chunk.
+    """
+    buf = b""
+    base = 0  # absolute offset of buf[0]
+    i = 0  # scan cursor inside buf
+    record_start = 0  # absolute offset of the record being scanned
+    in_quotes = False
+    eof = False
+
+    def refill() -> bool:
+        """Drop bytes before the current record, then read one chunk."""
+        nonlocal buf, base, i
+        keep = record_start - base
+        if keep:
+            buf = buf[keep:]
+            base += keep
+            i -= keep
+        more = fh.read(chunk_size)
+        if not more:
+            return False
+        buf += more
+        return True
+
+    while True:
+        if in_quotes:
+            j = buf.find(b'"', i)
+            if j == -1:
+                i = len(buf)
+                if eof:
+                    break
+                eof = not refill()
+                continue
+            if j + 1 >= len(buf):
+                # cannot yet tell a closing quote from an escaped one
+                if not eof:
+                    eof = not refill()
+                    continue
+                in_quotes = False
+                i = j + 1
+                continue
+            if buf[j + 1] == _QUOTE:
+                i = j + 2  # escaped quote, still inside the field
+            else:
+                in_quotes = False
+                i = j + 1
+            continue
+
+        q = buf.find(b'"', i)
+        n = buf.find(b"\n", i)
+        if q == -1 and n == -1:
+            i = len(buf)
+            if eof:
+                break
+            eof = not refill()
+            continue
+        if n == -1 or (q != -1 and q < n):
+            in_quotes = True
+            i = q + 1
+            continue
+        end = base + n + 1
+        yield record_start, end, buf[record_start - base : end - base]
+        record_start = end
+        i = n + 1
+
+    tail_end = base + len(buf)
+    if tail_end > record_start:
+        # a final record without a trailing newline
+        yield record_start, tail_end, buf[record_start - base :]
+
+
+@dataclass
+class SliceResult:
+    """What a slice actually is - measured, not intended."""
+
+    path: Path
+    target_bytes: int
+    actual_bytes: int  # including the header line
+    rows: int  # data rows, header excluded
+    header_bytes: int
+    source_records_read: int
+    source_passes: int  # >1 means the source was repeated to fill the rung
+    rewritten: bool  # True if records were re-serialised (projection path)
+
+    @property
+    def fill_ratio(self) -> float:
+        return self.actual_bytes / self.target_bytes if self.target_bytes else 0.0
+
+
+def read_header(path: Path) -> bytes:
+    """The first record of a CSV file, newline included."""
+    with open(path, "rb") as fh:
+        for _start, _end, data in iter_records(fh):
+            return data
+    raise SliceError("reference file %s has no header record" % path)
+
+
+def header_columns(path: Path, delimiter: str = ",") -> list[str]:
+    """Column names of a reference file, in file order."""
+    text = read_header(path).decode("utf-8").rstrip("\r\n")
+    return next(csv.reader(io.StringIO(text), delimiter=delimiter))
+
+
+def _project(
+    record: bytes,
+    keep_index: list[int],
+    delimiter: str,
+    id_position: int | None,
+    next_id: int | None,
+) -> bytes:
+    text = record.decode("utf-8").rstrip("\r\n")
+    fields = next(csv.reader(io.StringIO(text), delimiter=delimiter))
+    kept = [fields[k] for k in keep_index]
+    if id_position is not None and next_id is not None:
+        kept[id_position] = str(next_id)
+    out = io.StringIO()
+    csv.writer(out, delimiter=delimiter, lineterminator="\n").writerow(kept)
+    return out.getvalue().encode("utf-8")
+
+
+def slice_csv(
+    source: Path,
+    dest: Path,
+    target_bytes: int,
+    *,
+    delimiter: str = ",",
+    drop_columns: Iterable[str] = (),
+    renumber_id: bool = False,
+    repeat: bool = False,
+    max_passes: int = 200,
+) -> SliceResult:
+    """Write a rung-sized, valid CSV slice of `source` to `dest`.
+
+    Records are added whole until the next one would exceed
+    `target_bytes`; at least one record is always written. The header is
+    always present. Nothing is held in memory beyond one record.
+
+    `drop_columns` and `renumber_id` switch on the projection path, which
+    re-serialises every record (slower, and the bytes are no longer the
+    source's bytes - `SliceResult.rewritten` records that). `repeat`
+    cycles the source when it is smaller than the rung; that would
+    duplicate `id` values, which the bulk upload id contract rejects, so
+    `id` must then be dropped or renumbered.
+    """
+    source = Path(source)
+    dest = Path(dest)
+    drop = list(drop_columns)
+    columns = header_columns(source, delimiter=delimiter)
+    for name in drop:
+        if name not in columns:
+            raise SliceError(
+                "cannot drop column %r: not in %s header %s" % (name, source, columns)
+            )
+    keep = [c for c in columns if c not in drop]
+    if not keep:
+        raise SliceError("dropping %s would leave no columns" % drop)
+    keep_index = [columns.index(c) for c in keep]
+
+    id_position = keep.index("id") if "id" in keep else None
+    if renumber_id and id_position is None:
+        raise SliceError("renumber_id requested but no 'id' column is emitted")
+    if repeat and id_position is not None and not renumber_id:
+        raise SliceError(
+            "repeating the source would duplicate 'id' values, which the bulk "
+            "upload id contract rejects: drop 'id' or set renumber_id"
+        )
+
+    rewritten = bool(drop) or renumber_id
+    if rewritten:
+        out = io.StringIO()
+        csv.writer(out, delimiter=delimiter, lineterminator="\n").writerow(keep)
+        header_bytes = out.getvalue().encode("utf-8")
+    else:
+        header_bytes = read_header(source)
+        if not header_bytes.endswith(b"\n"):
+            header_bytes += b"\n"
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    total = len(header_bytes)
+    rows = 0
+    records_read = 0
+    passes = 0
+    next_id = 1
+    tmp = dest.with_name(dest.name + ".partial")
+
+    with open(tmp, "wb") as out_fh:
+        out_fh.write(header_bytes)
+        done = False
+        while not done:
+            passes += 1
+            if passes > max_passes:
+                raise SliceError(
+                    "source %s exhausted after %d passes without reaching %d bytes"
+                    % (source, max_passes, target_bytes)
+                )
+            wrote_this_pass = False
+            with open(source, "rb") as in_fh:
+                for index, (_start, _end, record) in enumerate(iter_records(in_fh)):
+                    if index == 0:
+                        continue  # the source header, already handled
+                    records_read += 1
+                    if rewritten:
+                        record = _project(
+                            record,
+                            keep_index,
+                            delimiter,
+                            id_position,
+                            next_id if renumber_id else None,
+                        )
+                    elif not record.endswith(b"\n"):
+                        record += b"\n"
+                    if rows and total + len(record) > target_bytes:
+                        done = True
+                        break
+                    out_fh.write(record)
+                    total += len(record)
+                    rows += 1
+                    next_id += 1
+                    wrote_this_pass = True
+                    if total >= target_bytes:
+                        done = True
+                        break
+            if not done and not repeat:
+                done = True
+            if not done and not wrote_this_pass:
+                raise SliceError("source %s yielded no data records" % source)
+
+    os.replace(tmp, dest)
+    actual = dest.stat().st_size
+    if actual != total:
+        raise SliceError(
+            "slice bookkeeping mismatch: counted %d bytes, file is %d" % (total, actual)
+        )
+    return SliceResult(
+        path=dest,
+        target_bytes=target_bytes,
+        actual_bytes=actual,
+        rows=rows,
+        header_bytes=len(header_bytes),
+        source_records_read=records_read,
+        source_passes=passes,
+        rewritten=rewritten,
+    )
+
+
+def verify_slice(
+    path: Path, expected_columns: int, delimiter: str = ","
+) -> tuple[int, set[int]]:
+    """Re-parse a slice with the stdlib CSV reader.
+
+    Returns `(data_rows, {field counts seen})`. If the slicer ever cut a
+    record in half this is where it shows: a parse error, or a row whose
+    field count differs from the header's.
+    """
+    counts: set[int] = set()
+    rows = 0
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        reader = csv.reader(fh, delimiter=delimiter)
+        header = next(reader)
+        counts.add(len(header))
+        if len(header) != expected_columns:
+            raise SliceError(
+                "header has %d columns, expected %d" % (len(header), expected_columns)
+            )
+        for row in reader:
+            rows += 1
+            counts.add(len(row))
+    return rows, counts

--- a/benchmarks/bulk_upload/tests/test_client.py
+++ b/benchmarks/bulk_upload/tests/test_client.py
@@ -9,8 +9,18 @@ wrong, a rung blames the wrong layer.
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 
-from benchmarks.bulk_upload.client import PLATFORM, PROXY, UNKNOWN, classify_responder
+from benchmarks.bulk_upload.client import (
+    PLATFORM,
+    PROXY,
+    SEND_CHUNK,
+    UNKNOWN,
+    BenchClient,
+    HttpResult,
+    classify_responder,
+    peek_early_response,
+)
 from benchmarks.bulk_upload.config import parse_size, rung_label
 from benchmarks.bulk_upload.results import ResultRow, schema_fingerprint
 
@@ -165,6 +175,126 @@ class ProductionGuardTests(unittest.TestCase):
         for path in root.rglob("*.py"):
             text = path.read_text(encoding="utf-8")
             self.assertIsNone(pattern.search(text), "token literal in %s" % path)
+
+
+class EarlyResponseDetectionTests(unittest.TestCase):
+    """Regression cover for the deadlock in WF-14.
+
+    A readable socket is not an answered request. On TLS 1.3 the server sends a
+    NewSessionTicket immediately after the handshake, so `select()` reports the
+    fd readable with no HTTP response behind it. The original client believed
+    `select()`, stopped sending after one 1 MiB chunk, and then blocked forever
+    in `getresponse()` while the server waited for the rest of the declared
+    Content-Length. Measured against production: every upload above SEND_CHUNK
+    hung; 4,224,952 bytes timed out at 240 s where curl took 1.13 s.
+    """
+
+    class _FakeSock:
+        def __init__(self, behaviour):
+            self.behaviour = behaviour
+            self.blocking = True
+
+        def setblocking(self, flag):
+            self.blocking = flag
+
+        def recv(self, _n):
+            if isinstance(self.behaviour, Exception):
+                raise self.behaviour
+            return self.behaviour
+
+    def test_tls_bookkeeping_is_not_an_answer(self):
+        """SSLWantReadError means keep sending -- this is the actual bug."""
+        import ssl as _ssl
+
+        sock = self._FakeSock(_ssl.SSLWantReadError())
+        self.assertEqual(peek_early_response(sock), b"")
+
+    def test_blocking_io_error_is_not_an_answer(self):
+        sock = self._FakeSock(BlockingIOError())
+        self.assertEqual(peek_early_response(sock), b"")
+
+    def test_real_bytes_are_an_answer(self):
+        sock = self._FakeSock(b"HTTP/1.1 413 Payload Too Large\r\n\r\n")
+        self.assertTrue(peek_early_response(sock).startswith(b"HTTP/1.1 413"))
+
+    def test_the_socket_is_left_blocking(self):
+        """A non-blocking socket left behind would corrupt the rest of the send."""
+        import ssl as _ssl
+
+        sock = self._FakeSock(_ssl.SSLWantReadError())
+        peek_early_response(sock)
+        self.assertTrue(sock.blocking)
+
+    def test_an_early_response_is_parsed_from_consumed_bytes(self):
+        """Once bytes are off the wire, getresponse() cannot be used."""
+        raw = (
+            b"HTTP/1.1 413 Payload Too Large\r\n"
+            b"Content-Type: text/html\r\n"
+            b"Content-Length: 22\r\n\r\n"
+            b"<html>too big</html>\r\n"
+        )
+        client = BenchClient("https://example.invalid", token="x")
+        result = HttpResult(method="POST", path="/p", status=None)
+        client._finish_from_bytes(raw, result)
+        self.assertEqual(result.status, 413)
+        self.assertIn("too big", result.body)
+        self.assertEqual(result.responder, PROXY)
+
+
+class UploadOverChunkSizeTests(unittest.TestCase):
+    """End-to-end over a real socket: a body larger than SEND_CHUNK must land.
+
+    On the pre-fix client this test hangs rather than fails, which is why the
+    outer timeout matters -- the bug's signature is a stall, not an exception.
+    """
+
+    def test_multi_chunk_body_is_sent_whole(self):
+        import http.server
+        import tempfile
+        import threading
+
+        received = {}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers["Content-Length"])
+                body = b""
+                while len(body) < length:
+                    body += self.rfile.read(min(65536, length - len(body)))
+                received["bytes"] = len(body)
+                payload = b'{"rows": 1, "event_id": 99}'
+                self.send_response(201)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *a):  # silence
+                pass
+
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            size = (SEND_CHUNK * 3) + 12345  # forces four writes
+            with tempfile.NamedTemporaryFile(delete=False) as fh:
+                fh.write(b"x" * size)
+                path = Path(fh.name)
+            client = BenchClient(
+                "http://127.0.0.1:%d" % server.server_address[1],
+                token="test",
+                timeout=60,
+            )
+            result = client.upload("t", path, gzipped=False)
+            self.assertEqual(result.status, 201, result.error)
+            self.assertEqual(result.bytes_sent, size)
+            self.assertEqual(received.get("bytes"), size)
+            self.assertEqual(result.responder, PLATFORM)
+        finally:
+            server.shutdown()
+            server.server_close()
+            path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/benchmarks/bulk_upload/tests/test_client.py
+++ b/benchmarks/bulk_upload/tests/test_client.py
@@ -1,0 +1,171 @@
+"""Tests for the response classifier and the run's small pure helpers.
+
+The map's standing rule is that a status code is never read alone:
+Apache answers its own 408 (HTML) on an idle request body after ~10 s and
+the platform's stall guard also answers 408 (JSON). If this classifier is
+wrong, a rung blames the wrong layer.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from benchmarks.bulk_upload.client import PLATFORM, PROXY, UNKNOWN, classify_responder
+from benchmarks.bulk_upload.config import parse_size, rung_label
+from benchmarks.bulk_upload.results import ResultRow, schema_fingerprint
+
+APACHE_408 = (
+    '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n<html><head>\n'
+    "<title>408 Request Timeout</title>\n</head><body>\n"
+    "<h1>Request Timeout</h1>\n</body></html>\n"
+)
+PLATFORM_408 = '{"reason": "Upload stalled: below 10240 bytes/second"}'
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_apache_html_408_is_the_proxy(self):
+        self.assertEqual(
+            classify_responder(408, {"Server": "Apache/2.4.52"}, APACHE_408), PROXY
+        )
+
+    def test_platform_json_408_is_the_platform(self):
+        self.assertEqual(
+            classify_responder(408, {"Content-Type": "application/json"}, PLATFORM_408),
+            PLATFORM,
+        )
+
+    def test_same_status_two_answers(self):
+        proxy = classify_responder(408, {}, APACHE_408)
+        platform = classify_responder(408, {}, PLATFORM_408)
+        self.assertNotEqual(proxy, platform)
+
+    def test_413_from_a_proxy_and_from_the_platform_are_distinguished(self):
+        nginx = "<html>\r\n<head><title>413 Request Entity Too Large</title></head>\r\n"
+        self.assertEqual(classify_responder(413, {}, nginx), PROXY)
+        self.assertEqual(
+            classify_responder(413, {}, '{"reason": "Upload too large"}'), PLATFORM
+        )
+
+    def test_json_array_body(self):
+        self.assertEqual(classify_responder(200, {}, "[]"), PLATFORM)
+
+    def test_content_type_is_the_fallback(self):
+        self.assertEqual(
+            classify_responder(500, {"Content-Type": "text/html"}, "boom"), PROXY
+        )
+        self.assertEqual(
+            classify_responder(500, {"Content-Type": "application/json"}, ""), PLATFORM
+        )
+
+    def test_unclassifiable_says_so_rather_than_guessing(self):
+        self.assertEqual(classify_responder(502, {}, "upstream gone"), UNKNOWN)
+
+    def test_a_json_looking_body_that_is_not_json_is_not_the_platform(self):
+        self.assertEqual(classify_responder(500, {}, "{not json at all"), UNKNOWN)
+
+
+class SizeTests(unittest.TestCase):
+    def test_decimal_and_binary_units_are_distinct(self):
+        self.assertEqual(parse_size("1MB"), 10**6)
+        self.assertEqual(parse_size("1MiB"), 1024**2)
+        self.assertEqual(parse_size("1.95GB"), 1_950_000_000)
+        self.assertEqual(parse_size("512"), 512)
+
+    def test_unknown_unit_is_refused(self):
+        with self.assertRaises(ValueError):
+            parse_size("3 parsecs")
+
+    def test_rung_labels_are_identifier_safe(self):
+        self.assertEqual(rung_label("1.95GB"), "1_95gb")
+        self.assertEqual(rung_label("100MB"), "100mb")
+
+
+class ResultRowTests(unittest.TestCase):
+    def test_derived_throughput(self):
+        row = ResultRow(slice_bytes=10**7, wire_bytes=10**6, slice_rows=1000)
+        row.upload_seconds = 10.0
+        row.outcome = "success"
+        row.compute_derived()
+        self.assertEqual(row.mb_per_s_uncompressed, 1.0)
+        self.assertEqual(row.mb_per_s_wire, 0.1)
+        self.assertEqual(row.rows_per_s, 100.0)
+        self.assertEqual(row.compress_ratio, 10.0)
+
+    def test_derived_is_safe_without_a_measurement(self):
+        row = ResultRow()
+        row.compute_derived()
+        self.assertEqual(row.rows_per_s, 0.0)
+
+    def test_a_failed_rung_reports_no_throughput(self):
+        """A rung refused after 1 MB of 36 MB is not a 50 GB/s result."""
+        row = ResultRow(
+            slice_bytes=10**8,
+            wire_bytes=36 * 10**6,
+            wire_bytes_sent=10**6,
+            slice_rows=777,
+            outcome="HTTP 413 from proxy/front-end",
+        )
+        row.upload_seconds = 0.002
+        row.compute_derived()
+        self.assertEqual(row.mb_per_s_uncompressed, 0.0)
+        self.assertEqual(row.mb_per_s_wire, 0.0)
+        self.assertEqual(row.rows_per_s, 0.0)
+        # but the compression ratio and what actually left survive
+        self.assertAlmostEqual(row.compress_ratio, 2.7778, places=3)
+        self.assertEqual(row.wire_bytes_sent, 10**6)
+
+    def test_schema_fingerprint_changes_with_the_column_typing(self):
+        text = schema_fingerprint([{"name": "series", "data_type": "text"}], [])
+        jsonb = schema_fingerprint([{"name": "series", "data_type": "jsonb"}], [])
+        self.assertNotEqual(text, jsonb)
+        self.assertEqual(
+            text, schema_fingerprint([{"name": "series", "data_type": "text"}], [])
+        )
+
+
+class ProductionGuardTests(unittest.TestCase):
+    """A write to production must be impossible without an explicit human."""
+
+    def test_production_target_refuses_writes_by_default(self):
+        from benchmarks.bulk_upload.config import TARGETS
+        from benchmarks.bulk_upload.run import BenchError, guard_production
+
+        self.assertTrue(TARGETS["prod"].is_production)
+        with self.assertRaises(BenchError):
+            guard_production(TARGETS["prod"], False, "create a table")
+
+    def test_production_target_allows_writes_when_confirmed(self):
+        from benchmarks.bulk_upload.config import TARGETS
+        from benchmarks.bulk_upload.run import guard_production
+
+        guard_production(TARGETS["prod"], True, "create a table")
+
+    def test_toep_is_not_production(self):
+        from benchmarks.bulk_upload.config import TARGETS
+        from benchmarks.bulk_upload.run import guard_production
+
+        self.assertFalse(TARGETS["toep"].is_production)
+        guard_production(TARGETS["toep"], False, "create a table")
+
+    def test_a_url_target_gets_a_filesystem_safe_name(self):
+        from benchmarks.bulk_upload.run import resolve_target
+
+        target = resolve_target("http://127.0.0.1:8099")
+        self.assertNotIn("/", target.name)
+        self.assertNotIn(":", target.name)
+        self.assertEqual(target.base_url, "http://127.0.0.1:8099")
+
+    def test_the_harness_contains_no_token_literal(self):
+        """The one rule WF-03 set: no credential in any source file."""
+        import pathlib
+        import re as _re
+
+        root = pathlib.Path(__file__).resolve().parents[2]
+        pattern = _re.compile(r"Token\s+[A-Za-z0-9]{20,}")
+        for path in root.rglob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            self.assertIsNone(pattern.search(text), "token literal in %s" % path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/bulk_upload/tests/test_slicing.py
+++ b/benchmarks/bulk_upload/tests/test_slicing.py
@@ -1,0 +1,199 @@
+"""Tests for the CSV-aware slicer.
+
+The slicer is the piece that can silently poison every measurement: a
+byte-sliced fat file fails mid-record, COPY rolls back, and the harness
+reports the wall clock of a rollback as if it were a load. So the record
+scanner is tested against handcrafted edge cases AND, when the reference
+data is present on the machine, against the real files.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import unittest
+from pathlib import Path
+
+from benchmarks.bulk_upload import config
+from benchmarks.bulk_upload.slicing import (
+    SliceError,
+    header_columns,
+    iter_records,
+    slice_csv,
+    verify_slice,
+)
+
+FAT = config.DEFAULT_REFERENCE_DIR / "open_modex_bsf_timeseries.csv"
+NARROW = config.DEFAULT_REFERENCE_DIR / "open_modex_bsf_data.csv"
+
+
+def records(data: bytes, chunk_size: int = 8) -> list[bytes]:
+    return [rec for _s, _e, rec in iter_records(io.BytesIO(data), chunk_size)]
+
+
+class RecordScannerTests(unittest.TestCase):
+    def test_plain_records(self):
+        data = b"a,b\n1,2\n3,4\n"
+        self.assertEqual(records(data), [b"a,b\n", b"1,2\n", b"3,4\n"])
+
+    def test_quoted_comma_does_not_split(self):
+        data = b'a,b\n1,"x,y,z"\n2,"p,q"\n'
+        self.assertEqual(records(data), [b"a,b\n", b'1,"x,y,z"\n', b'2,"p,q"\n'])
+
+    def test_quoted_newline_does_not_end_the_record(self):
+        data = b'a,b\n1,"line one\nline two"\n2,"z"\n'
+        self.assertEqual(
+            records(data), [b"a,b\n", b'1,"line one\nline two"\n', b'2,"z"\n']
+        )
+
+    def test_escaped_quotes(self):
+        data = b'a\n"he said ""hi"", then left"\n"next"\n'
+        self.assertEqual(
+            records(data),
+            [b"a\n", b'"he said ""hi"", then left"\n', b'"next"\n'],
+        )
+
+    def test_crlf_is_preserved(self):
+        data = b"a,b\r\n1,2\r\n"
+        self.assertEqual(records(data), [b"a,b\r\n", b"1,2\r\n"])
+
+    def test_missing_final_newline(self):
+        data = b"a,b\n1,2"
+        self.assertEqual(records(data), [b"a,b\n", b"1,2"])
+
+    def test_chunk_boundaries_do_not_change_the_answer(self):
+        data = b'a,b\n1,"x,""y"",\nz"\n2,"q"\n3,4\n'
+        expected = records(data, chunk_size=4096)
+        for size in (1, 2, 3, 5, 7, 13, 64):
+            self.assertEqual(records(data, size), expected, "chunk size %d" % size)
+
+    def test_bytes_are_conserved(self):
+        data = b'a,b\n1,"x,y"\n2,"a""b"\n3,4\n'
+        self.assertEqual(b"".join(records(data, 3)), data)
+
+    def test_agrees_with_stdlib_csv_on_record_count(self):
+        data = b'a,b\n1,"x,y"\n2,"line\nbreak"\n3,"q""q"\n'
+        mine = len(records(data, 5))
+        theirs = sum(1 for _ in csv.reader(io.StringIO(data.decode())))
+        self.assertEqual(mine, theirs)
+
+
+class SliceTests(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.source = self.dir / "source.csv"
+        rows = "".join('%d,"a,b %d"\n' % (i, i) for i in range(1, 101))
+        self.source.write_bytes(b"id,payload\n" + rows.encode())
+
+    def test_header_is_always_carried(self):
+        result = slice_csv(self.source, self.dir / "out.csv", 40)
+        text = (self.dir / "out.csv").read_text()
+        self.assertTrue(text.startswith("id,payload\n"))
+        self.assertGreaterEqual(result.rows, 1)
+
+    def test_never_exceeds_the_target_beyond_one_record(self):
+        result = slice_csv(self.source, self.dir / "out.csv", 200)
+        self.assertLessEqual(result.actual_bytes, 200)
+        self.assertEqual(result.actual_bytes, (self.dir / "out.csv").stat().st_size)
+
+    def test_at_least_one_row_even_for_a_tiny_target(self):
+        result = slice_csv(self.source, self.dir / "out.csv", 1)
+        self.assertEqual(result.rows, 1)
+
+    def test_target_larger_than_source_stops_at_the_source(self):
+        result = slice_csv(self.source, self.dir / "out.csv", 10**9)
+        self.assertEqual(result.rows, 100)
+        self.assertEqual(result.source_passes, 1)
+
+    def test_repeat_requires_id_handling(self):
+        with self.assertRaises(SliceError):
+            slice_csv(self.source, self.dir / "out.csv", 10**5, repeat=True)
+
+    def test_repeat_with_renumbered_ids_is_monotonic(self):
+        result = slice_csv(
+            self.source,
+            self.dir / "out.csv",
+            20_000,
+            repeat=True,
+            renumber_id=True,
+        )
+        self.assertGreater(result.source_passes, 1)
+        self.assertTrue(result.rewritten)
+        with open(self.dir / "out.csv", newline="") as fh:
+            reader = csv.reader(fh)
+            next(reader)
+            ids = [int(r[0]) for r in reader]
+        self.assertEqual(ids, list(range(1, len(ids) + 1)))
+
+    def test_dropping_a_column(self):
+        result = slice_csv(
+            self.source, self.dir / "out.csv", 10**6, drop_columns=("id",)
+        )
+        rows, counts = verify_slice(self.dir / "out.csv", 1)
+        self.assertEqual(rows, result.rows)
+        self.assertEqual(counts, {1})
+
+    def test_dropping_an_unknown_column_is_an_error(self):
+        with self.assertRaises(SliceError):
+            slice_csv(self.source, self.dir / "out.csv", 100, drop_columns=("nope",))
+
+
+@unittest.skipUnless(
+    FAT.exists() and NARROW.exists(),
+    "reference data not present on this machine (%s)" % config.DEFAULT_REFERENCE_DIR,
+)
+class ReferenceFileTests(unittest.TestCase):
+    """The claim that matters: real slices of the real files parse."""
+
+    def setUp(self):
+        import tempfile
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_fat_slice_is_valid_csv_with_five_columns(self):
+        columns = header_columns(FAT)
+        self.assertEqual(len(columns), 5)
+        out = self.dir / "fat.csv"
+        result = slice_csv(FAT, out, 10 * 10**6)
+        rows, counts = verify_slice(out, 5)
+        self.assertEqual(rows, result.rows)
+        self.assertEqual(counts, {5}, "a split record would show up as a short row")
+        self.assertLessEqual(result.actual_bytes, 10 * 10**6)
+        # the fat file's records are ~111 KB, so a 10 MB rung is ~90 rows
+        self.assertGreater(result.rows, 10)
+
+    def test_fat_slice_bytes_are_the_source_bytes(self):
+        out = self.dir / "fat.csv"
+        result = slice_csv(FAT, out, 2 * 10**6)
+        self.assertFalse(result.rewritten)
+        with open(FAT, "rb") as fh:
+            prefix = fh.read(result.actual_bytes)
+        self.assertEqual(
+            out.read_bytes(),
+            prefix,
+            "an unrewritten slice must be a byte-exact prefix of the source",
+        )
+
+    def test_narrow_slice_is_valid_csv_with_fourteen_columns(self):
+        out = self.dir / "narrow.csv"
+        result = slice_csv(NARROW, out, 5 * 10**6)
+        rows, counts = verify_slice(out, 14)
+        self.assertEqual(rows, result.rows)
+        self.assertEqual(counts, {14})
+
+    def test_narrow_full_scan_matches_the_stdlib_reader(self):
+        with open(NARROW, "rb") as fh:
+            mine = sum(1 for _ in iter_records(fh))
+        with open(NARROW, newline="", encoding="utf-8") as fh:
+            theirs = sum(1 for _ in csv.reader(fh))
+        self.assertEqual(mine, theirs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


## Summary of the discussion

Every throughput number in the Bulk Upload PRD came from a Django test client against a local Postgres, produced by api/tests/bench_apply.py and api/tests/bench_bulk.py - which were never committed and survive only as stale .pyc files. The numbers cannot be reproduced today. This adds the harness back, in the repository, so the next release re-measures instead of re-deriving.

benchmarks/ is a new top-level package rather than scripts/, because scripts/ is gitignored (.gitignore:117) and therefore cannot hold anything meant to be re-run per release. The harness is standard library only and imports no Django: a benchmark has to run from the machine that has the uplink and the reference data, not only from one that can boot the platform.

What it does per rung: slice a rung-sized CSV out of a reference file, create a fresh sandbox table, upload it gzipped, time the phases client-side, append a result row, drop the table and confirm it is gone.

The slicer is the part that can silently poison every measurement. The fat reference file carries a ~111 KB quoted JSON array per row, full of commas, so a byte slice splits a record, COPY fails on the truncated line and the run measures a rollback rather than a load. Records are therefore found with a quote-aware byte scanner and copied whole; the target size is a target, while the actual bytes and rows are measured. Verified against the real files: the scanner reproduces the stdlib CSV reader's record count on both, conserves every byte of the 2,040,220,631-byte fat file, and a full 1.95 GB slice re-parses as 17,727 rows of exactly five fields.

Failures are findings, not absences. A rung refused mid-body records the status, who answered, the bytes that actually left and the response body, then stops the staircase. Who answered is decided by response body format, never by status code alone: Apache emits its own HTML 408 on an idle request body and the platform's stall guard emits a JSON 408. A failed rung reports no throughput at all, because dividing a fraction of the payload by a fraction of the time invents a headline number out of a refusal.

Column definitions are configuration, not code, and are replaceable from a JSON file: typing the fat file's `series` as text measures raw ingest while json/jsonb measures validated-JSON ingest, and those are different benchmarks. Each result row carries a fingerprint of the exact table definition it was loaded into, so rungs measured under different typings are never silently compared.

The credential is read only from OEP_BENCH_TOKEN and appears in no source file (there is a test for that). Production is write-protected behind an explicit flag, and --insecure is refused against production outright.


## Workflow checklist

### Automation

Closes #2426

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
