### PR TITLE
Drop the unfilled PR placeholder from the changelog

### DIFF
--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -16,7 +16,6 @@ SPDX-License-Identifier: CC0-1.0
 - `python manage.py fetch_oekg_shapes` obtains the canonical OEKG SHACL shape
   from a pinned revision of the `oekg` repository, and generates the
   `rdfs:label` subset validation needs from the OEO release already on disk.
-  (#PR)
 
 ## Bugs
 


### PR DESCRIPTION
## Summary of the discussion

This PR carries a one-line follow-up to the first slice of the OEKG REST API
work, which landed on `develop` directly rather than through a pull request:

- [`cbb731c2`](https://github.com/OpenEnergyPlatform/oeplatform/commit/cbb731c2c3509b1d0d78a200297109613ceecda5)
  — *Fetch the OEKG SHACL shape from a pinned revision*
- [`42a8f79a`](https://github.com/OpenEnergyPlatform/oeplatform/commit/42a8f79a53035319dc2dd05b763501593218dcc7)
  — *Move the shape and its labels together, or not at all*

Together they add `python manage.py fetch_oekg_shapes`, the single seam through
which the platform obtains the two artifacts the OEKG REST API will validate
scenario bundles against:

| File | Source |
|---|---|
| `shapes/oekg_shapes.ttl` | fetched from the `oekg` repo at a **pinned** commit |
| `shapes/oeo_labels.ttl` | generated from the OEO release already under `ontologies/` |

Four properties are deliberate, each with a test:

- **The revision is pinned, and an unpinned one cannot be expressed.** The URL is
  assembled from a repository, a `PinnedRef` and a path, so no branch URL can be
  passed in; `--tag latest` / `main` / `production` is refused with a reason. An
  unpinned fetch would change the *validator* without a deploy.
- **The full ontology is never fetched.** `ex:CommonShape` needs exactly one
  `rdfs:label` on every OEO term a bundle picks — but only the labels. The
  subset is 2,058 triples and 198 KB, against 1.3 GB resident and ~36 s to parse
  `oeo-full.owl`, so it is extracted from the release already on disk.
- **A failed or partial fetch leaves the previous artifacts usable.** The body is
  parsed and checked to carry an `sh:NodeShape` before anything is written, both
  payloads are built before either is written, and each write is a rename.
- **Re-running is safe and says whether anything moved** — each artifact reports
  created / updated / unchanged with its size and digest.

Verified against the real source, not only in tests: 18,045 bytes of shape
(1,031 triples) and 2,058 label triples.

**Known gap, documented rather than hidden:** only half the pair is pinned. The
shape cannot move, but the OEO the labels come from can — `podman/Dockerfile`
and `docker-entrypoint.dev.sh` fetch `releases/latest`, and `podman-compose.yaml`
mounts a named volume over `/app/ontologies`. The command therefore prints the
release it used and writes that version into `oeo_labels.ttl`, so a moved
ontology shows up as an `updated` artifact instead of quietly changing what the
validator sees. `--oeo-version` pins it explicitly. Pinning the ontology fetch
itself is a separate job — it is already duplicated across four sites with three
URLs and inconsistent pinning.

**Deliberately not in this slice:** a boot-time check that the artifacts exist,
and calling the command from CI. Nothing reads the shape yet, so both would only
break environments that have not run it; they belong with the slice that first
reads the shape.

**Deviation worth flagging:** the design note put `OEKG_SHAPES_ROOT` in
`securitysettings.py` beside `ONTOLOGY_ROOT`. It landed in `settings.py` instead
— it is not a secret, and that file is tracked, so the pin lives under version
control where a bump is reviewable.

**What this PR itself changes:** the changelog entry ended with a literal
`(#PR)`. CONTRIBUTING asks for the pull request number there, but those commits
went to `develop` directly, so there was no number to fill in. Removing it is
better than leaving a placeholder that reads like a broken link.

## Type of change (CHANGELOG.md)

### Features

- `python manage.py fetch_oekg_shapes` obtains the canonical OEKG SHACL shape
  from a pinned revision of the `oekg` repository, and generates the
  `rdfs:label` subset validation needs from the OEO release already on disk
  [(#2428)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2428)
  — *entry added by the two commits above, not by this PR*

### Changes

- Remove the unfilled `(#PR2428)` placeholder from that changelog entry
  [(#)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2428)

### Documentation updates

- Document the shape and label artifacts in `oekg/README.md`, and add the
  `fetch_oekg_shapes` step to the installation guide
  [(#2428)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2428)
  — *added by the two commits above*

## Workflow checklist

### Automation

Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [x] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done