### PR TITLE
Stop the dev image throwing its pip cache away on every rebuild

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# The syntax directive is what enables RUN --mount below.
 # We currently stick to this python version
 FROM python:3.10.14
 
@@ -31,8 +33,17 @@ WORKDIR /home/appuser/app
 COPY requirements.txt ./requirements.txt
 COPY requirements-dev.txt ./requirements-dev.txt
 COPY requirements-docs.txt ./requirements-docs.txt
-RUN pip install --upgrade pip \
-     && pip install --no-cache-dir -r requirements-dev.txt
+# The pip cache lives in a BuildKit cache mount, NOT in the image: the image
+# stays as small as --no-cache-dir made it, and a rebuild reuses the downloads
+# and the wheels it already built.
+#
+# This matters because the COPY lines above invalidate this layer, so ONE new
+# line in requirements.txt used to re-download and re-compile all ~47 packages
+# -- psycopg2, shapely and owlready2 build from source against build-essential,
+# which is most of the several minutes that took.
+RUN --mount=type=cache,target=/root/.cache/pip \
+     pip install --upgrade pip \
+     && pip install -r requirements-dev.txt
 
 # bring in your dev-entrypoint (in docker/)
 COPY docker/docker-entrypoint.dev.sh .

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -11,6 +11,12 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Changes
 
+- The dev image caches pip downloads and built wheels in a BuildKit cache mount
+  instead of discarding them. A single new line in `requirements.txt` used to
+  re-download and re-compile all ~47 packages, several minutes of it building
+  `psycopg2`, `shapely` and `owlready2` from source. The image stays the same
+  size, because the cache lives outside it
+
 ## Features
 
 - The OEKG REST API gets its own transport to the graph store


### PR DESCRIPTION
## Summary of the discussion

Adding one line to requirements.txt cost several minutes. The COPY lines above the install invalidate that layer, and --no-cache-dir then forbids pip from reusing anything, so all ~47 packages were re-downloaded AND re-built -- psycopg2, shapely and owlready2 compile from source against build-essential, which was most of the time. Measured on one such rebuild: 400 s, of which the network was idle and ~2.3 cores were busy. It was compiling, not downloading.

--no-cache-dir is the right advice for a production image, where the trade is a smaller image. For a dev image that is rebuilt whenever a dependency moves it is the wrong way round: it saves a few hundred megabytes once and pays the full rebuild every time.

A BuildKit cache mount gets both. The cache lives outside the image, so the image stays exactly as small as --no-cache-dir made it, and the next rebuild reuses the downloads and the wheels it already built. Needs the syntax directive at the top of the file, which is why that is there.

Verified with `docker build --check`: no warnings.

Not touched: docker/Dockerfile (production) keeps --no-cache-dir. It is built once in CI, so the trade genuinely runs the other way there.

### PR-Assignee

- [ ] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [ ] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/)

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
