### PR TITLE
Feature oekg api create read bundle

### DIFF
--- a/.github/workflows/automated-testing.yaml
+++ b/.github/workflows/automated-testing.yaml
@@ -118,6 +118,11 @@ jobs:
           cp oeplatform/securitysettings.py.default oeplatform/securitysettings.py
           python manage.py collectstatic
           python manage.py compress
+      - name: OEKG shape artifacts
+        # The scenario-bundle API validates against these, so without them its
+        # tests skip and the validation this slice exists for is never checked.
+        # Needs the ontology step above: the label subset is generated from it.
+        run: python manage.py fetch_oekg_shapes
       - name: Migrations & User creation
         run: |
           python manage.py makemigrations --check

--- a/api/urls.py
+++ b/api/urls.py
@@ -72,6 +72,7 @@ from api.views import (
     table_approx_row_count_view,
     usrprop_api_view,
 )
+from oekg.api_views import ScenarioBundleAPIView, ScenarioBundleCollectionAPIView
 
 app_name = "api"
 
@@ -297,6 +298,19 @@ urlpatterns_v0 = [
         r"^scenario-bundle/scenario/manage-datasets/?$",
         ManageOekgScenarioDatasetsAPIView.as_view(),
         name="add-scenario-datasets",
+    ),
+    # The scenario-bundle REST API. Plural, and superseding the singular
+    # manage-datasets route above rather than extending it: that one writes
+    # predicates the canonical shape does not validate.
+    path(
+        "scenario-bundles/",
+        ScenarioBundleCollectionAPIView.as_view(),
+        name="scenario-bundles",
+    ),
+    path(
+        "scenario-bundles/<uid>/",
+        ScenarioBundleAPIView.as_view(),
+        name="scenario-bundle",
     ),
     path(
         "datasets/",

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -69,10 +69,18 @@ services:
       LOCAL_DB_PASSWORD: postgres
       LOCAL_DB_NAME: oedb
       LOCAL_DB_HOST: postgres
+      # The graph store is a service in this network, so name it here rather
+      # than relying on securitysettings.py. That file is each developer's own
+      # and securitysettings.py.default resolves the host to "localhost" -- which
+      # inside this container is the container itself, so the OEKG API would
+      # answer 503 instead of writing. Stated explicitly, the dev stack works
+      # whatever the local settings file happens to say.
+      RDF_DATABASE_HOST: fuseki
       VITE_DEV_MODE: "True"
       VITE_DEV_SERVER_URL: "http://vite:5173"
     depends_on:
       - postgres
+      - fuseki
 
   vite:
     build:

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -1,0 +1,168 @@
+"""The OEKG scenario-bundle API: create one, read one.
+
+The order of operations in a create is the whole point of this slice, so it is
+worth stating plainly:
+
+1. the payload is checked for structure, and an unknown key is refused;
+2. the acronym is checked for uniqueness, comparing like with like;
+3. the server mints the identifier;
+4. the **post-state** is assembled and validated against the shape;
+5. only then is anything written, in **one** request.
+
+Nothing is written before step 5, so an invalid payload leaves the graph
+untouched -- not "mostly untouched", untouched. And because one request is one
+transaction, a write that fails halfway leaves nothing behind either.
+
+Reads need no authentication: the SPARQL endpoint already serves the same data,
+so requiring a token here would protect nothing while making public research
+records awkward to read.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+import logging
+
+from django.urls import reverse
+from rdflib import Literal
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from factsheet.models import ScenarioBundleAccessControl
+from oekg.bundles import (
+    BUNDLE_CLASS,
+    DC,
+    bundle_iri,
+    bundle_payload,
+    build_bundle_graph,
+    mint_bundle_uid,
+)
+from oekg.graph_store import GraphStore, GraphStoreError
+from oekg.serializers import READ_ONLY_CONTAINER, ScenarioBundleSerializer
+from oekg.shape import ShapeUnavailable
+from oekg.validation import validate_post_state
+
+logger = logging.getLogger("oeplatform")
+
+
+class ScenarioBundleCollectionAPIView(APIView):
+    """`POST` creates a scenario bundle."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = ScenarioBundleSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        store = GraphStore.from_settings()
+        acronym = payload["acronym"].strip()
+        try:
+            if _acronym_taken(store, acronym):
+                return Response(
+                    {
+                        "detail": (
+                            f"A scenario bundle with the acronym {acronym!r} "
+                            "already exists. Acronyms identify a bundle to a "
+                            "pipeline, so they have to be unique."
+                        )
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            uid = mint_bundle_uid()
+            post_state = build_bundle_graph(uid, payload)
+
+            violations = validate_post_state(post_state)
+            if violations:
+                return Response(
+                    {
+                        "detail": "The bundle does not conform to the OEKG shape.",
+                        "violations": [v.as_dict() for v in violations],
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            store.insert(post_state)
+        except ShapeUnavailable as error:
+            logger.error("OEKG API cannot validate: %s", error)
+            return Response(
+                {"detail": "The OEKG shape is not available on this server."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except GraphStoreError as error:
+            logger.error("OEKG API write failed: %s", error)
+            return Response(
+                {"detail": "The OEKG graph store could not be written to."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        # Ownership is recorded now so the creator can edit later. A bundle with
+        # no ownership record is administrator-only by design, which would make
+        # every bundle this API creates uneditable by the person who created it.
+        ScenarioBundleAccessControl.objects.create(
+            owner_user=request.user, bundle_id=uid
+        )
+
+        location = reverse("api:scenario-bundle", kwargs={"uid": uid})
+        response = Response(
+            _represent(uid, bundle_payload(post_state, uid)),
+            status=status.HTTP_201_CREATED,
+        )
+        response["Location"] = location
+        return response
+
+
+class ScenarioBundleAPIView(APIView):
+    """`GET` returns one scenario bundle. Public."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, uid):
+        store = GraphStore.from_settings()
+        try:
+            subgraph = store.construct(
+                "CONSTRUCT { ?s ?p ?o } WHERE { "
+                f"  VALUES ?root {{ {bundle_iri(uid).n3()} }} "
+                "  { ?root ?p ?o . BIND(?root AS ?s) } "
+                "  UNION "
+                "  { ?root ?q ?s . ?s ?p ?o } "
+                "}"
+            )
+        except GraphStoreError as error:
+            logger.error("OEKG API read failed: %s", error)
+            return Response(
+                {"detail": "The OEKG graph store could not be read."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        if (bundle_iri(uid), None, None) not in subgraph:
+            return Response(
+                {"detail": f"No scenario bundle {uid}."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        return Response(_represent(uid, bundle_payload(subgraph, uid)))
+
+
+def _acronym_taken(store: GraphStore, acronym: str) -> bool:
+    """Whether a bundle already uses this acronym.
+
+    Compares the stored literal with the literal a write would store -- like
+    with like. The user interface's check normalises one side and not the other,
+    so any acronym with a space, hyphen, umlaut, slash, colon or parenthesis
+    slips past it.
+    """
+    return store.ask(
+        "ASK { ?bundle a %s ; %s %s }"
+        % (BUNDLE_CLASS.n3(), DC.acronym.n3(), Literal(acronym).n3())
+    )
+
+
+def _represent(uid: str, payload: dict) -> dict:
+    """A read returns exactly what a write accepts, plus one read-only key."""
+    return {
+        **payload,
+        READ_ONLY_CONTAINER: {"uid": uid, "iri": str(bundle_iri(uid))},
+    }

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -22,22 +22,26 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 """  # noqa: 501
 
 import logging
+import uuid
 
+from django.db import DatabaseError
 from django.urls import reverse
-from rdflib import Literal
+from rdflib import RDFS, Literal, URIRef
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from rest_framework.views import APIView
 
 from factsheet.models import ScenarioBundleAccessControl
 from oekg.bundles import (
     BUNDLE_CLASS,
     DC,
+    build_bundle_graph,
     bundle_iri,
     bundle_payload,
-    build_bundle_graph,
     mint_bundle_uid,
+    referenced_node_iris,
 )
 from oekg.graph_store import GraphStore, GraphStoreError
 from oekg.serializers import READ_ONLY_CONTAINER, ScenarioBundleSerializer
@@ -47,10 +51,21 @@ from oekg.validation import validate_post_state
 logger = logging.getLogger("oeplatform")
 
 
+class ScenarioBundleThrottle(AnonRateThrottle):
+    """Reads are public, so the public endpoint needs a ceiling of its own."""
+
+    scope = "oekg_bundles_anon"
+
+
+class ScenarioBundleUserThrottle(UserRateThrottle):
+    scope = "oekg_bundles_user"
+
+
 class ScenarioBundleCollectionAPIView(APIView):
     """`POST` creates a scenario bundle."""
 
     permission_classes = [IsAuthenticated]
+    throttle_classes = [ScenarioBundleThrottle, ScenarioBundleUserThrottle]
 
     def post(self, request):
         serializer = ScenarioBundleSerializer(data=request.data)
@@ -58,7 +73,10 @@ class ScenarioBundleCollectionAPIView(APIView):
         payload = serializer.validated_data
 
         store = GraphStore.from_settings()
-        acronym = payload["acronym"].strip()
+        # Checked and stored as the same value. Stripping one side only is how
+        # the user interface's check comes to miss duplicates.
+        payload["acronym"] = payload["acronym"].strip()
+        acronym = payload["acronym"]
         try:
             if _acronym_taken(store, acronym):
                 return Response(
@@ -72,8 +90,23 @@ class ScenarioBundleCollectionAPIView(APIView):
                     status=status.HTTP_409_CONFLICT,
                 )
 
+            known_labels = _labels_of(store, referenced_node_iris(payload))
+            renamed = _renames(payload, known_labels)
+            if renamed:
+                return Response(
+                    {
+                        "detail": (
+                            "A shared node cannot be renamed through this API. "
+                            "Reference it by iri and send the label it already "
+                            "has, or omit the iri to mint a new node."
+                        ),
+                        "conflicts": renamed,
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             uid = mint_bundle_uid()
-            post_state = build_bundle_graph(uid, payload)
+            post_state = build_bundle_graph(uid, payload, known_labels)
 
             violations = validate_post_state(post_state)
             if violations:
@@ -99,18 +132,32 @@ class ScenarioBundleCollectionAPIView(APIView):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
-        # Ownership is recorded now so the creator can edit later. A bundle with
+        # Ownership is recorded now so the creator can edit later: a bundle with
         # no ownership record is administrator-only by design, which would make
-        # every bundle this API creates uneditable by the person who created it.
-        ScenarioBundleAccessControl.objects.create(
-            owner_user=request.user, bundle_id=uid
-        )
+        # every bundle this API creates uneditable by its author.
+        #
+        # The graph and the database cannot share a transaction. The graph has
+        # already committed, so a failure here is logged and named in the
+        # response rather than turned into a 500 that would deny a write that
+        # did happen.
+        owned = True
+        try:
+            ScenarioBundleAccessControl.objects.create(
+                owner_user=request.user, bundle_id=uid
+            )
+        except DatabaseError:
+            owned = False
+            logger.exception(
+                "OEKG bundle %s was written to the graph but its ownership row "
+                "could not be saved. It is administrator-only until repaired.",
+                uid,
+            )
 
         location = reverse("api:scenario-bundle", kwargs={"uid": uid})
-        response = Response(
-            _represent(uid, bundle_payload(post_state, uid)),
-            status=status.HTTP_201_CREATED,
-        )
+        body = _represent(uid, bundle_payload(post_state, uid))
+        if not owned:
+            body[READ_ONLY_CONTAINER]["ownership_recorded"] = False
+        response = Response(body, status=status.HTTP_201_CREATED)
         response["Location"] = location
         return response
 
@@ -119,13 +166,24 @@ class ScenarioBundleAPIView(APIView):
     """`GET` returns one scenario bundle. Public."""
 
     permission_classes = [AllowAny]
+    throttle_classes = [ScenarioBundleThrottle, ScenarioBundleUserThrottle]
 
     def get(self, request, uid):
+        # Identifiers are minted here, so anything that is not one cannot name a
+        # bundle. Checked before it reaches a query, where an IRI-unsafe
+        # character would raise out of rdflib as a 500 rather than a 404.
+        if not _is_minted_identifier(uid):
+            return Response(
+                {"detail": f"No scenario bundle {uid}."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         store = GraphStore.from_settings()
         try:
             subgraph = store.construct(
                 "CONSTRUCT { ?s ?p ?o } WHERE { "
                 f"  VALUES ?root {{ {bundle_iri(uid).n3()} }} "
+                f"  ?root a {BUNDLE_CLASS.n3()} . "
                 "  { ?root ?p ?o . BIND(?root AS ?s) } "
                 "  UNION "
                 "  { ?root ?q ?s . ?s ?p ?o } "
@@ -144,6 +202,58 @@ class ScenarioBundleAPIView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
         return Response(_represent(uid, bundle_payload(subgraph, uid)))
+
+
+def _is_minted_identifier(uid: str) -> bool:
+    try:
+        uuid.UUID(str(uid))
+    except (ValueError, AttributeError, TypeError):
+        return False
+    return True
+
+
+def _labels_of(store: GraphStore, iris: list) -> dict:
+    """The label each of these nodes already carries, for the ones that exist."""
+    if not iris:
+        return {}
+    values = " ".join(URIRef(iri).n3() for iri in iris)
+    rows = store.select(
+        "SELECT ?node ?label WHERE { VALUES ?node { %s } ?node %s ?label }"
+        % (values, RDFS.label.n3())
+    )
+    return {row["node"]: row["label"] for row in rows}
+
+
+def _renames(payload: dict, known_labels: dict) -> list:
+    """Referenced nodes whose label the payload disagrees with.
+
+    The API offers no rename. Shared IRIs stay shared -- that is the point of a
+    graph -- but a shared contact or organisation is cited by other bundles, so
+    letting one payload rewrite its label would change every one of them.
+    """
+    conflicts = []
+    for iri in referenced_node_iris(payload):
+        if iri not in known_labels:
+            continue
+        for entry in _entries_for(payload, iri):
+            if entry["label"] != known_labels[iri]:
+                conflicts.append(
+                    {
+                        "iri": iri,
+                        "stored_label": known_labels[iri],
+                        "sent_label": entry["label"],
+                    }
+                )
+    return conflicts
+
+
+def _entries_for(payload: dict, iri: str) -> list:
+    return [
+        entry
+        for field_name in ("contacts", "organisations", "funders")
+        for entry in (payload.get(field_name) or [])
+        if entry.get("iri") == iri
+    ]
 
 
 def _acronym_taken(store: GraphStore, acronym: str) -> bool:

--- a/oekg/bundles.py
+++ b/oekg/bundles.py
@@ -52,10 +52,6 @@ class BundleField:
     node_class: Optional[URIRef] = None
     mint_segment: str = ""
 
-    @property
-    def is_multiple(self) -> bool:
-        return self.kind != LITERAL
-
 
 # The closed bundle field set: these and nothing else.
 BUNDLE_FIELDS = (
@@ -76,8 +72,6 @@ BUNDLE_FIELDS = (
     BundleField("models", HAS_PART, PART, OEO.OEO_00000277, "model"),
 )
 
-FIELDS_BY_NAME = {field.name: field for field in BUNDLE_FIELDS}
-
 
 def mint_bundle_uid() -> str:
     """A new bundle identifier. The server's to give, never the client's."""
@@ -89,12 +83,31 @@ def bundle_iri(uid: str) -> URIRef:
     return OEKG[uid]
 
 
-def build_bundle_graph(uid: str, payload: dict) -> Graph:
+def referenced_node_iris(payload: dict) -> list:
+    """Every existing node IRI the payload points at, across all node fields."""
+    iris = []
+    for field in BUNDLE_FIELDS:
+        if field.kind != NODE:
+            continue
+        for entry in payload.get(field.name) or []:
+            if entry.get("iri"):
+                iris.append(entry["iri"])
+    return iris
+
+
+def build_bundle_graph(uid: str, payload: dict, known_labels: dict = None) -> Graph:
     """Assemble the triples a bundle payload means.
 
     The result is the post-state to validate and, unchanged, the thing to
     write: nothing is added between validating and writing.
+
+    ``known_labels`` maps an already-existing node IRI to the label it already
+    carries. Shared IRIs stay shared -- that is the point of a graph -- so a
+    referenced node keeps its own label and this never writes a second one onto
+    it. Without that, an additive write would leave a contact other bundles
+    cite carrying two labels, violating sh:maxCount 1 for all of them.
     """
+    known_labels = known_labels or {}
     graph = Graph()
     subject = bundle_iri(uid)
     graph.add((subject, RDF.type, BUNDLE_CLASS))
@@ -111,10 +124,19 @@ def build_bundle_graph(uid: str, payload: dict) -> Graph:
                 graph.add((subject, field.predicate, URIRef(iri)))
         elif field.kind == NODE:
             for entry in value:
-                node = _node_for(entry.get("iri"), field)
+                iri = entry.get("iri")
+                node = URIRef(iri) if iri else _minted(field)
                 graph.add((subject, field.predicate, node))
-                graph.add((node, RDF.type, field.node_class))
-                graph.add((node, RDFS.label, Literal(entry["label"])))
+                if iri and iri in known_labels:
+                    # An existing shared node is referenced, never rewritten.
+                    # Its label comes from the graph so the post-state is
+                    # complete for validation, and the write adds nothing to a
+                    # node other bundles depend on.
+                    graph.add((node, RDF.type, field.node_class))
+                    graph.add((node, RDFS.label, Literal(known_labels[iri])))
+                else:
+                    graph.add((node, RDF.type, field.node_class))
+                    graph.add((node, RDFS.label, Literal(entry["label"])))
         elif field.kind == PART:
             for entry in value:
                 node = _minted(field)
@@ -165,21 +187,6 @@ def bundle_payload(graph: Graph, uid: str) -> dict:
                 key=lambda entry: entry["label"],
             )
     return payload
-
-
-def acronym_of(payload: dict) -> str:
-    return (payload.get("acronym") or "").strip()
-
-
-def _node_for(iri: Optional[str], field: BundleField) -> URIRef:
-    """Reference the node the payload names, or mint one.
-
-    Shared IRIs stay shared -- that is the point of a graph -- so a payload may
-    point at an existing contact or organisation. What it may not do is rename
-    one, which is why nothing here writes a label onto a node it did not mint
-    without the caller having said so.
-    """
-    return URIRef(iri) if iri else _minted(field)
 
 
 def _minted(field: BundleField) -> URIRef:

--- a/oekg/bundles.py
+++ b/oekg/bundles.py
@@ -1,0 +1,190 @@
+"""A scenario bundle, as triples and as a payload.
+
+One field table drives both directions, so a read returns exactly what a write
+accepts and neither can drift from the other. The table is traceable to the
+shape: every entry names the property the shape validates.
+
+Three decisions are worth stating here rather than leaving to be inferred:
+
+- **The server mints identifiers.** No client-supplied identifier is accepted,
+  so a pipeline cannot collide with, or overwrite, somebody else's bundle by
+  choosing a value.
+- **Minted nodes are typed.** The shape's ``sh:class`` constraints require it,
+  and the user interface does not do it -- the live graph carries violations it
+  produced. Writing ``rdf:type`` is one line and it is the difference between a
+  bundle that validates and one that only looks valid.
+- **Frameworks and models are minted per bundle.** They are fields, not
+  addressable resources, so nothing outside this bundle should reference them.
+  The user interface mints them globally, which is why deleting one bundle
+  today strips labels from every other bundle citing the same model.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+
+from rdflib import RDF, RDFS, Graph, Literal, Namespace, URIRef
+
+OEO = Namespace("https://openenergyplatform.org/ontology/oeo/")
+OEKG = Namespace("https://openenergyplatform.org/ontology/oekg/")
+OBO = Namespace("http://purl.obolibrary.org/obo/")
+DC = Namespace("http://purl.org/dc/terms/")
+
+BUNDLE_CLASS = OEO.OEO_00020227
+HAS_PART = OBO.BFO_0000051
+HAS_IRI = OEO.OEO_00390094
+
+# Kinds of field, which decide how a value becomes triples and back again.
+LITERAL = "literal"  # a plain string on the bundle
+ENUM = "enum"  # IRIs picked from one of the shape's sh:in lists
+NODE = "node"  # a referenced or minted node: {iri, label}
+PART = "part"  # a bundle-local node reached by has-part: {label, iri}
+
+
+@dataclass(frozen=True)
+class BundleField:
+    name: str
+    predicate: URIRef
+    kind: str
+    node_class: Optional[URIRef] = None
+    mint_segment: str = ""
+
+    @property
+    def is_multiple(self) -> bool:
+        return self.kind != LITERAL
+
+
+# The closed bundle field set: these and nothing else.
+BUNDLE_FIELDS = (
+    BundleField("label", RDFS.label, LITERAL),
+    BundleField("acronym", DC.acronym, LITERAL),
+    BundleField("abstract", DC.abstract, LITERAL),
+    BundleField("descriptors", OEO.OEO_00390071, ENUM),
+    BundleField("sector_divisions", OEO.OEO_00390079, ENUM),
+    BundleField("sectors", OEO.OEO_00020439, ENUM),
+    BundleField("technologies", OEO.OEO_00020438, ENUM),
+    BundleField("energy_carriers", OEO.OEO_00020432, ENUM),
+    BundleField("contacts", OEO.OEO_00000508, NODE, OEO.OEO_00000107, "contact"),
+    BundleField(
+        "organisations", OEO.OEO_00000510, NODE, OEO.OEO_00030022, "organisation"
+    ),
+    BundleField("funders", OEO.OEO_00000509, NODE, OEO.OEO_00090001, "funder"),
+    BundleField("frameworks", HAS_PART, PART, OEO.OEO_00000172, "framework"),
+    BundleField("models", HAS_PART, PART, OEO.OEO_00000277, "model"),
+)
+
+FIELDS_BY_NAME = {field.name: field for field in BUNDLE_FIELDS}
+
+
+def mint_bundle_uid() -> str:
+    """A new bundle identifier. The server's to give, never the client's."""
+    return str(uuid.uuid4())
+
+
+def bundle_iri(uid: str) -> URIRef:
+    """The IRI a bundle lives at -- the same one the user interface reads."""
+    return OEKG[uid]
+
+
+def build_bundle_graph(uid: str, payload: dict) -> Graph:
+    """Assemble the triples a bundle payload means.
+
+    The result is the post-state to validate and, unchanged, the thing to
+    write: nothing is added between validating and writing.
+    """
+    graph = Graph()
+    subject = bundle_iri(uid)
+    graph.add((subject, RDF.type, BUNDLE_CLASS))
+
+    for field in BUNDLE_FIELDS:
+        if field.name not in payload:
+            continue
+        value = payload[field.name]
+        if field.kind == LITERAL:
+            if value is not None and value != "":
+                graph.add((subject, field.predicate, Literal(value)))
+        elif field.kind == ENUM:
+            for iri in value:
+                graph.add((subject, field.predicate, URIRef(iri)))
+        elif field.kind == NODE:
+            for entry in value:
+                node = _node_for(entry.get("iri"), field)
+                graph.add((subject, field.predicate, node))
+                graph.add((node, RDF.type, field.node_class))
+                graph.add((node, RDFS.label, Literal(entry["label"])))
+        elif field.kind == PART:
+            for entry in value:
+                node = _minted(field)
+                graph.add((subject, field.predicate, node))
+                graph.add((node, RDF.type, field.node_class))
+                graph.add((node, RDFS.label, Literal(entry["label"])))
+                if entry.get("iri"):
+                    # has-iri is a STRING on these nodes, per the shape: it
+                    # points at a factsheet page, it is not the node's identity.
+                    graph.add((node, HAS_IRI, Literal(entry["iri"])))
+    return graph
+
+
+def bundle_payload(graph: Graph, uid: str) -> dict:
+    """Read a bundle subgraph back into exactly what a write would accept."""
+    subject = bundle_iri(uid)
+    payload = {}
+    for field in BUNDLE_FIELDS:
+        if field.kind == LITERAL:
+            value = graph.value(subject, field.predicate)
+            payload[field.name] = None if value is None else str(value)
+        elif field.kind == ENUM:
+            payload[field.name] = sorted(
+                str(obj) for obj in graph.objects(subject, field.predicate)
+            )
+        elif field.kind == NODE:
+            payload[field.name] = sorted(
+                (
+                    {
+                        "iri": str(node),
+                        "label": str(graph.value(node, RDFS.label) or ""),
+                    }
+                    for node in graph.objects(subject, field.predicate)
+                ),
+                key=lambda entry: entry["label"],
+            )
+        elif field.kind == PART:
+            # Frameworks and models share has-part; their type tells them apart.
+            payload[field.name] = sorted(
+                (
+                    {
+                        "label": str(graph.value(node, RDFS.label) or ""),
+                        "iri": _optional(graph.value(node, HAS_IRI)),
+                    }
+                    for node in graph.objects(subject, field.predicate)
+                    if (node, RDF.type, field.node_class) in graph
+                ),
+                key=lambda entry: entry["label"],
+            )
+    return payload
+
+
+def acronym_of(payload: dict) -> str:
+    return (payload.get("acronym") or "").strip()
+
+
+def _node_for(iri: Optional[str], field: BundleField) -> URIRef:
+    """Reference the node the payload names, or mint one.
+
+    Shared IRIs stay shared -- that is the point of a graph -- so a payload may
+    point at an existing contact or organisation. What it may not do is rename
+    one, which is why nothing here writes a label onto a node it did not mint
+    without the caller having said so.
+    """
+    return URIRef(iri) if iri else _minted(field)
+
+
+def _minted(field: BundleField) -> URIRef:
+    return OEKG[f"{field.mint_segment}/{uuid.uuid4()}"]
+
+
+def _optional(node) -> Optional[str]:
+    return None if node is None else str(node)

--- a/oekg/graph_store.py
+++ b/oekg/graph_store.py
@@ -109,8 +109,15 @@ class GraphStore:
 
     @classmethod
     def from_settings(cls, *, graph: Optional[str] = None) -> "GraphStore":
-        """Build the store the platform is configured to talk to."""
+        """Build the store the platform is configured to talk to.
+
+        ``graph`` defaults to ``settings.OEKG_GRAPH``, which is ``None`` -- the
+        default graph, where the platform's bundles live. A test overrides it to
+        work in a graph of its own without having to reach into the views.
+        """
         rdf = settings.RDF_DATABASES["knowledge"]
+        if graph is None:
+            graph = getattr(settings, "OEKG_GRAPH", None)
         base = "http://{host}:{port}/{name}".format(
             host=rdf["host"], port=rdf["port"], name=rdf["name"]
         )

--- a/oekg/graph_store.py
+++ b/oekg/graph_store.py
@@ -54,6 +54,11 @@ AVAILABILITY_TIMEOUT_SECONDS = 5
 # the store's state, so the probe is safe against any endpoint.
 AVAILABILITY_PROBE_GRAPH = "urn:oep:graph-store-availability-probe"
 
+# Distinguishes "use whatever is configured" from an explicit "the default
+# graph". Without it, asking for the default graph would silently pick up a
+# test's override instead.
+USE_CONFIGURED_GRAPH = object()
+
 
 class GraphStoreError(Exception):
     """Base class for every way talking to the graph store can fail.
@@ -108,15 +113,17 @@ class GraphStore:
     )
 
     @classmethod
-    def from_settings(cls, *, graph: Optional[str] = None) -> "GraphStore":
+    def from_settings(cls, *, graph=USE_CONFIGURED_GRAPH) -> "GraphStore":
         """Build the store the platform is configured to talk to.
 
         ``graph`` defaults to ``settings.OEKG_GRAPH``, which is ``None`` -- the
-        default graph, where the platform's bundles live. A test overrides it to
-        work in a graph of its own without having to reach into the views.
+        default graph, where the platform's bundles live. A test overrides that
+        setting to work in a graph of its own without reaching into the views.
+        Passing ``graph=None`` explicitly means the default graph and ignores
+        the setting.
         """
         rdf = settings.RDF_DATABASES["knowledge"]
-        if graph is None:
+        if graph is USE_CONFIGURED_GRAPH:
             graph = getattr(settings, "OEKG_GRAPH", None)
         base = "http://{host}:{port}/{name}".format(
             host=rdf["host"], port=rdf["port"], name=rdf["name"]

--- a/oekg/serializers.py
+++ b/oekg/serializers.py
@@ -28,7 +28,6 @@ from rest_framework import serializers
 from oekg.bundles import BUNDLE_FIELDS, ENUM
 from oekg.shape import constraint_message, enumeration
 
-
 # Everything read-only lives under one key, and writes ignore it. That is what
 # lets a client send back what it read without stripping anything -- and it
 # keeps the closed check structural instead of an exception list that grows.
@@ -55,7 +54,7 @@ class ClosedSerializer(serializers.Serializer):
 class NodeReferenceSerializer(ClosedSerializer):
     """A contact, organisation or funder: referenced by IRI, or minted here."""
 
-    iri = serializers.CharField(required=False, allow_blank=False)
+    iri = serializers.CharField(required=False, allow_blank=False, allow_null=True)
     label = serializers.CharField()
 
 
@@ -64,8 +63,9 @@ class PartSerializer(ClosedSerializer):
 
     label = serializers.CharField()
     # has-iri is a string on these nodes per the shape -- it points at a
-    # factsheet page and is not the node's identity.
-    iri = serializers.CharField(required=False, allow_blank=True)
+    # factsheet page and is not the node's identity. Nullable because a read of
+    # a framework without one returns null, and a read must be sendable back.
+    iri = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
 
 class EnumeratedListField(serializers.ListField):
@@ -100,7 +100,9 @@ class ScenarioBundleSerializer(ClosedSerializer):
 
     label = serializers.CharField()
     acronym = serializers.CharField()
-    abstract = serializers.CharField(required=False, allow_blank=True)
+    # Nullable for the same reason: an absent abstract reads as null, and the
+    # round trip a client (and, later, replace) depends on has to survive it.
+    abstract = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
     contacts = NodeReferenceSerializer(many=True, required=False)
     organisations = NodeReferenceSerializer(many=True, required=False)

--- a/oekg/serializers.py
+++ b/oekg/serializers.py
@@ -1,0 +1,119 @@
+"""Serializers for the OEKG scenario-bundle API.
+
+Hand-written, not generated. A serializer layer can express only about 61% of
+the shape -- class constraints, disjunctions and every target-by-predicate rule
+need the graph -- so these carry the *structure* and the shape on the graph
+carries the *constraints*. A conformance test asserts the two stay aligned.
+
+Two behaviours are made explicit because the framework's defaults are wrong for
+a closed shape:
+
+- **An unknown key is a rejection.** The framework silently drops keys it does
+  not recognise, which would let a client believe it had sent something it had
+  not.
+- **No identifier is accepted.** The server mints it. ``uid`` is not an
+  ignored key here, it is a rejected one, so a client that tries to choose is
+  told rather than quietly overridden.
+
+Enumerated picks are checked against the shape's own ``sh:in`` lists, read from
+the artifact at runtime, and a rejection quotes the shape's own message. Nothing
+is copied into Python: the lists are still moving in the shape's repository.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from rest_framework import serializers
+
+from oekg.bundles import BUNDLE_FIELDS, ENUM
+from oekg.shape import constraint_message, enumeration
+
+
+# Everything read-only lives under one key, and writes ignore it. That is what
+# lets a client send back what it read without stripping anything -- and it
+# keeps the closed check structural instead of an exception list that grows.
+READ_ONLY_CONTAINER = "_meta"
+
+
+class ClosedSerializer(serializers.Serializer):
+    """A serializer that refuses what it does not recognise."""
+
+    def to_internal_value(self, data):
+        if not isinstance(data, dict):
+            raise serializers.ValidationError(
+                {"detail": "Expected an object describing the resource."}
+            )
+        data = {key: value for key, value in data.items() if key != READ_ONLY_CONTAINER}
+        unknown = sorted(set(data) - set(self.fields))
+        if unknown:
+            raise serializers.ValidationError(
+                {name: "Unknown field. The bundle shape is closed." for name in unknown}
+            )
+        return super().to_internal_value(data)
+
+
+class NodeReferenceSerializer(ClosedSerializer):
+    """A contact, organisation or funder: referenced by IRI, or minted here."""
+
+    iri = serializers.CharField(required=False, allow_blank=False)
+    label = serializers.CharField()
+
+
+class PartSerializer(ClosedSerializer):
+    """A framework or model factsheet: bundle-local, with a link out."""
+
+    label = serializers.CharField()
+    # has-iri is a string on these nodes per the shape -- it points at a
+    # factsheet page and is not the node's identity.
+    iri = serializers.CharField(required=False, allow_blank=True)
+
+
+class EnumeratedListField(serializers.ListField):
+    """A list of IRIs the shape's sh:in list for this property allows."""
+
+    child = serializers.CharField()
+
+    def __init__(self, property_iri, **kwargs):
+        self.property_iri = str(property_iri)
+        super().__init__(**kwargs)
+
+    def to_internal_value(self, data):
+        values = super().to_internal_value(data)
+        allowed = enumeration(self.property_iri)
+        if not allowed:
+            return values
+        unknown = [value for value in values if value not in allowed]
+        if unknown:
+            message = constraint_message(self.property_iri)
+            raise serializers.ValidationError(
+                [
+                    f"{value} is not one of the {len(allowed)} values the shape "
+                    f"allows here." + (f" {message}" if message else "")
+                    for value in unknown
+                ]
+            )
+        return values
+
+
+class ScenarioBundleSerializer(ClosedSerializer):
+    """The closed bundle field set -- these and nothing else."""
+
+    label = serializers.CharField()
+    acronym = serializers.CharField()
+    abstract = serializers.CharField(required=False, allow_blank=True)
+
+    contacts = NodeReferenceSerializer(many=True, required=False)
+    organisations = NodeReferenceSerializer(many=True, required=False)
+    funders = NodeReferenceSerializer(many=True, required=False)
+    frameworks = PartSerializer(many=True, required=False)
+    models = PartSerializer(many=True, required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # The enumerated fields are declared from the same table that builds the
+        # triples, so a field cannot exist in one direction and not the other.
+        for field in BUNDLE_FIELDS:
+            if field.kind == ENUM:
+                self.fields[field.name] = EnumeratedListField(
+                    field.predicate, required=False
+                )

--- a/oekg/shape.py
+++ b/oekg/shape.py
@@ -1,0 +1,125 @@
+"""The canonical SHACL shape, read as data.
+
+The shape is the contract for what a scenario bundle is, and it is still
+moving in its own repository. So nothing here is copied into Python: the
+enumerations a payload may pick from and the messages a rejection carries are
+both read from the artifact ``manage.py fetch_oekg_shapes`` puts on disk.
+
+That artifact is the cache key. A redeploy with a new pin changes the file, and
+the file's identity changes with it, so the cache invalidates itself and no
+process serves yesterday's enumerations.
+
+Two things this module does NOT do:
+
+- **It does not fall back.** A missing artifact raises rather than validating
+  against nothing, because a validator that silently disappears is worse than
+  one that is absent loudly.
+- **It does not translate.** ``message_for`` returns the shape's own wording,
+  so the API and the shape can never disagree about the same rule. The
+  validator in use does not honour ``sh:resultMessage`` itself, and relying on
+  an engine's leniency for the API's error text would be fragile anyway.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from django.conf import settings
+from rdflib import Graph, URIRef
+from rdflib.collection import Collection
+from rdflib.namespace import SH
+
+
+class ShapeUnavailable(Exception):
+    """The shape artifacts are not on disk, so nothing can be validated."""
+
+
+def shape_graph() -> Graph:
+    """The SHACL shape itself."""
+    return _parsed(_fingerprint(Path(settings.OEKG_SHAPES_PATH)))
+
+
+def label_graph() -> Graph:
+    """The rdfs:label subset the shape's targets need to satisfy it."""
+    return _parsed(_fingerprint(Path(settings.OEKG_SHAPE_LABELS_PATH)))
+
+
+def enumeration(property_iri: str) -> frozenset:
+    """The IRIs a payload may pick for ``property_iri``, per the shape's sh:in.
+
+    Empty for a property the shape does not constrain by enumeration -- which
+    a caller must treat as "not enumerated", never as "nothing is allowed".
+    """
+    return _enumerations(_fingerprint(Path(settings.OEKG_SHAPES_PATH)))[0].get(
+        property_iri, frozenset()
+    )
+
+
+def constraint_message(property_iri: str) -> Optional[str]:
+    """The shape's own wording for the property shape constraining ``property_iri``.
+
+    Used so a rejected pick is explained in the shape's words rather than in a
+    second set written here, which could then disagree with it.
+    """
+    return _enumerations(_fingerprint(Path(settings.OEKG_SHAPES_PATH)))[1].get(
+        property_iri
+    )
+
+
+def message_for(source_shape) -> Optional[str]:
+    """The shape's own wording for a violation raised by ``source_shape``."""
+    if source_shape is None:
+        return None
+    message = shape_graph().value(source_shape, SH.resultMessage)
+    return str(message) if message is not None else None
+
+
+def _fingerprint(path: Path) -> tuple:
+    """Identity of an artifact: its path and what a redeploy would change."""
+    try:
+        stat = path.stat()
+    except OSError as error:
+        raise ShapeUnavailable(
+            f"The OEKG shape artifact {path} is missing. Run "
+            "'python manage.py fetch_oekg_shapes' to obtain it; the API "
+            "refuses to validate against a shape it does not have."
+        ) from error
+    return (str(path), stat.st_mtime_ns, stat.st_size)
+
+
+@lru_cache(maxsize=4)
+def _parsed(fingerprint: tuple) -> Graph:
+    graph = Graph()
+    graph.parse(fingerprint[0], format="turtle")
+    return graph
+
+
+@lru_cache(maxsize=2)
+def _enumerations(fingerprint: tuple) -> tuple:
+    """Every sh:in list in the shape, and the message beside it.
+
+    Keyed by the property path each constrains, so a caller asks in the
+    vocabulary it already has.
+    """
+    graph = _parsed(fingerprint)
+    allowed_by_path = {}
+    message_by_path = {}
+    for constraint, members in graph.subject_objects(SH["in"]):
+        path = graph.value(constraint, SH.path)
+        if path is None:
+            continue
+        allowed = frozenset(
+            str(member)
+            for member in Collection(graph, members)
+            if isinstance(member, URIRef)
+        )
+        allowed_by_path[str(path)] = (
+            allowed_by_path.get(str(path), frozenset()) | allowed
+        )
+        message = graph.value(constraint, SH.resultMessage)
+        if message is not None:
+            message_by_path.setdefault(str(path), str(message))
+    return allowed_by_path, message_by_path

--- a/oekg/shape.py
+++ b/oekg/shape.py
@@ -53,9 +53,7 @@ def enumeration(property_iri: str) -> frozenset:
     Empty for a property the shape does not constrain by enumeration -- which
     a caller must treat as "not enumerated", never as "nothing is allowed".
     """
-    return _enumerations(_fingerprint(Path(settings.OEKG_SHAPES_PATH)))[0].get(
-        property_iri, frozenset()
-    )
+    return _shape_enumerations()[0].get(property_iri, frozenset())
 
 
 def constraint_message(property_iri: str) -> Optional[str]:
@@ -64,9 +62,7 @@ def constraint_message(property_iri: str) -> Optional[str]:
     Used so a rejected pick is explained in the shape's words rather than in a
     second set written here, which could then disagree with it.
     """
-    return _enumerations(_fingerprint(Path(settings.OEKG_SHAPES_PATH)))[1].get(
-        property_iri
-    )
+    return _shape_enumerations()[1].get(property_iri)
 
 
 def message_for(source_shape) -> Optional[str]:
@@ -75,6 +71,10 @@ def message_for(source_shape) -> Optional[str]:
         return None
     message = shape_graph().value(source_shape, SH.resultMessage)
     return str(message) if message is not None else None
+
+
+def _shape_enumerations() -> tuple:
+    return _enumerations(_fingerprint(Path(settings.OEKG_SHAPES_PATH)))
 
 
 def _fingerprint(path: Path) -> tuple:

--- a/oekg/shape_artifacts.py
+++ b/oekg/shape_artifacts.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import requests
-from rdflib import RDF, RDFS, Graph, URIRef
+from rdflib import RDF, RDFS, Graph, Literal, URIRef
 from rdflib.namespace import SH
 
 RAW_GITHUB_HOST = "https://raw.githubusercontent.com"
@@ -223,6 +223,14 @@ def build_label_subset_payload(oeo_full_owl: Path, oeo_version: str = "") -> byt
     OEO the labels came from can move even though the shape cannot. Recording
     it means a moved ontology shows up as a changed artifact rather than
     silently altering what the validator sees.
+
+    The labels are **normalised to exactly one plain string per term**, because
+    the shape they exist to satisfy requires ``sh:datatype xsd:string`` and
+    ``sh:maxCount 1`` on ``rdfs:label``. The OEO gives neither: 1,855 of its
+    2,058 labels carry ``@en`` (a language tag makes a literal
+    ``rdf:langString``, not ``xsd:string``), and four terms carry two labels,
+    one of them a whole sentence. Copied verbatim, every picked OEO term fails
+    validation -- measured, not feared.
     """
     oeo_full_owl = Path(oeo_full_owl)
     if not oeo_full_owl.is_file():
@@ -240,11 +248,15 @@ def build_label_subset_payload(oeo_full_owl: Path, oeo_version: str = "") -> byt
             "subset cannot be generated. Re-download the ontology release."
         ) from error
 
-    subset = Graph()
-    subset.bind("rdfs", RDFS)
+    candidates = {}
     for subject, label in ontology.subject_objects(RDFS.label):
         if isinstance(subject, URIRef):
-            subset.add((subject, RDFS.label, label))
+            candidates.setdefault(subject, []).append(label)
+
+    subset = Graph()
+    subset.bind("rdfs", RDFS)
+    for subject, labels in candidates.items():
+        subset.add((subject, RDFS.label, Literal(_preferred_label(labels))))
 
     if not len(subset):
         raise UnusableOntologyError(
@@ -257,6 +269,21 @@ def build_label_subset_payload(oeo_full_owl: Path, oeo_version: str = "") -> byt
         f"# source: {oeo_full_owl.name} {oeo_version}\n"
     )
     return header.encode("utf-8") + subset.serialize(format="turtle").encode("utf-8")
+
+
+def _preferred_label(labels: list) -> str:
+    """Pick the one label a term keeps, as a plain string.
+
+    English first, then untagged, then whatever is left; ties broken by the
+    text itself so the artifact is byte-stable across runs. Deterministic
+    rather than clever: where a term really has two labels the choice is
+    arbitrary, and being repeatable matters more than being right.
+    """
+    for language in ("en", None):
+        tagged = sorted(str(label) for label in labels if label.language == language)
+        if tagged:
+            return tagged[0]
+    return sorted(str(label) for label in labels)[0]
 
 
 def _reject_if_not_a_shape_graph(payload: bytes, url: str) -> None:

--- a/oekg/tests/__init__.py
+++ b/oekg/tests/__init__.py
@@ -20,9 +20,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 import unittest
 import uuid
+from pathlib import Path
 
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from oekg.graph_store import GraphStore
 
@@ -38,17 +39,35 @@ TEST_GRAPH_PREFIX = "urn:oep:test:"
 LOCAL_GRAPH_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]", "fuseki"})
 
 
-class OekgGraphTestCase(SimpleTestCase):
-    """A test with an isolated graph on a real store, or a stated skip."""
+class RequiresShapeArtifactsMixin:
+    """Skips unless the fetched shape artifacts are on disk.
 
-    # SimpleTestCase blocks database access, which suits this slice: the
-    # transport talks only to the graph. Later slices that write history rows or
-    # resolve dataset links against Postgres will need `databases` set, or a
-    # TestCase-based sibling.
+    Same bargain as the graph store: a developer who has not run
+    `manage.py fetch_oekg_shapes` gets a stated skip rather than a wall of
+    failures. CI runs the command, so there the tests always execute.
+    """
 
     @classmethod
     def setUpClass(cls):
+        for setting in ("OEKG_SHAPES_PATH", "OEKG_SHAPE_LABELS_PATH"):
+            path = Path(getattr(settings, setting))
+            if not path.is_file():
+                raise unittest.SkipTest(
+                    f"The OEKG shape artifact {path} is missing. Run "
+                    "'python manage.py fetch_oekg_shapes' to obtain it."
+                )
         super().setUpClass()
+
+
+class IsolatedGraphMixin:
+    """Points a test at a real store, in a graph of its own, or skips."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Both checks run BEFORE super(). A TestCase opens class-level atomics
+        # in setUpClass, and raising SkipTest after that skips tearDownClass
+        # too, leaving them open -- which breaks the NEXT test class with
+        # "connection already closed", nowhere near the cause.
         host = settings.RDF_DATABASES["knowledge"]["host"]
         if host not in LOCAL_GRAPH_HOSTS:
             raise unittest.SkipTest(
@@ -67,12 +86,31 @@ class OekgGraphTestCase(SimpleTestCase):
                 "RDF_DATABASE_HOST / RDF_DATABASE_USER / RDF_DATABASE_PASSWORD "
                 "at a running Fuseki, to run the graph tests."
             )
+        super().setUpClass()
 
     def setUp(self):
         super().setUp()
-        self.store = GraphStore.from_settings(
-            graph=TEST_GRAPH_PREFIX + str(uuid.uuid4())
-        )
+        self.graph_name = TEST_GRAPH_PREFIX + str(uuid.uuid4())
+        self.store = GraphStore.from_settings(graph=self.graph_name)
         # Cleaning up afterwards rather than beforehand is what lets every test
         # assert on an empty graph without depending on execution order.
         self.addCleanup(self.store.clear)
+
+
+class OekgGraphTestCase(IsolatedGraphMixin, SimpleTestCase):
+    """A graph test with no database. The transport needs none."""
+
+
+class OekgGraphAPITestCase(RequiresShapeArtifactsMixin, IsolatedGraphMixin, TestCase):
+    """A graph test that also has the database.
+
+    The API writes ownership rows to Postgres beside the graph, so its tests
+    need both. `OEKG_GRAPH` points the views' own store at this test's graph
+    without the tests having to reach inside them.
+    """
+
+    def setUp(self):
+        super().setUp()
+        override = override_settings(OEKG_GRAPH=self.graph_name)
+        override.enable()
+        self.addCleanup(override.disable)

--- a/oekg/tests/test_bundle_api.py
+++ b/oekg/tests/test_bundle_api.py
@@ -124,6 +124,27 @@ class CreateBundleTest(BundleApiTestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_an_identifier_that_is_not_iri_safe_is_a_404(self):
+        # Not a 500: these characters make rdflib refuse to build the IRI, and
+        # that refusal is also what keeps the query free of injection.
+        for uid in ["a b", "a<b", 'a"b', "a|b", "a^b"]:
+            with self.subTest(uid=uid):
+                response = self.client.get(f"/api/v0/scenario-bundles/{uid}/")
+                self.assertEqual(response.status_code, 404)
+
+    def test_an_iri_that_is_not_a_bundle_is_a_404(self):
+        # Minting puts other nodes in the same namespace. Reading one of those
+        # as though it were a bundle would answer 200 with an empty payload.
+        uid = self.create({**VALID_PAYLOAD, "contacts": [{"label": "A contact"}]}).data[
+            READ_ONLY_CONTAINER
+        ]["uid"]
+        contact_iri = self.client.get(self.detail_url(uid)).data["contacts"][0]["iri"]
+        contact_uid = contact_iri.rsplit("/", 1)[-1]
+
+        response = self.client.get(self.detail_url(contact_uid))
+
+        self.assertEqual(response.status_code, 404)
+
 
 class AcronymUniquenessTest(BundleApiTestCase):
     def test_a_duplicate_acronym_is_refused(self):
@@ -145,6 +166,16 @@ class AcronymUniquenessTest(BundleApiTestCase):
                 second = self.create({**VALID_PAYLOAD, "acronym": acronym})
                 self.assertEqual(second.status_code, 409, second.data)
 
+    def test_an_acronym_is_checked_and_stored_as_the_same_value(self):
+        # Checking a stripped value and storing an unstripped one is how a
+        # duplicate slips through.
+        first = self.create({**VALID_PAYLOAD, "acronym": "SPACED "})
+        self.assertEqual(first.status_code, 201, first.data)
+
+        second = self.create({**VALID_PAYLOAD, "acronym": "SPACED"})
+
+        self.assertEqual(second.status_code, 409, second.data)
+
     def test_a_refused_duplicate_writes_nothing(self):
         self.create()
         before = len(self.store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"))
@@ -153,6 +184,51 @@ class AcronymUniquenessTest(BundleApiTestCase):
 
         after = self.store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")
         self.assertEqual(len(after), before)
+
+
+class SharedNodeTest(BundleApiTestCase):
+    """A shared contact or organisation is referenced, never rewritten."""
+
+    def existing_contact(self):
+        uid = self.create(
+            {**VALID_PAYLOAD, "contacts": [{"label": "Institute of Things"}]}
+        ).data[READ_ONLY_CONTAINER]["uid"]
+        read = self.client.get(self.detail_url(uid)).data
+        return read["contacts"][0]["iri"]
+
+    def test_referencing_an_existing_node_writes_no_second_label(self):
+        iri = self.existing_contact()
+
+        response = self.create(
+            {
+                **VALID_PAYLOAD,
+                "acronym": "API-TEST-2",
+                "contacts": [{"iri": iri, "label": "Institute of Things"}],
+            }
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        labels = self.store.select(
+            "SELECT ?l WHERE { <%s> <http://www.w3.org/2000/01/rdf-schema#label> ?l }"
+            % iri
+        )
+        self.assertEqual(len(labels), 1, labels)
+
+    def test_renaming_a_shared_node_is_refused(self):
+        # A shared node is cited by other bundles, so one payload rewriting its
+        # label would change every one of them.
+        iri = self.existing_contact()
+
+        response = self.create(
+            {
+                **VALID_PAYLOAD,
+                "acronym": "API-TEST-2",
+                "contacts": [{"iri": iri, "label": "A different name"}],
+            }
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data["conflicts"][0]["iri"], iri)
 
 
 class ShapeValidationTest(BundleApiTestCase):
@@ -222,6 +298,25 @@ class RoundTripTest(BundleApiTestCase):
 
         self.assertEqual(sent_back.status_code, 201, sent_back.data)
 
+    def test_a_bundle_with_every_optional_absent_round_trips(self):
+        # The round trip is the property replace will depend on, and it breaks
+        # on nulls: an absent abstract reads back as null, and a framework
+        # without an iri carries null too.
+        minimal = {key: v for key, v in VALID_PAYLOAD.items() if key != "abstract"}
+        minimal["frameworks"] = [{"label": "A framework with no page"}]
+        uid = self.create(minimal).data[READ_ONLY_CONTAINER]["uid"]
+
+        read = self.client.get(self.detail_url(uid)).data
+        self.assertIsNone(read["abstract"])
+        self.assertIsNone(read["frameworks"][0]["iri"])
+
+        sent_back = self.client.post(
+            self.collection_url,
+            data={**read, "acronym": "API-TEST-MINIMAL"},
+            content_type="application/json",
+        )
+        self.assertEqual(sent_back.status_code, 201, sent_back.data)
+
     def test_reading_twice_gives_the_same_answer(self):
         uid = self.create().data[READ_ONLY_CONTAINER]["uid"]
 
@@ -273,6 +368,11 @@ class ShapeConformanceTest(RequiresShapeArtifactsMixin, SimpleTestCase):
             paths - covered,
             set(),
             "the shape validates properties the serializer has no field for",
+        )
+        self.assertEqual(
+            covered - paths,
+            set(),
+            "the serializer has fields the shape does not validate",
         )
 
     def test_every_serializer_field_is_a_field_the_builder_knows(self):

--- a/oekg/tests/test_bundle_api.py
+++ b/oekg/tests/test_bundle_api.py
@@ -1,0 +1,371 @@
+"""
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.urls import reverse
+from rdflib import RDF, RDFS, Graph, Literal
+from rdflib.namespace import SH
+
+from factsheet.models import ScenarioBundleAccessControl
+from login.models import myuser
+from oekg.bundles import (
+    BUNDLE_CLASS,
+    BUNDLE_FIELDS,
+    DC,
+    ENUM,
+    LITERAL,
+    NODE,
+    OEO,
+    PART,
+    build_bundle_graph,
+    bundle_iri,
+    bundle_payload,
+)
+from oekg.graph_store import GraphStore
+from oekg.serializers import READ_ONLY_CONTAINER, ScenarioBundleSerializer
+from oekg.shape import enumeration, shape_graph
+from oekg.tests import OekgGraphAPITestCase, RequiresShapeArtifactsMixin
+
+# Real picks from the shape's own sh:in lists -- the four the shape requires.
+VALID_PAYLOAD = {
+    "label": "A scenario bundle written by the API",
+    "acronym": "API-TEST",
+    "abstract": "Created by the test suite.",
+    "descriptors": [str(OEO.OEO_00000143)],
+    "sector_divisions": [str(OEO.OEO_00000368)],
+    "sectors": [str(OEO.OEO_00000367)],
+    "technologies": [str(OEO.OEO_00000407)],
+}
+
+
+class BundleApiTestCase(OekgGraphAPITestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = myuser.objects.create_user(
+            name="bundle-author", email="author@example.org", affiliation=""
+        )
+        self.collection_url = reverse("api:scenario-bundles")
+
+    def create(self, payload=None, authenticate=True):
+        if authenticate:
+            self.client.force_login(self.user)
+        return self.client.post(
+            self.collection_url,
+            data=payload if payload is not None else VALID_PAYLOAD,
+            content_type="application/json",
+        )
+
+    def detail_url(self, uid):
+        return reverse("api:scenario-bundle", kwargs={"uid": uid})
+
+
+class CreateBundleTest(BundleApiTestCase):
+    def test_a_bundle_is_created_and_reads_back(self):
+        response = self.create()
+
+        self.assertEqual(response.status_code, 201, response.data)
+        uid = response.data[READ_ONLY_CONTAINER]["uid"]
+
+        read = self.client.get(self.detail_url(uid))
+        self.assertEqual(read.status_code, 200)
+        self.assertEqual(read.data["label"], VALID_PAYLOAD["label"])
+        self.assertEqual(read.data["acronym"], VALID_PAYLOAD["acronym"])
+        self.assertEqual(read.data["technologies"], VALID_PAYLOAD["technologies"])
+
+    def test_the_response_names_where_the_bundle_now_lives(self):
+        response = self.create()
+
+        uid = response.data[READ_ONLY_CONTAINER]["uid"]
+        self.assertEqual(response["Location"], self.detail_url(uid))
+
+    def test_the_server_mints_the_identifier(self):
+        # A client that picks its own identifier can overwrite a stranger's
+        # bundle by guessing. There is no key to supply one through.
+        response = self.create({**VALID_PAYLOAD, "uid": "chosen-by-the-client"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("uid", response.data)
+
+    def test_two_bundles_get_different_identifiers(self):
+        first = self.create()
+        second = self.create({**VALID_PAYLOAD, "acronym": "API-TEST-2"})
+
+        self.assertNotEqual(
+            first.data[READ_ONLY_CONTAINER]["uid"],
+            second.data[READ_ONLY_CONTAINER]["uid"],
+        )
+
+    def test_the_creator_owns_the_bundle(self):
+        # Without this the bundle is ownerless, which means administrator-only
+        # -- so the person who created it could never edit it.
+        response = self.create()
+
+        uid = response.data[READ_ONLY_CONTAINER]["uid"]
+        self.assertTrue(ScenarioBundleAccessControl.user_has_access(self.user, uid))
+
+    def test_an_unauthenticated_write_is_refused(self):
+        response = self.create(authenticate=False)
+
+        self.assertIn(response.status_code, (401, 403))
+        self.assertFalse(self.store.ask("ASK { ?s ?p ?o }"))
+
+    def test_a_read_needs_no_authentication(self):
+        uid = self.create().data[READ_ONLY_CONTAINER]["uid"]
+        self.client.logout()
+
+        self.assertEqual(self.client.get(self.detail_url(uid)).status_code, 200)
+
+    def test_an_unknown_bundle_is_a_404(self):
+        response = self.client.get(self.detail_url("does-not-exist"))
+
+        self.assertEqual(response.status_code, 404)
+
+
+class AcronymUniquenessTest(BundleApiTestCase):
+    def test_a_duplicate_acronym_is_refused(self):
+        self.create()
+
+        response = self.create()
+
+        self.assertEqual(response.status_code, 409)
+
+    def test_an_acronym_the_old_check_would_miss_is_still_caught(self):
+        # The user interface compares a normalised acronym against the raw
+        # stored value, so anything with a space, hyphen, umlaut, slash, colon
+        # or parenthesis slips through. Each of these is one of those.
+        for acronym in ["Wind Study", "wind-study", "Wärme", "a/b", "x:y", "p(q)"]:
+            with self.subTest(acronym=acronym):
+                first = self.create({**VALID_PAYLOAD, "acronym": acronym})
+                self.assertEqual(first.status_code, 201, first.data)
+
+                second = self.create({**VALID_PAYLOAD, "acronym": acronym})
+                self.assertEqual(second.status_code, 409, second.data)
+
+    def test_a_refused_duplicate_writes_nothing(self):
+        self.create()
+        before = len(self.store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"))
+
+        self.create()
+
+        after = self.store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")
+        self.assertEqual(len(after), before)
+
+
+class ShapeValidationTest(BundleApiTestCase):
+    def test_a_payload_the_shape_rejects_writes_nothing(self):
+        # No technologies: the shape requires at least one.
+        payload = {key: v for key, v in VALID_PAYLOAD.items() if key != "technologies"}
+
+        response = self.create(payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(self.store.ask("ASK { ?s ?p ?o }"))
+
+    def test_the_rejection_carries_the_shapes_own_words(self):
+        payload = {key: v for key, v in VALID_PAYLOAD.items() if key != "technologies"}
+
+        response = self.create(payload)
+
+        messages = [v["message"] for v in response.data["violations"]]
+        self.assertIn(
+            "Study target: This should cover at least one technology.", messages
+        )
+
+    def test_an_unknown_key_is_refused(self):
+        response = self.create({**VALID_PAYLOAD, "sectorz": ["typo"]})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("sectorz", response.data)
+
+    def test_a_pick_outside_the_shapes_list_is_refused(self):
+        response = self.create(
+            {**VALID_PAYLOAD, "technologies": [str(OEO.OEO_99999999)]}
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("technologies", response.data)
+
+    def test_minted_nodes_are_typed(self):
+        # The shape's sh:class constraints require it and the user interface
+        # does not do it, so the live graph carries violations it produced.
+        response = self.create(
+            {
+                **VALID_PAYLOAD,
+                "contacts": [{"label": "A contact"}],
+                "organisations": [{"label": "An institute"}],
+                "funders": [{"label": "A funder"}],
+            }
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        for node_class in [OEO.OEO_00000107, OEO.OEO_00030022, OEO.OEO_00090001]:
+            with self.subTest(node_class=node_class):
+                self.assertTrue(self.store.ask("ASK { ?node a %s }" % node_class.n3()))
+
+
+class RoundTripTest(BundleApiTestCase):
+    def test_a_read_can_be_sent_back_unchanged(self):
+        # The property replace will depend on: what a read returns is what a
+        # write accepts, including the read-only container, which writes ignore.
+        uid = self.create().data[READ_ONLY_CONTAINER]["uid"]
+        read = self.client.get(self.detail_url(uid)).data
+
+        sent_back = self.client.post(
+            self.collection_url,
+            data={**read, "acronym": "API-TEST-COPY"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(sent_back.status_code, 201, sent_back.data)
+
+    def test_reading_twice_gives_the_same_answer(self):
+        uid = self.create().data[READ_ONLY_CONTAINER]["uid"]
+
+        first = self.client.get(self.detail_url(uid)).data
+        second = self.client.get(self.detail_url(uid)).data
+
+        self.assertEqual(first, second)
+
+
+class OneWriteTest(BundleApiTestCase):
+    def test_creating_a_bundle_is_one_request_to_the_store(self):
+        # The whole write path rests on this. Today's user interface writes one
+        # committed request per triple, which is why a bundle create costs ~200
+        # requests and can leave half a bundle behind.
+        real_update = GraphStore.update
+        updates = []
+
+        def counting_update(store, *operations):
+            updates.append(operations)
+            return real_update(store, *operations)
+
+        with patch.object(GraphStore, "update", counting_update):
+            response = self.create()
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(len(updates), 1, updates)
+
+
+class ShapeConformanceTest(RequiresShapeArtifactsMixin, SimpleTestCase):
+    """Every property the shape validates on a bundle has a serializer field.
+
+    This is the anti-drift property a generator would have given, without the
+    generator: if the shape gains a property, this fails rather than the API
+    quietly ignoring it.
+    """
+
+    def test_every_bundle_property_in_the_shape_has_a_field(self):
+        shape = shape_graph()
+        bundle_shape = shape.value(predicate=SH.targetClass, object=BUNDLE_CLASS)
+        paths = {
+            str(shape.value(constraint, SH.path))
+            for constraint in shape.objects(bundle_shape, SH.property)
+            if shape.value(constraint, SH.path) is not None
+        }
+
+        covered = {str(field.predicate) for field in BUNDLE_FIELDS}
+        self.assertTrue(paths, "the shape declares no bundle properties")
+        self.assertEqual(
+            paths - covered,
+            set(),
+            "the shape validates properties the serializer has no field for",
+        )
+
+    def test_every_serializer_field_is_a_field_the_builder_knows(self):
+        serializer_fields = set(ScenarioBundleSerializer().fields)
+        builder_fields = {field.name for field in BUNDLE_FIELDS}
+
+        self.assertEqual(serializer_fields, builder_fields)
+
+    def test_every_enumerated_field_reads_its_values_from_the_shape(self):
+        for field in BUNDLE_FIELDS:
+            if field.kind == ENUM:
+                with self.subTest(field=field.name):
+                    self.assertTrue(enumeration(str(field.predicate)))
+
+
+class BundleGraphTest(RequiresShapeArtifactsMixin, SimpleTestCase):
+    """The builder, without a store."""
+
+    def test_a_field_absent_from_the_payload_writes_nothing(self):
+        graph = build_bundle_graph("u1", {"label": "Only a label"})
+
+        self.assertIsNone(graph.value(bundle_iri("u1"), DC.acronym))
+
+    def test_the_bundle_is_typed(self):
+        graph = build_bundle_graph("u1", {"label": "L"})
+
+        self.assertIn((bundle_iri("u1"), RDF.type, BUNDLE_CLASS), graph)
+
+    def test_every_field_kind_round_trips(self):
+        payload = {
+            **VALID_PAYLOAD,
+            "contacts": [{"label": "A contact"}],
+            "frameworks": [{"label": "A framework", "iri": "https://example.org/f"}],
+            "models": [{"label": "A model", "iri": "https://example.org/m"}],
+        }
+        graph = build_bundle_graph("u1", payload)
+
+        read_back = bundle_payload(graph, "u1")
+
+        self.assertEqual(read_back["label"], payload["label"])
+        self.assertEqual(read_back["sectors"], payload["sectors"])
+        self.assertEqual(read_back["contacts"][0]["label"], "A contact")
+        self.assertEqual(read_back["frameworks"][0]["iri"], "https://example.org/f")
+        self.assertEqual(read_back["models"][0]["label"], "A model")
+
+    def test_frameworks_and_models_do_not_bleed_into_each_other(self):
+        # They share the has-part predicate; only their type tells them apart.
+        graph = build_bundle_graph(
+            "u1",
+            {
+                "label": "L",
+                "frameworks": [{"label": "F"}],
+                "models": [{"label": "M"}],
+            },
+        )
+
+        read_back = bundle_payload(graph, "u1")
+
+        self.assertEqual([f["label"] for f in read_back["frameworks"]], ["F"])
+        self.assertEqual([m["label"] for m in read_back["models"]], ["M"])
+
+
+class FieldTableTest(RequiresShapeArtifactsMixin, SimpleTestCase):
+    def test_the_field_kinds_are_the_ones_the_builder_handles(self):
+        self.assertEqual(
+            {field.kind for field in BUNDLE_FIELDS},
+            {LITERAL, ENUM, NODE, PART},
+        )
+
+    def test_node_and_part_fields_declare_the_class_they_type(self):
+        for field in BUNDLE_FIELDS:
+            if field.kind in (NODE, PART):
+                with self.subTest(field=field.name):
+                    self.assertIsNotNone(field.node_class)
+                    self.assertTrue(field.mint_segment)
+
+
+class LabelsAreWrittenTest(RequiresShapeArtifactsMixin, SimpleTestCase):
+    def test_a_minted_node_carries_exactly_one_plain_label(self):
+        graph = build_bundle_graph(
+            "u1", {"label": "L", "contacts": [{"label": "A contact"}]}
+        )
+
+        contact = next(graph.objects(bundle_iri("u1"), OEO.OEO_00000508))
+        labels = list(graph.objects(contact, RDFS.label))
+        self.assertEqual(labels, [Literal("A contact")])
+        self.assertIsNone(labels[0].language)
+
+
+class GraphIsNotTouchedByReadsTest(RequiresShapeArtifactsMixin, SimpleTestCase):
+    def test_building_a_graph_touches_no_store(self):
+        # The builder is pure: it is what makes validate-before-write possible.
+        graph = build_bundle_graph("u1", VALID_PAYLOAD)
+
+        self.assertIsInstance(graph, Graph)
+        self.assertGreater(len(graph), 0)

--- a/oekg/tests/test_shape_artifacts.py
+++ b/oekg/tests/test_shape_artifacts.py
@@ -27,6 +27,8 @@ from oekg.shape_artifacts import (
 
 COMMIT = "b4604e02060624b381bdbe2f872df94cfd0f5630"
 
+OEO = "https://openenergyplatform.org/ontology/oeo/"
+
 # A minimal but real SHACL shape: enough that a parse-and-recognise check passes.
 SHAPE_TTL = b"""
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -57,6 +59,20 @@ oeo:OEO_00020227 a owl:Class ;
 
 oeo:OEO_00010449 a owl:Class ;
     rdfs:label "wind technology" .
+
+# The OEO labels almost everything @en. The shape wants sh:datatype xsd:string,
+# and a language-tagged literal is rdf:langString, so a tag is a violation.
+oeo:OEO_00010455 a owl:Class ;
+    rdfs:label "solar technology"@en .
+
+# A handful of terms carry more than one label, which sh:maxCount 1 rejects.
+oeo:OEO_00010487 a owl:Class ;
+    rdfs:label "Matlab programming language"@en ;
+    rdfs:label "The Matlab programming language is one developed by MathWorks."@en .
+
+# Only a German label: still needs to end up as one plain string.
+oeo:OEO_00010471 a owl:Class ;
+    rdfs:label "Windkraft"@de .
 
 [] rdfs:label "a label on a blank node" .
 """
@@ -260,16 +276,32 @@ class LabelSubsetTest(TempArtifactsTestCase):
         self.assertEqual(
             labels,
             {
-                (
-                    "https://openenergyplatform.org/ontology/oeo/OEO_00020227",
-                    "scenario bundle",
-                ),
-                (
-                    "https://openenergyplatform.org/ontology/oeo/OEO_00010449",
-                    "wind technology",
-                ),
+                (OEO + "OEO_00020227", "scenario bundle"),
+                (OEO + "OEO_00010449", "wind technology"),
+                (OEO + "OEO_00010455", "solar technology"),
+                (OEO + "OEO_00010487", "Matlab programming language"),
+                (OEO + "OEO_00010471", "Windkraft"),
             },
         )
+
+    def test_no_label_keeps_its_language_tag(self):
+        # ex:CommonShape requires sh:datatype xsd:string on rdfs:label, and a
+        # language-tagged literal is rdf:langString. Keeping the tag makes every
+        # picked OEO term fail validation.
+        self.extract(self.oeo_full_owl, self.labels_path)
+
+        graph = Graph()
+        graph.parse(str(self.labels_path), format="turtle")
+        self.assertEqual([o.language for _, _, o in graph], [None] * len(graph))
+
+    def test_a_term_gets_exactly_one_label(self):
+        # sh:maxCount 1. A few OEO terms carry two, one of them a whole sentence.
+        self.extract(self.oeo_full_owl, self.labels_path)
+
+        graph = Graph()
+        graph.parse(str(self.labels_path), format="turtle")
+        subjects = [s for s, _, _ in graph]
+        self.assertEqual(len(subjects), len(set(subjects)))
 
     def test_the_ontology_version_is_recorded_in_the_file(self):
         # Two of the three environments fetch the OEO from an unpinned

--- a/oekg/validation.py
+++ b/oekg/validation.py
@@ -1,0 +1,89 @@
+"""Shape validation for scenario bundles, in one function.
+
+**The post-state is what gets validated** -- the bundle as it would be after
+the write, assembled in memory, before anything is sent to the store. Not the
+diff: a diff carries no ``rdf:type``, so no shape targets it and it conforms
+vacuously. That would not be weak validation, it would be a confident false
+pass.
+
+The whole graph is unnecessary. The shape has no cross-bundle constraint, so
+one bundle's post-state is a complete unit.
+
+The label subset is merged in for the same reason it exists: ``ex:CommonShape``
+requires exactly one ``rdfs:label`` on every OEO term a bundle picks, and the
+payload carries labels only for the nodes it mints.
+
+One seam, one function: post-state graph in, violations out. The engine behind
+it is then swappable -- the fallback if the library ever stalls is Jena's own
+SHACL engine, which this stack already deploys.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from pyshacl import validate as pyshacl_validate
+from rdflib import RDF, Graph
+from rdflib.namespace import SH
+
+from oekg.shape import label_graph, message_for, shape_graph
+
+
+@dataclass(frozen=True)
+class ShapeViolation:
+    """One thing the shape objects to, in the shape's own words."""
+
+    message: str
+    focus_node: Optional[str] = None
+    path: Optional[str] = None
+    value: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "message": self.message,
+            "focus_node": self.focus_node,
+            "path": self.path,
+            "value": self.value,
+        }
+
+
+def validate_post_state(post_state: Graph) -> List[ShapeViolation]:
+    """Validate a bundle subgraph. An empty list means it conforms."""
+    shape = shape_graph()
+    conforms, report, _ = pyshacl_validate(
+        post_state + label_graph(),
+        shacl_graph=shape,
+        advanced=True,
+        inference="none",
+    )
+    if conforms:
+        return []
+
+    violations = [
+        _violation(report, result)
+        for result in report.subjects(RDF.type, SH.ValidationResult)
+    ]
+    # Sorted so the same invalid payload always reports in the same order:
+    # pyshacl walks the report graph, whose iteration order is not stable.
+    return sorted(violations, key=lambda v: (v.path or "", v.message))
+
+
+def _violation(report: Graph, result) -> ShapeViolation:
+    source_shape = report.value(result, SH.sourceShape)
+    # The shape's own wording where it has one, the engine's only as a
+    # fallback: the API and the shape must never phrase the same rule twice.
+    message = message_for(source_shape) or str(
+        report.value(result, SH.resultMessage) or "The bundle does not conform."
+    )
+    return ShapeViolation(
+        message=message,
+        focus_node=_text(report.value(result, SH.focusNode)),
+        path=_text(report.value(result, SH.resultPath)),
+        value=_text(report.value(result, SH.value)),
+    )
+
+
+def _text(node) -> Optional[str]:
+    return None if node is None else str(node)

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -418,7 +418,13 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.TokenAuthentication",
-    )
+    ),
+    # The OEKG bundle API reads publicly, so it carries its own ceiling rather
+    # than relying on there being one somewhere else.
+    "DEFAULT_THROTTLE_RATES": {
+        "oekg_bundles_anon": "60/minute",
+        "oekg_bundles_user": "600/minute",
+    },
 }
 
 AUTHENTICATION_BACKENDS = [

--- a/oeplatform/settings.py
+++ b/oeplatform/settings.py
@@ -385,6 +385,11 @@ OEKG_SHAPES_SOURCE_FILE = "oekg/shapes/oekg_shapes.ttl"
 # pin is a commit sha. Bump this line to move the validator.
 OEKG_SHAPES_PINNED_COMMIT = "b4604e02060624b381bdbe2f872df94cfd0f5630"
 
+# The named graph the OEKG API reads and writes. None is the default graph,
+# which is where the platform's bundles live today; a test overrides it to work
+# in isolation.
+OEKG_GRAPH = None
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,10 @@ django-fontawesome-5==1.0.18
 omi==1.1.0
 zipstream-new==1.1.8
 rdflib==7.0.0
+# SHACL validation for the OEKG API. 0.28.1 is the newest release that still
+# accepts rdflib>=6.3.2; 0.29 and later require rdflib>=7.1.1, which would drag
+# the pin above with them and every consumer of it.
+pyshacl==0.28.1
 pyparsing==2.4.7 # <3 otherwise: sparql queries as text cannot be parsed
 django-better-admin-arrayfield==1.4.2
 SPARQLWrapper==1.8.5

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -13,6 +13,13 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Features
 
+- The OEKG scenario-bundle REST API: `POST /api/v0/scenario-bundles/` creates a
+  bundle and `GET /api/v0/scenario-bundles/<uid>/` reads it back. The server
+  mints the identifier, the acronym is enforced unique, the bundle is validated
+  against the canonical SHACL shape **before** anything is written, and the
+  write is one atomic request. Reads are public; writes need authentication
+  [(#2430)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2430)
+
 - The OEKG REST API gets its own transport to the graph store
   (`oekg/graph_store.py`): one SPARQL request per write, which Fuseki treats as
   one transaction, instead of one committed request per triple. Its tests run

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -17,19 +17,29 @@ SPDX-License-Identifier: CC0-1.0
   (`oekg/graph_store.py`): one SPARQL request per write, which Fuseki treats as
   one transaction, instead of one committed request per triple. Its tests run
   against a real store in an isolated named graph, and skip with a stated reason
-  when no store is reachable.
+  when no store is reachable
+  [(#2429)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2429)
 
 - `python manage.py fetch_oekg_shapes` obtains the canonical OEKG SHACL shape
   from a pinned revision of the `oekg` repository, and generates the
-  `rdfs:label` subset validation needs from the OEO release already on disk.
+  `rdfs:label` subset validation needs from the OEO release already on disk
+  [(#2428)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2428)
 
 ## Bugs
+
+- The generated OEO label subset copied labels verbatim, so 1,855 of 2,058
+  carried an `@en` tag and four terms carried two labels. The shape requires
+  `sh:datatype xsd:string` and `sh:maxCount 1` on `rdfs:label`, and a
+  language-tagged literal is `rdf:langString` — so every picked OEO term failed
+  validation. Labels are normalised to one plain string per term
+  [(#2430)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2430)
 
 - The OEKG SPARQL endpoint test patched `oekg.utils.execute_sparql_query` while
   the view binds that function into its own namespace, so the mock never took
   effect and the test made a real network call to a host that only resolves
   inside the compose network. It failed on every local run. Patched at the right
-  name, it is now hermetic.
+  name, it is now hermetic
+  [(#2429)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2429)
 
 ## Documentation updates
 

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: CC0-1.0
   mints the identifier, the acronym is enforced unique, the bundle is validated
   against the canonical SHACL shape **before** anything is written, and the
   write is one atomic request. Reads are public; writes need authentication
-  [(#2430)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2430)
+  [(#2435)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2435)
 
 - The OEKG REST API gets its own transport to the graph store
   (`oekg/graph_store.py`): one SPARQL request per write, which Fuseki treats as
@@ -39,7 +39,7 @@ SPDX-License-Identifier: CC0-1.0
   `sh:datatype xsd:string` and `sh:maxCount 1` on `rdfs:label`, and a
   language-tagged literal is `rdf:langString` — so every picked OEO term failed
   validation. Labels are normalised to one plain string per term
-  [(#2430)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2430)
+  [(#2435)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2435)
 
 - The OEKG SPARQL endpoint test patched `oekg.utils.execute_sparql_query` while
   the view binds that function into its own namespace, so the mock never took

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -11,6 +11,13 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Changes
 
+- The dev compose stack names the graph store host explicitly
+  (`RDF_DATABASE_HOST: fuseki`) and waits for that service. Previously it relied
+  on the local `securitysettings.py`, whose shipped default resolves the host to
+  `localhost` -- which inside the container is the container itself, so the OEKG
+  API answered `503` instead of writing
+  [(#2435)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2435)
+
 - Model/Framework factsheet overviews load in a fraction of the time. The row
   data is built by the server in one pass instead of being assembled in the page
   template (2,138 database queries down to 3, whatever the number of


### PR DESCRIPTION
## Summary of the discussion

The tracer bullet for the OEKG REST API: one complete path through every layer,
from an authenticated `POST` to triples in the store and back out again.

```
POST /api/v0/scenario-bundles/         201 + Location, authenticated
GET  /api/v0/scenario-bundles/<uid>/   200, public
```

**The order of operations is the slice**, so it is written down in the view and
asserted in the tests:

1. structure is checked and an unknown key is refused;
2. the acronym is checked for uniqueness, comparing like with like;
3. the server mints the identifier;
4. the **post-state** is assembled and validated against the shape;
5. only then is anything written, in **one** request.

Nothing is written before step 5, so an invalid payload leaves the graph
untouched — asserted, not asserted-ish: the test reads the store back and finds
it empty. And because one request is one transaction, a write that fails halfway
leaves nothing behind either.

### The pieces

| Module | What it is |
|---|---|
| `oekg/shape.py` | the fetched shape read as data — `sh:in` lists and rejection messages both come from the artifact on disk, which is also the cache key |
| `oekg/validation.py` | one function: post-state in, violations out |
| `oekg/bundles.py` | one field table driving both directions, so a read returns what a write accepts |
| `oekg/serializers.py` | hand-written and closed; `_meta` is ignored, not rejected |
| `oekg/api_views.py` | sequences the above |

### Three things the shape requires that the UI does not do

- **Minted organisation, funder and contact nodes are typed.** The live graph
  carries `sh:class` violations because they are not.
- **Frameworks and models are minted per bundle**, not globally. Deleting one
  bundle today strips labels from every other bundle citing the same model.
- **The acronym check compares stored literal to stored literal.** The UI
  normalises one side only, so `Wind Study`, `wind-study`, `Wärme`, `a/b`, `x:y`
  and `p(q)` all slip past it — each is a case in the test.

### Two findings that revise the plan, both measured

- **The rdflib bump is not needed.** The design note booked
  `pyshacl 0.40.1 → rdflib>=7.3.0`, which would have dragged the pin and every
  consumer of it. **`pyshacl 0.28.1` is the newest release still accepting
  `rdflib>=6.3.2`**, so the pin stays at 7.0.0.
- **That validator does not honour `sh:resultMessage`.** Rather than upgrade for
  it, the message is read off the shape ourselves via `sh:sourceShape`. All six
  violations on a minimal invalid bundle resolve to the shape's own words, and
  the API no longer depends on an engine's leniency for its error text.

### A defect in an already-merged slice, fixed here

The generated OEO label subset copied labels verbatim, so **1,855 of 2,058
carried `@en`**. A language-tagged literal is `rdf:langString`, not the
`xsd:string` the shape demands — so **every picked OEO term failed validation**.
Four terms also carried two labels against `sh:maxCount 1`. Found by validating
a minimal bundle against the real shape rather than trusting the plan.

The subset now keeps one plain string per term. It comes to 192,747 bytes,
within a kilobyte of the 191.6 KB the original prototype recorded — which
suggests the prototype normalised too and its note simply did not say so.

### Review found five defects; all five are fixed with tests

- **The create path renamed shared nodes.** Referencing an existing contact by
  IRI wrote a *second* label onto it, breaking `sh:maxCount 1` for every other
  bundle citing it — invisibly, because post-state validation cannot see the
  other bundle. A differing label is a `400` now.
- **The round trip did not work.** An absent abstract reads back as `null` and
  the serializer rejected it; the round-trip test passed only because its
  payload happened to fill every optional. This is the property the later
  `replace` endpoint depends on, so it has a test that omits them deliberately.
- **The acronym check still was not like-for-like** — it asked the store for the
  stripped value and stored the unstripped one.
- **A malformed identifier was a `500`**, not a `404`.
- **A `GET` did not check the node was a bundle**, so reading a minted contact
  answered `200` with an all-`null` payload.

### Also in scope

- **Throttling**, which the auth decision called part of the deliverable
  because reads are public: both views carry an anonymous and a user rate.
- **Ownership is recorded on create** — without it every bundle would be
  ownerless, which is administrator-only by design, so its author could never
  edit it. The graph and Postgres cannot share a transaction, so a failure there
  is logged and named in `_meta.ownership_recorded` rather than turned into a
  `500` denying a write that happened.
- **CI now fetches the shape artifacts.** That is where the first slice deferred
  them to; there is finally something that reads the shape.

### Deliberately not in this slice

- **Nested sub-resources** (scenarios, study reports, dataset links) — the next
  slices.
- **A boot-time check** that the artifacts exist. A missing artifact is a stated
  skip locally and a `503` at runtime, not a boot failure: the shape is a
  dependency of *this API*, not of the platform, and crashing everything over it
  would be disproportionate.
- **`sh:minCount 1` as `required=True`** on the four required enumerations. The
  shape owns that constraint so the rejection carries the shape's wording rather
  than a second phrasing written here.

### Known limit

The acronym check and the insert are not one transaction, so two concurrent
creates can both succeed. It needs the version guard the next slice introduces.

**Tests: 541 green** with a graph store and the shape artifacts present, **512
green** with neither (the graph tests skip with a stated reason).

## Type of change (CHANGELOG.md)

### Features

- The OEKG scenario-bundle REST API: `POST /api/v0/scenario-bundles/` creates a
  bundle and `GET /api/v0/scenario-bundles/<uid>/` reads it back. The server
  mints the identifier, the acronym is enforced unique, the bundle is validated
  against the canonical SHACL shape **before** anything is written, and the
  write is one atomic request. Reads are public; writes need authentication
  [(#2430)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2430)

### Bugs

- The generated OEO label subset copied labels verbatim, so 1,855 of 2,058
  carried an `@en` tag and four terms carried two labels. The shape requires
  `sh:datatype xsd:string` and `sh:maxCount 1` on `rdfs:label`, and a
  language-tagged literal is `rdf:langString` — so every picked OEO term failed
  validation. Labels are normalised to one plain string per term
  [(#2430)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2430)

## Workflow checklist

### Automation

Closes #2434 

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [x] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done