### PR TITLE
Feature oekg api patch version guard

### DIFF
--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -57,12 +57,10 @@ from oekg.bundles import (
     BUNDLE_CLASS,
     DC,
     build_bundle_graph,
-    bundle_field,
+    bundle_delta,
     bundle_iri,
     bundle_payload,
     bundle_subgraph,
-    field_triples,
-    linked_field_triples,
     mint_bundle_uid,
     referenced_node_iris,
 )
@@ -77,16 +75,11 @@ from oekg.versioning import (
     guarded_operation,
     mint_write_token,
     read_version,
-    stamped,
     version_triples,
+    write_applied,
 )
 
 logger = logging.getLogger("oeplatform")
-
-# `If-Match: *` names no version. It is a legal header value, but it satisfies
-# the letter of the precondition while withholding the one thing the
-# precondition is for, so it is treated as absent rather than as a match.
-ANY_VERSION = object()
 
 
 class ScenarioBundleThrottle(AnonRateThrottle):
@@ -111,9 +104,9 @@ class ScenarioBundleCollectionAPIView(APIView):
         payload = serializer.validated_data
 
         store = GraphStore.from_settings()
-        # Checked and stored as the same value. Stripping one side only is how
-        # the user interface's check comes to miss duplicates.
-        payload["acronym"] = payload["acronym"].strip()
+        # One value, checked and stored. The serializer has already trimmed
+        # it, so the check and the write cannot compare different things --
+        # which is the whole of the user interface's bug.
         acronym = payload["acronym"]
         try:
             if _acronym_taken(store, acronym):
@@ -141,7 +134,12 @@ class ScenarioBundleCollectionAPIView(APIView):
                     insert=post_state + version_triples(uid, FIRST_VERSION, token),
                 )
             )
-            if not stamped(store, uid, token):
+            if not write_applied(store, uid, token):
+                # The acronym is the ONLY condition in that guard, so a miss
+                # can only mean the acronym was taken in between. A second
+                # condition -- which is what `also_require` exists to allow --
+                # would make this answer wrong, so it would have to distinguish
+                # them before one is added.
                 return _acronym_conflict(acronym)
         except ShapeUnavailable as error:
             return _shape_unavailable(error)
@@ -210,7 +208,7 @@ class ScenarioBundleAPIView(APIView):
         except GraphStoreError as error:
             return _store_unavailable(error, "read")
 
-        return _representation(uid, bundle_payload(subgraph, uid), version)
+        return _bundle_response(uid, bundle_payload(subgraph, uid), version)
 
     def patch(self, request, uid):
         if not _is_minted_identifier(uid):
@@ -230,11 +228,6 @@ class ScenarioBundleAPIView(APIView):
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
-
-        if "acronym" in payload:
-            # Stripped here as it is on a create, because the check and the
-            # write have to compare the same value.
-            payload["acronym"] = payload["acronym"].strip()
 
         store = GraphStore.from_settings()
         try:
@@ -266,7 +259,7 @@ class ScenarioBundleAPIView(APIView):
             if renamed:
                 return _rename_refused(renamed)
 
-            removed, added = _delta(uid, payload, pre_state, known_labels)
+            removed, added = bundle_delta(uid, payload, pre_state, known_labels)
             post_state = bundle_subgraph(pre_state - removed + added, uid)
 
             violations = validate_post_state(post_state)
@@ -289,7 +282,7 @@ class ScenarioBundleAPIView(APIView):
                     ),
                 )
             )
-            if not stamped(store, uid, token):
+            if not write_applied(store, uid, token):
                 # The guard held nothing back that the client could have known
                 # about: the bundle moved -- or went away -- after the read this
                 # request had to make.
@@ -309,29 +302,13 @@ class ScenarioBundleAPIView(APIView):
             return _store_unavailable(error, "written to")
 
         written = BundleVersion(version.number + 1, token)
-        return _representation(uid, bundle_payload(post_state, uid), written)
-
-
-def _delta(uid: str, payload: dict, pre_state: Graph, known_labels: dict) -> tuple:
-    """What a patch removes and what it adds -- per named field, nothing else.
-
-    A set-valued field named in the payload is replaced whole: its links go and
-    the payload's take their place. Emptying such a field is therefore a real
-    change, which the shape then judges -- an empty list on a field the shape
-    requires is a rejection, never a silent wipe.
-    """
-    removed, added = Graph(), Graph()
-    for name, value in payload.items():
-        field = bundle_field(name)
-        removed += linked_field_triples(pre_state, uid, field)
-        added += field_triples(uid, field, value, known_labels)
-    return removed, added
+        return _bundle_response(uid, bundle_payload(post_state, uid), written)
 
 
 def _precondition_refusal(request, version: BundleVersion) -> Optional[Response]:
     """Why this request may not proceed on its precondition, if it may not."""
     named = _versions_named(request)
-    if named is None or named is ANY_VERSION:
+    if named is None:
         return Response(
             {
                 "detail": (
@@ -358,11 +335,15 @@ def _precondition_refusal(request, version: BundleVersion) -> Optional[Response]
 
 
 def _versions_named(request):
-    """The versions an ``If-Match`` names: a list, ``ANY_VERSION``, or ``None``.
+    """The versions an ``If-Match`` names, or ``None`` if it names none.
 
     Lenient in what it accepts and strict in what it emits: a weak validator or
     a bare number is read as the version it plainly is, while a value that is
     not a version simply matches nothing and is refused as stale.
+
+    ``*`` names no version. It is a legal header value, and it satisfies the
+    letter of the precondition while withholding the one thing the precondition
+    is for, so it reads here as an absent header rather than as a match.
     """
     header = request.headers.get("If-Match")
     if header is None:
@@ -371,7 +352,7 @@ def _versions_named(request):
     for entry in header.split(","):
         entry = entry.strip()
         if entry == "*":
-            return ANY_VERSION
+            return None
         if entry.startswith("W/"):
             entry = entry[2:].strip()
         named.append(entry.strip('"'))
@@ -493,7 +474,8 @@ def _represent(uid: str, payload: dict, version: BundleVersion) -> dict:
     }
 
 
-def _representation(uid: str, payload: dict, version: BundleVersion) -> Response:
+def _bundle_response(uid: str, payload: dict, version: BundleVersion) -> Response:
+    """The body, plus the entity tag every read has to carry."""
     response = Response(_represent(uid, payload, version))
     response["ETag"] = version.etag
     return response

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -1,17 +1,35 @@
-"""The OEKG scenario-bundle API: create one, read one.
+"""The OEKG scenario-bundle API: create one, read one, change one field.
 
-The order of operations in a create is the whole point of this slice, so it is
-worth stating plainly:
+The order of operations in a create is the whole point, so it is worth stating
+plainly:
 
 1. the payload is checked for structure, and an unknown key is refused;
 2. the acronym is checked for uniqueness, comparing like with like;
 3. the server mints the identifier;
 4. the **post-state** is assembled and validated against the shape;
-5. only then is anything written, in **one** request.
+5. only then is anything written, in **one** request -- and the acronym check
+   is bound inside that request, so two concurrent creates cannot both take an
+   acronym they both found free.
 
 Nothing is written before step 5, so an invalid payload leaves the graph
 untouched -- not "mostly untouched", untouched. And because one request is one
 transaction, a write that fails halfway leaves nothing behind either.
+
+A patch runs the same course with two additions: it reads the bundle first,
+because the shape can only be checked against a whole bundle, and that read
+opens a window. **The window is closed inside the write**, by binding the
+version the read saw in the update's own guard -- see `oekg/versioning.py` for
+why that guard needs a read-back to speak. Three refusals mean three different
+things and get three statuses:
+
+- **428** the client did not say which version it was editing;
+- **412** it named a version, and that is not the current one;
+- **409** the server's own guard fired -- the bundle moved between the read and
+  the write. Re-read, re-apply, retry.
+
+A patch touches only the keys it names. A key that is absent is untouched --
+not read and rewritten, genuinely untouched -- which is also what stops an
+unrelated patch from re-minting every framework and model in the bundle.
 
 Reads need no authentication: the SPARQL endpoint already serves the same data,
 so requiring a token here would protect nothing while making public research
@@ -23,10 +41,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 import logging
 import uuid
+from typing import Optional
 
 from django.db import DatabaseError
 from django.urls import reverse
-from rdflib import RDFS, Literal, URIRef
+from rdflib import RDFS, Graph, Literal, URIRef
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -38,17 +57,36 @@ from oekg.bundles import (
     BUNDLE_CLASS,
     DC,
     build_bundle_graph,
+    bundle_field,
     bundle_iri,
     bundle_payload,
+    bundle_subgraph,
+    field_triples,
+    linked_field_triples,
     mint_bundle_uid,
     referenced_node_iris,
 )
 from oekg.graph_store import GraphStore, GraphStoreError
+from oekg.permissions import may_write_bundle
 from oekg.serializers import READ_ONLY_CONTAINER, ScenarioBundleSerializer
 from oekg.shape import ShapeUnavailable
 from oekg.validation import validate_post_state
+from oekg.versioning import (
+    FIRST_VERSION,
+    BundleVersion,
+    guarded_operation,
+    mint_write_token,
+    read_version,
+    stamped,
+    version_triples,
+)
 
 logger = logging.getLogger("oeplatform")
+
+# `If-Match: *` names no version. It is a legal header value, but it satisfies
+# the letter of the precondition while withholding the one thing the
+# precondition is for, so it is treated as absent rather than as a match.
+ANY_VERSION = object()
 
 
 class ScenarioBundleThrottle(AnonRateThrottle):
@@ -79,58 +117,36 @@ class ScenarioBundleCollectionAPIView(APIView):
         acronym = payload["acronym"]
         try:
             if _acronym_taken(store, acronym):
-                return Response(
-                    {
-                        "detail": (
-                            f"A scenario bundle with the acronym {acronym!r} "
-                            "already exists. Acronyms identify a bundle to a "
-                            "pipeline, so they have to be unique."
-                        )
-                    },
-                    status=status.HTTP_409_CONFLICT,
-                )
+                return _acronym_conflict(acronym)
 
             known_labels = _labels_of(store, referenced_node_iris(payload))
             renamed = _renames(payload, known_labels)
             if renamed:
-                return Response(
-                    {
-                        "detail": (
-                            "A shared node cannot be renamed through this API. "
-                            "Reference it by iri and send the label it already "
-                            "has, or omit the iri to mint a new node."
-                        ),
-                        "conflicts": renamed,
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+                return _rename_refused(renamed)
 
             uid = mint_bundle_uid()
             post_state = build_bundle_graph(uid, payload, known_labels)
 
             violations = validate_post_state(post_state)
             if violations:
-                return Response(
-                    {
-                        "detail": "The bundle does not conform to the OEKG shape.",
-                        "violations": [v.as_dict() for v in violations],
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+                return _does_not_conform(violations)
 
-            store.insert(post_state)
+            # The uniqueness check above is friendly, not sufficient: it is a
+            # separate request, so two creates can both pass it. The guard here
+            # is part of the write, so only one of them lands.
+            token = mint_write_token()
+            store.update(
+                store.guarded_modification(
+                    _no_bundle_has_acronym(acronym),
+                    insert=post_state + version_triples(uid, FIRST_VERSION, token),
+                )
+            )
+            if not stamped(store, uid, token):
+                return _acronym_conflict(acronym)
         except ShapeUnavailable as error:
-            logger.error("OEKG API cannot validate: %s", error)
-            return Response(
-                {"detail": "The OEKG shape is not available on this server."},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
+            return _shape_unavailable(error)
         except GraphStoreError as error:
-            logger.error("OEKG API write failed: %s", error)
-            return Response(
-                {"detail": "The OEKG graph store could not be written to."},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
+            return _store_unavailable(error, "written to")
 
         # Ownership is recorded now so the creator can edit later: a bundle with
         # no ownership record is administrator-only by design, which would make
@@ -153,55 +169,235 @@ class ScenarioBundleCollectionAPIView(APIView):
                 uid,
             )
 
-        location = reverse("api:scenario-bundle", kwargs={"uid": uid})
-        body = _represent(uid, bundle_payload(post_state, uid))
+        version = BundleVersion(FIRST_VERSION, token)
+        body = _represent(uid, bundle_payload(post_state, uid), version)
         if not owned:
             body[READ_ONLY_CONTAINER]["ownership_recorded"] = False
         response = Response(body, status=status.HTTP_201_CREATED)
-        response["Location"] = location
+        response["Location"] = reverse("api:scenario-bundle", kwargs={"uid": uid})
+        response["ETag"] = version.etag
         return response
 
 
 class ScenarioBundleAPIView(APIView):
-    """`GET` returns one scenario bundle. Public."""
+    """`GET` returns one scenario bundle, publicly. `PATCH` changes a field."""
 
-    permission_classes = [AllowAny]
     throttle_classes = [ScenarioBundleThrottle, ScenarioBundleUserThrottle]
+
+    def get_permissions(self):
+        # The safe methods are named and everything else is closed, rather than
+        # the other way round: a verb a later slice adds is then authenticated
+        # by default instead of public until somebody remembers. The price is
+        # that an unsupported verb answers 401 before it can answer 405, which
+        # is the cheaper of the two mistakes.
+        if self.request.method in ("GET", "HEAD", "OPTIONS"):
+            return [AllowAny()]
+        return [IsAuthenticated()]
 
     def get(self, request, uid):
         # Identifiers are minted here, so anything that is not one cannot name a
         # bundle. Checked before it reaches a query, where an IRI-unsafe
         # character would raise out of rdflib as a 500 rather than a 404.
         if not _is_minted_identifier(uid):
-            return Response(
-                {"detail": f"No scenario bundle {uid}."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+            return _no_such_bundle(uid)
 
         store = GraphStore.from_settings()
         try:
-            subgraph = store.construct(
-                "CONSTRUCT { ?s ?p ?o } WHERE { "
-                f"  VALUES ?root {{ {bundle_iri(uid).n3()} }} "
-                f"  ?root a {BUNDLE_CLASS.n3()} . "
-                "  { ?root ?p ?o . BIND(?root AS ?s) } "
-                "  UNION "
-                "  { ?root ?q ?s . ?s ?p ?o } "
-                "}"
-            )
+            subgraph = _read_bundle(store, uid)
+            if subgraph is None:
+                return _no_such_bundle(uid)
+            version = read_version(store, uid)
         except GraphStoreError as error:
-            logger.error("OEKG API read failed: %s", error)
+            return _store_unavailable(error, "read")
+
+        return _representation(uid, bundle_payload(subgraph, uid), version)
+
+    def patch(self, request, uid):
+        if not _is_minted_identifier(uid):
+            return _no_such_bundle(uid)
+
+        serializer = ScenarioBundleSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        payload = dict(serializer.validated_data)
+        if not payload:
             return Response(
-                {"detail": "The OEKG graph store could not be read."},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                {
+                    "detail": (
+                        "A patch has to name at least one field to change. "
+                        "Read-only data is ignored on a write, so a payload "
+                        f"carrying only {READ_ONLY_CONTAINER!r} changes nothing."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
-        if (bundle_iri(uid), None, None) not in subgraph:
-            return Response(
-                {"detail": f"No scenario bundle {uid}."},
-                status=status.HTTP_404_NOT_FOUND,
+        if "acronym" in payload:
+            # Stripped here as it is on a create, because the check and the
+            # write have to compare the same value.
+            payload["acronym"] = payload["acronym"].strip()
+
+        store = GraphStore.from_settings()
+        try:
+            # Existence first, as it is for the two-step delete: one order for
+            # the whole API rather than one per endpoint. Reads are public, so
+            # answering 404 before authorisation reveals nothing a GET would
+            # not.
+            pre_state = _read_bundle(store, uid)
+            if pre_state is None:
+                return _no_such_bundle(uid)
+
+            if not may_write_bundle(request.user, uid):
+                return _not_the_owner()
+
+            version = read_version(store, uid)
+            refusal = _precondition_refusal(request, version)
+            if refusal is not None:
+                return refusal
+
+            # An acronym is how a pipeline finds its bundle again, so a rename
+            # onto one that is taken has to be refused here too -- otherwise
+            # uniqueness holds only for as long as nobody patches.
+            acronym = payload.get("acronym")
+            if acronym is not None and _acronym_taken(store, acronym, besides=uid):
+                return _acronym_conflict(acronym)
+
+            known_labels = _labels_of(store, referenced_node_iris(payload))
+            renamed = _renames(payload, known_labels)
+            if renamed:
+                return _rename_refused(renamed)
+
+            removed, added = _delta(uid, payload, pre_state, known_labels)
+            post_state = bundle_subgraph(pre_state - removed + added, uid)
+
+            violations = validate_post_state(post_state)
+            if violations:
+                return _does_not_conform(violations)
+
+            token = mint_write_token()
+            store.update(
+                guarded_operation(
+                    store,
+                    uid,
+                    version,
+                    token,
+                    delete=removed,
+                    insert=added,
+                    also_require=(
+                        None
+                        if acronym is None
+                        else _no_bundle_has_acronym(acronym, besides=uid)
+                    ),
+                )
             )
-        return Response(_represent(uid, bundle_payload(subgraph, uid)))
+            if not stamped(store, uid, token):
+                # The guard held nothing back that the client could have known
+                # about: the bundle moved -- or went away -- after the read this
+                # request had to make.
+                return Response(
+                    {
+                        "detail": (
+                            "The bundle changed while this request was being "
+                            "prepared, so nothing was written. Read it again, "
+                            "apply the change to what you get back, and retry."
+                        )
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+        except ShapeUnavailable as error:
+            return _shape_unavailable(error)
+        except GraphStoreError as error:
+            return _store_unavailable(error, "written to")
+
+        written = BundleVersion(version.number + 1, token)
+        return _representation(uid, bundle_payload(post_state, uid), written)
+
+
+def _delta(uid: str, payload: dict, pre_state: Graph, known_labels: dict) -> tuple:
+    """What a patch removes and what it adds -- per named field, nothing else.
+
+    A set-valued field named in the payload is replaced whole: its links go and
+    the payload's take their place. Emptying such a field is therefore a real
+    change, which the shape then judges -- an empty list on a field the shape
+    requires is a rejection, never a silent wipe.
+    """
+    removed, added = Graph(), Graph()
+    for name, value in payload.items():
+        field = bundle_field(name)
+        removed += linked_field_triples(pre_state, uid, field)
+        added += field_triples(uid, field, value, known_labels)
+    return removed, added
+
+
+def _precondition_refusal(request, version: BundleVersion) -> Optional[Response]:
+    """Why this request may not proceed on its precondition, if it may not."""
+    named = _versions_named(request)
+    if named is None or named is ANY_VERSION:
+        return Response(
+            {
+                "detail": (
+                    "This write needs an If-Match header carrying the version "
+                    "you read, so that it cannot silently overwrite a change "
+                    f"made since. The bundle is at {version.etag}."
+                )
+            },
+            status=status.HTTP_428_PRECONDITION_REQUIRED,
+        )
+    if str(version.number) not in named:
+        return Response(
+            {
+                "detail": (
+                    "The bundle is not at the version this request expects, so "
+                    "nothing was written. It is at "
+                    f"{version.etag}. Read it again and apply the change to "
+                    "what you get back."
+                )
+            },
+            status=status.HTTP_412_PRECONDITION_FAILED,
+        )
+    return None
+
+
+def _versions_named(request):
+    """The versions an ``If-Match`` names: a list, ``ANY_VERSION``, or ``None``.
+
+    Lenient in what it accepts and strict in what it emits: a weak validator or
+    a bare number is read as the version it plainly is, while a value that is
+    not a version simply matches nothing and is refused as stale.
+    """
+    header = request.headers.get("If-Match")
+    if header is None:
+        return None
+    named = []
+    for entry in header.split(","):
+        entry = entry.strip()
+        if entry == "*":
+            return ANY_VERSION
+        if entry.startswith("W/"):
+            entry = entry[2:].strip()
+        named.append(entry.strip('"'))
+    return named
+
+
+def _read_bundle(store: GraphStore, uid: str) -> Optional[Graph]:
+    """A bundle and one hop out, or ``None`` if there is no such bundle.
+
+    One hop is the whole bundle: its fields are either literals, picked IRIs,
+    or nodes carrying a type and a label. The version node is unreachable from
+    here, because it points at the bundle rather than away from it -- which is
+    what keeps bookkeeping out of the payload without any filtering.
+    """
+    subgraph = store.construct(
+        "CONSTRUCT { ?s ?p ?o } WHERE { "
+        f"  VALUES ?root {{ {bundle_iri(uid).n3()} }} "
+        f"  ?root a {BUNDLE_CLASS.n3()} . "
+        "  { ?root ?p ?o . BIND(?root AS ?s) } "
+        "  UNION "
+        "  { ?root ?q ?s . ?s ?p ?o } "
+        "}"
+    )
+    if (bundle_iri(uid), None, None) not in subgraph:
+        return None
+    return subgraph
 
 
 def _is_minted_identifier(uid: str) -> bool:
@@ -256,23 +452,120 @@ def _entries_for(payload: dict, iri: str) -> list:
     ]
 
 
-def _acronym_taken(store: GraphStore, acronym: str) -> bool:
+def _acronym_taken(store: GraphStore, acronym: str, besides: str = None) -> bool:
     """Whether a bundle already uses this acronym.
 
     Compares the stored literal with the literal a write would store -- like
     with like. The user interface's check normalises one side and not the other,
     so any acronym with a space, hyphen, umlaut, slash, colon or parenthesis
     slips past it.
+
+    ``besides`` exempts one bundle, so a patch that sends an acronym back
+    unchanged is not refused by its own value.
     """
-    return store.ask(
-        "ASK { ?bundle a %s ; %s %s }"
-        % (BUNDLE_CLASS.n3(), DC.acronym.n3(), Literal(acronym).n3())
+    return store.ask("ASK { %s }" % _acronym_pattern(acronym, besides))
+
+
+def _no_bundle_has_acronym(acronym: str, besides: str = None) -> str:
+    return "FILTER NOT EXISTS { %s }" % _acronym_pattern(acronym, besides)
+
+
+def _acronym_pattern(acronym: str, besides: str = None) -> str:
+    pattern = "?bundle a %s ; %s %s" % (
+        BUNDLE_CLASS.n3(),
+        DC.acronym.n3(),
+        Literal(acronym).n3(),
+    )
+    if besides is None:
+        return pattern
+    return "%s . FILTER(?bundle != %s)" % (pattern, bundle_iri(besides).n3())
+
+
+def _represent(uid: str, payload: dict, version: BundleVersion) -> dict:
+    """A read returns exactly what a write accepts, plus read-only data."""
+    return {
+        **payload,
+        READ_ONLY_CONTAINER: {
+            "uid": uid,
+            "iri": str(bundle_iri(uid)),
+            "version": version.number,
+        },
+    }
+
+
+def _representation(uid: str, payload: dict, version: BundleVersion) -> Response:
+    response = Response(_represent(uid, payload, version))
+    response["ETag"] = version.etag
+    return response
+
+
+def _no_such_bundle(uid: str) -> Response:
+    return Response(
+        {"detail": f"No scenario bundle {uid}."}, status=status.HTTP_404_NOT_FOUND
     )
 
 
-def _represent(uid: str, payload: dict) -> dict:
-    """A read returns exactly what a write accepts, plus one read-only key."""
-    return {
-        **payload,
-        READ_ONLY_CONTAINER: {"uid": uid, "iri": str(bundle_iri(uid))},
-    }
+def _not_the_owner() -> Response:
+    return Response(
+        {
+            "detail": (
+                "Only an owner of this scenario bundle may change it. A bundle "
+                "with no recorded owner can be changed by an administrator "
+                "only."
+            )
+        },
+        status=status.HTTP_403_FORBIDDEN,
+    )
+
+
+def _acronym_conflict(acronym: str) -> Response:
+    return Response(
+        {
+            "detail": (
+                f"A scenario bundle with the acronym {acronym!r} already "
+                "exists. Acronyms identify a bundle to a pipeline, so they "
+                "have to be unique."
+            )
+        },
+        status=status.HTTP_409_CONFLICT,
+    )
+
+
+def _rename_refused(renamed: list) -> Response:
+    return Response(
+        {
+            "detail": (
+                "A shared node cannot be renamed through this API. Reference "
+                "it by iri and send the label it already has, or omit the iri "
+                "to mint a new node."
+            ),
+            "conflicts": renamed,
+        },
+        status=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+def _does_not_conform(violations: list) -> Response:
+    return Response(
+        {
+            "detail": "The bundle does not conform to the OEKG shape.",
+            "violations": [violation.as_dict() for violation in violations],
+        },
+        status=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+def _shape_unavailable(error: Exception) -> Response:
+    logger.error("OEKG API cannot validate: %s", error)
+    return Response(
+        {"detail": "The OEKG shape is not available on this server."},
+        status=status.HTTP_503_SERVICE_UNAVAILABLE,
+    )
+
+
+def _store_unavailable(error: Exception, action: str) -> Response:
+    logger.error("OEKG API %s failed: %s", action, error)
+    return Response(
+        {"detail": f"The OEKG graph store could not be {action}."},
+        status=status.HTTP_503_SERVICE_UNAVAILABLE,
+    )

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -136,10 +136,9 @@ class ScenarioBundleCollectionAPIView(APIView):
             )
             if not write_applied(store, uid, token):
                 # The acronym is the ONLY condition in that guard, so a miss
-                # can only mean the acronym was taken in between. A second
-                # condition -- which is what `also_require` exists to allow --
-                # would make this answer wrong, so it would have to distinguish
-                # them before one is added.
+                # can only mean the acronym was taken in between. Binding a
+                # second condition into the same WHERE would make this answer
+                # wrong, so it would have to distinguish them first.
                 return _acronym_conflict(acronym)
         except ShapeUnavailable as error:
             return _shape_unavailable(error)
@@ -247,13 +246,6 @@ class ScenarioBundleAPIView(APIView):
             if refusal is not None:
                 return refusal
 
-            # An acronym is how a pipeline finds its bundle again, so a rename
-            # onto one that is taken has to be refused here too -- otherwise
-            # uniqueness holds only for as long as nobody patches.
-            acronym = payload.get("acronym")
-            if acronym is not None and _acronym_taken(store, acronym, besides=uid):
-                return _acronym_conflict(acronym)
-
             known_labels = _labels_of(store, referenced_node_iris(payload))
             renamed = _renames(payload, known_labels)
             if renamed:
@@ -269,17 +261,7 @@ class ScenarioBundleAPIView(APIView):
             token = mint_write_token()
             store.update(
                 guarded_operation(
-                    store,
-                    uid,
-                    version,
-                    token,
-                    delete=removed,
-                    insert=added,
-                    also_require=(
-                        None
-                        if acronym is None
-                        else _no_bundle_has_acronym(acronym, besides=uid)
-                    ),
+                    store, uid, version, token, delete=removed, insert=added
                 )
             )
             if not write_applied(store, uid, token):
@@ -433,7 +415,7 @@ def _entries_for(payload: dict, iri: str) -> list:
     ]
 
 
-def _acronym_taken(store: GraphStore, acronym: str, besides: str = None) -> bool:
+def _acronym_taken(store: GraphStore, acronym: str) -> bool:
     """Whether a bundle already uses this acronym.
 
     Compares the stored literal with the literal a write would store -- like
@@ -441,25 +423,26 @@ def _acronym_taken(store: GraphStore, acronym: str, besides: str = None) -> bool
     so any acronym with a space, hyphen, umlaut, slash, colon or parenthesis
     slips past it.
 
-    ``besides`` exempts one bundle, so a patch that sends an acronym back
-    unchanged is not refused by its own value.
+    **Asked on a create only.** A patch may still rename a bundle onto an
+    acronym another one holds, so uniqueness holds from creation and not
+    thereafter. That gap is deliberate and deferred: the read side is where the
+    acronym becomes load-bearing, because that is where a pipeline looks a
+    bundle up by it, so the check belongs with the endpoint that makes the
+    promise. `PatchAcronymTest` in the tests pins the gap down as it stands.
     """
-    return store.ask("ASK { %s }" % _acronym_pattern(acronym, besides))
+    return store.ask("ASK { %s }" % _acronym_pattern(acronym))
 
 
-def _no_bundle_has_acronym(acronym: str, besides: str = None) -> str:
-    return "FILTER NOT EXISTS { %s }" % _acronym_pattern(acronym, besides)
+def _no_bundle_has_acronym(acronym: str) -> str:
+    return "FILTER NOT EXISTS { %s }" % _acronym_pattern(acronym)
 
 
-def _acronym_pattern(acronym: str, besides: str = None) -> str:
-    pattern = "?bundle a %s ; %s %s" % (
+def _acronym_pattern(acronym: str) -> str:
+    return "?bundle a %s ; %s %s" % (
         BUNDLE_CLASS.n3(),
         DC.acronym.n3(),
         Literal(acronym).n3(),
     )
-    if besides is None:
-        return pattern
-    return "%s . FILTER(?bundle != %s)" % (pattern, bundle_iri(besides).n3())
 
 
 def _represent(uid: str, payload: dict, version: BundleVersion) -> dict:

--- a/oekg/bundles.py
+++ b/oekg/bundles.py
@@ -72,6 +72,8 @@ BUNDLE_FIELDS = (
     BundleField("models", HAS_PART, PART, OEO.OEO_00000277, "model"),
 )
 
+_FIELDS_BY_NAME = {field.name: field for field in BUNDLE_FIELDS}
+
 
 def mint_bundle_uid() -> str:
     """A new bundle identifier. The server's to give, never the client's."""
@@ -95,6 +97,11 @@ def referenced_node_iris(payload: dict) -> list:
     return iris
 
 
+def bundle_field(name: str) -> BundleField:
+    """The one entry in the field table called ``name``."""
+    return _FIELDS_BY_NAME[name]
+
+
 def build_bundle_graph(uid: str, payload: dict, known_labels: dict = None) -> Graph:
     """Assemble the triples a bundle payload means.
 
@@ -107,47 +114,104 @@ def build_bundle_graph(uid: str, payload: dict, known_labels: dict = None) -> Gr
     it. Without that, an additive write would leave a contact other bundles
     cite carrying two labels, violating sh:maxCount 1 for all of them.
     """
+    graph = Graph()
+    graph.add((bundle_iri(uid), RDF.type, BUNDLE_CLASS))
+    for field in BUNDLE_FIELDS:
+        if field.name in payload:
+            graph += field_triples(uid, field, payload[field.name], known_labels)
+    return graph
+
+
+def field_triples(
+    uid: str, field: BundleField, value, known_labels: dict = None
+) -> Graph:
+    """The triples one field's value means, and nothing else.
+
+    A create needs every field's triples at once; a patch needs exactly the
+    named field's, so that a field nobody mentioned is genuinely untouched
+    rather than deleted and rewritten identically. Both ask here, so the two
+    directions cannot come to disagree about what a field is.
+    """
     known_labels = known_labels or {}
     graph = Graph()
     subject = bundle_iri(uid)
-    graph.add((subject, RDF.type, BUNDLE_CLASS))
-
-    for field in BUNDLE_FIELDS:
-        if field.name not in payload:
-            continue
-        value = payload[field.name]
-        if field.kind == LITERAL:
-            if value is not None and value != "":
-                graph.add((subject, field.predicate, Literal(value)))
-        elif field.kind == ENUM:
-            for iri in value:
-                graph.add((subject, field.predicate, URIRef(iri)))
-        elif field.kind == NODE:
-            for entry in value:
-                iri = entry.get("iri")
-                node = URIRef(iri) if iri else _minted(field)
-                graph.add((subject, field.predicate, node))
-                if iri and iri in known_labels:
-                    # An existing shared node is referenced, never rewritten.
-                    # Its label comes from the graph so the post-state is
-                    # complete for validation, and the write adds nothing to a
-                    # node other bundles depend on.
-                    graph.add((node, RDF.type, field.node_class))
-                    graph.add((node, RDFS.label, Literal(known_labels[iri])))
-                else:
-                    graph.add((node, RDF.type, field.node_class))
-                    graph.add((node, RDFS.label, Literal(entry["label"])))
-        elif field.kind == PART:
-            for entry in value:
-                node = _minted(field)
-                graph.add((subject, field.predicate, node))
-                graph.add((node, RDF.type, field.node_class))
+    if field.kind == LITERAL:
+        if value is not None and value != "":
+            graph.add((subject, field.predicate, Literal(value)))
+    elif field.kind == ENUM:
+        for iri in value:
+            graph.add((subject, field.predicate, URIRef(iri)))
+    elif field.kind == NODE:
+        for entry in value:
+            iri = entry.get("iri")
+            node = URIRef(iri) if iri else _minted(field)
+            graph.add((subject, field.predicate, node))
+            graph.add((node, RDF.type, field.node_class))
+            if iri and iri in known_labels:
+                # An existing shared node is referenced, never rewritten. Its
+                # label comes from the graph so the post-state is complete for
+                # validation, and the write adds nothing to a node other
+                # bundles depend on.
+                graph.add((node, RDFS.label, Literal(known_labels[iri])))
+            else:
                 graph.add((node, RDFS.label, Literal(entry["label"])))
-                if entry.get("iri"):
-                    # has-iri is a STRING on these nodes, per the shape: it
-                    # points at a factsheet page, it is not the node's identity.
-                    graph.add((node, HAS_IRI, Literal(entry["iri"])))
+    elif field.kind == PART:
+        for entry in value:
+            node = _minted(field)
+            graph.add((subject, field.predicate, node))
+            graph.add((node, RDF.type, field.node_class))
+            graph.add((node, RDFS.label, Literal(entry["label"])))
+            if entry.get("iri"):
+                # has-iri is a STRING on these nodes, per the shape: it points
+                # at a factsheet page, it is not the node's identity.
+                graph.add((node, HAS_IRI, Literal(entry["iri"])))
     return graph
+
+
+def linked_field_triples(graph: Graph, uid: str, field: BundleField) -> Graph:
+    """The triples that currently attach ``field``'s values to the bundle.
+
+    What a patch of that field removes -- **the links only.** A referenced
+    contact, organisation or funder is shared with other bundles, and a
+    framework or model is on the same "unlink, never delete" footing: nothing
+    here reaches into a node's own triples, so no patch can strip a label that
+    another bundle is displaying.
+
+    The cost of that rule is an unlinked node left in the graph. It is
+    unreachable from the bundle, so no read returns it and no shape is asked
+    about it, and deciding which nodes may actually be removed is the typed
+    containment walk's job -- a whole slice of its own, because the allowlist
+    was already wrong once while it was being drafted. Unlinking fails safe;
+    guessing does not.
+
+    Frameworks and models share the has-part predicate, so the type is what
+    tells them apart. Deleting by predicate alone would take both.
+    """
+    subject = bundle_iri(uid)
+    triples = Graph()
+    for obj in graph.objects(subject, field.predicate):
+        if field.kind == PART and (obj, RDF.type, field.node_class) not in graph:
+            continue
+        triples.add((subject, field.predicate, obj))
+    return triples
+
+
+def bundle_subgraph(graph: Graph, uid: str) -> Graph:
+    """``graph`` narrowed to the bundle and one hop out, as a read returns it.
+
+    Applied to a patch's post-state, this is what makes "validate the
+    post-state" mean the state that will actually read back: a node a patch
+    unlinked is no longer part of the bundle, so it is no longer part of what
+    the shape is asked about.
+    """
+    subject = bundle_iri(uid)
+    narrowed = Graph()
+    for predicate, obj in graph.predicate_objects(subject):
+        narrowed.add((subject, predicate, obj))
+        if isinstance(obj, URIRef):
+            for node_predicate, node_object in graph.predicate_objects(obj):
+                narrowed.add((obj, node_predicate, node_object))
+    return narrowed
 
 
 def bundle_payload(graph: Graph, uid: str) -> dict:

--- a/oekg/bundles.py
+++ b/oekg/bundles.py
@@ -196,6 +196,28 @@ def linked_field_triples(graph: Graph, uid: str, field: BundleField) -> Graph:
     return triples
 
 
+def bundle_delta(
+    uid: str, payload: dict, pre_state: Graph, known_labels: dict = None
+) -> tuple:
+    """What a patch of ``payload`` removes and what it adds. Nothing else.
+
+    Per named field, so a field the payload does not mention contributes to
+    neither side and is genuinely untouched -- not deleted and rewritten
+    identically, which would churn every minted node in the bundle.
+
+    A set-valued field that *is* named is replaced whole: its links go and the
+    payload's take their place. Emptying such a field is therefore a real
+    change, which the shape then judges -- an empty list on a field the shape
+    requires is a rejection, never a silent wipe.
+    """
+    removed, added = Graph(), Graph()
+    for name, value in payload.items():
+        field = bundle_field(name)
+        removed += linked_field_triples(pre_state, uid, field)
+        added += field_triples(uid, field, value, known_labels)
+    return removed, added
+
+
 def bundle_subgraph(graph: Graph, uid: str) -> Graph:
     """``graph`` narrowed to the bundle and one hop out, as a read returns it.
 

--- a/oekg/graph_store.py
+++ b/oekg/graph_store.py
@@ -94,6 +94,10 @@ class UnsafeClearError(GraphStoreError):
     """Refused to empty the default graph."""
 
 
+class NothingToModifyError(GraphStoreError):
+    """A guarded modification was asked for with no triples to change."""
+
+
 @dataclass(frozen=True)
 class GraphStore:
     """A query client and an update client, and no pretence of being a graph.
@@ -167,10 +171,10 @@ class GraphStore:
 
         The operations are the caller's own SPARQL and are sent as written --
         **this method does not scope them to the target graph.** Use
-        ``insert_data`` and ``delete_data`` to build scoped operations; reach
-        for a hand-written one only where no builder exists yet, such as a
-        guarded compare-and-set, and scope it yourself. An unscoped
-        ``INSERT DATA`` writes the default graph whatever this store targets.
+        ``insert_data``, ``delete_data`` and ``guarded_modification`` to build
+        scoped operations; reach for a hand-written one only where no builder
+        exists yet, and scope it yourself. An unscoped ``INSERT DATA`` writes
+        the default graph whatever this store targets.
         """
         if not operations:
             return
@@ -193,6 +197,44 @@ class GraphStore:
     def delete_data(self, triples: Graph) -> str:
         """The DELETE DATA operation for ``triples``, scoped to the target graph."""
         return f"DELETE DATA {{ {self._in_target_graph(triples)} }}"
+
+    def guarded_modification(
+        self,
+        where: str,
+        delete: Optional[Graph] = None,
+        insert: Optional[Graph] = None,
+    ) -> str:
+        """A DELETE/INSERT/WHERE operation, scoped to the target graph.
+
+        ``where`` is the guard, and it is part of the write rather than a check
+        in front of it: SPARQL applies the templates only if the pattern
+        matches, so a compare-and-set cannot be overtaken between the test and
+        the change. The price is that a guard that does not match is
+        indistinguishable from one that does -- the store answers ``200`` and
+        changes nothing either way -- so the caller has to read back for the
+        signal. That is not a shortcoming of this method; it is what SPARQL
+        update offers.
+
+        Scoping is by ``WITH``, which makes the target graph the default for
+        every unqualified pattern in all three clauses at once. Writing
+        ``GRAPH`` blocks instead would put the same decision in three places,
+        and forgetting one of them writes the default graph -- in production,
+        the graph the platform serves.
+        """
+        clauses = []
+        if delete is not None and len(delete):
+            clauses.append(f"DELETE {{ {delete.serialize(format='nt')} }}")
+        if insert is not None and len(insert):
+            clauses.append(f"INSERT {{ {insert.serialize(format='nt')} }}")
+        if not clauses:
+            # A guard with nothing behind it would still be a valid request the
+            # store answers 200 to, which is the one answer a caller must never
+            # read as "the guard held".
+            raise NothingToModifyError(
+                "A guarded modification needs triples to delete or to insert."
+            )
+        prefix = f"WITH <{self.graph}>\n" if self.graph else ""
+        return f"{prefix}{' '.join(clauses)} WHERE {{ {where} }}"
 
     def clear(self) -> None:
         """Remove this store's named graph. Refuses on the default graph.

--- a/oekg/permissions.py
+++ b/oekg/permissions.py
@@ -1,0 +1,32 @@
+"""Who may write a scenario bundle.
+
+One function, asked by every mutating endpoint, because ownership is about to
+be asked in four more places -- sub-resources, the two-step delete, replace --
+and a rule spelled out at each of them would drift at the first change. When
+the group system is connected to bundles, this is the place that learns about
+it.
+
+Two properties are deliberate rather than incidental:
+
+- **Ownership is asked of the access-control model, not compared against a
+  creator.** Multi-owner bundles already exist -- an admin command adds a
+  second owner -- so a single-owner comparison would be wrong today, not just
+  after some future change.
+- **A bundle with no ownership record is administrator-only.** Records of
+  unknown provenance fail closed. That is the platform's existing behaviour for
+  these bundles, kept on purpose rather than inherited by accident.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from factsheet.models import ScenarioBundleAccessControl
+
+
+def may_write_bundle(user, uid: str) -> bool:
+    """Whether ``user`` may change the bundle ``uid``."""
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "is_admin", False):
+        return True
+    return ScenarioBundleAccessControl.user_has_access(user, uid)

--- a/oekg/serializers.py
+++ b/oekg/serializers.py
@@ -99,7 +99,12 @@ class ScenarioBundleSerializer(ClosedSerializer):
     """The closed bundle field set -- these and nothing else."""
 
     label = serializers.CharField()
-    acronym = serializers.CharField()
+    # The trim is stated rather than inherited, because uniqueness depends on
+    # it: the value the uniqueness check compares and the value the write
+    # stores are this one, so normalising here normalises both at once. The
+    # user interface's check normalises one side only, which is exactly why it
+    # misses duplicates.
+    acronym = serializers.CharField(trim_whitespace=True)
     # Nullable for the same reason: an absent abstract reads as null, and the
     # round trip a client (and, later, replace) depends on has to survive it.
     abstract = serializers.CharField(required=False, allow_blank=True, allow_null=True)

--- a/oekg/tests/bundle_fixtures.py
+++ b/oekg/tests/bundle_fixtures.py
@@ -1,0 +1,66 @@
+"""Shared fixtures for the scenario-bundle API tests.
+
+The base class and the one valid payload live here rather than in a test
+module, so the create tests and the patch tests use the same bundle and cannot
+drift into testing two different things. `oekg/tests/__init__.py` holds the
+graph seam; this holds what a bundle looks like.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from django.urls import reverse
+
+from login.models import myuser
+from oekg.bundles import OEO
+from oekg.serializers import READ_ONLY_CONTAINER
+from oekg.tests import OekgGraphAPITestCase
+
+# Real picks from the shape's own sh:in lists -- the four the shape requires.
+VALID_PAYLOAD = {
+    "label": "A scenario bundle written by the API",
+    "acronym": "API-TEST",
+    "abstract": "Created by the test suite.",
+    "descriptors": [str(OEO.OEO_00000143)],
+    "sector_divisions": [str(OEO.OEO_00000368)],
+    "sectors": [str(OEO.OEO_00000367)],
+    "technologies": [str(OEO.OEO_00000407)],
+}
+
+
+class BundleApiTestCase(OekgGraphAPITestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = myuser.objects.create_user(
+            name="bundle-author", email="author@example.org", affiliation=""
+        )
+        self.collection_url = reverse("api:scenario-bundles")
+
+    def create(self, payload=None, authenticate=True):
+        if authenticate:
+            self.client.force_login(self.user)
+        return self.client.post(
+            self.collection_url,
+            data=payload if payload is not None else VALID_PAYLOAD,
+            content_type="application/json",
+        )
+
+    def detail_url(self, uid):
+        return reverse("api:scenario-bundle", kwargs={"uid": uid})
+
+    def created(self, payload=None):
+        """Create a bundle and return its identifier and its entity tag."""
+        response = self.create(payload)
+        self.assertEqual(response.status_code, 201, response.data)
+        return response.data[READ_ONLY_CONTAINER]["uid"], response["ETag"]
+
+    def patch(self, uid, payload, if_match=None, authenticate=True):
+        if authenticate:
+            self.client.force_login(self.user)
+        headers = {} if if_match is None else {"HTTP_IF_MATCH": if_match}
+        return self.client.patch(
+            self.detail_url(uid),
+            data=payload,
+            content_type="application/json",
+            **headers,
+        )

--- a/oekg/tests/bundle_fixtures.py
+++ b/oekg/tests/bundle_fixtures.py
@@ -54,9 +54,9 @@ class BundleApiTestCase(OekgGraphAPITestCase):
         self.assertEqual(response.status_code, 201, response.data)
         return response.data[READ_ONLY_CONTAINER]["uid"], response["ETag"]
 
-    def patch(self, uid, payload, if_match=None, authenticate=True):
+    def patch(self, uid, payload, if_match=None, authenticate=True, as_user=None):
         if authenticate:
-            self.client.force_login(self.user)
+            self.client.force_login(as_user or self.user)
         headers = {} if if_match is None else {"HTTP_IF_MATCH": if_match}
         return self.client.patch(
             self.detail_url(uid),

--- a/oekg/tests/test_bundle_api.py
+++ b/oekg/tests/test_bundle_api.py
@@ -6,12 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
-from django.urls import reverse
 from rdflib import RDF, RDFS, Graph, Literal
 from rdflib.namespace import SH
 
 from factsheet.models import ScenarioBundleAccessControl
-from login.models import myuser
 from oekg.bundles import (
     BUNDLE_CLASS,
     BUNDLE_FIELDS,
@@ -28,39 +26,8 @@ from oekg.bundles import (
 from oekg.graph_store import GraphStore
 from oekg.serializers import READ_ONLY_CONTAINER, ScenarioBundleSerializer
 from oekg.shape import enumeration, shape_graph
-from oekg.tests import OekgGraphAPITestCase, RequiresShapeArtifactsMixin
-
-# Real picks from the shape's own sh:in lists -- the four the shape requires.
-VALID_PAYLOAD = {
-    "label": "A scenario bundle written by the API",
-    "acronym": "API-TEST",
-    "abstract": "Created by the test suite.",
-    "descriptors": [str(OEO.OEO_00000143)],
-    "sector_divisions": [str(OEO.OEO_00000368)],
-    "sectors": [str(OEO.OEO_00000367)],
-    "technologies": [str(OEO.OEO_00000407)],
-}
-
-
-class BundleApiTestCase(OekgGraphAPITestCase):
-    def setUp(self):
-        super().setUp()
-        self.user = myuser.objects.create_user(
-            name="bundle-author", email="author@example.org", affiliation=""
-        )
-        self.collection_url = reverse("api:scenario-bundles")
-
-    def create(self, payload=None, authenticate=True):
-        if authenticate:
-            self.client.force_login(self.user)
-        return self.client.post(
-            self.collection_url,
-            data=payload if payload is not None else VALID_PAYLOAD,
-            content_type="application/json",
-        )
-
-    def detail_url(self, uid):
-        return reverse("api:scenario-bundle", kwargs={"uid": uid})
+from oekg.tests import RequiresShapeArtifactsMixin
+from oekg.tests.bundle_fixtures import VALID_PAYLOAD, BundleApiTestCase
 
 
 class CreateBundleTest(BundleApiTestCase):

--- a/oekg/tests/test_bundle_patch.py
+++ b/oekg/tests/test_bundle_patch.py
@@ -440,14 +440,19 @@ class InterleavedWriteTest(BundleApiTestCase):
 
         return patch.object(GraphStore, "update", update_after_a_competitor)
 
+    def someone_else_patches(self, uid, label="Theirs"):
+        """A competitor that relabels the bundle, using the API's own guard."""
+
+        def competitor(real_update):
+            other = GraphStore.from_settings(graph=self.graph_name)
+            real_update(other, guarded_bump(other, uid, label))
+
+        return competitor
+
     def test_two_writes_against_the_same_version_cannot_both_succeed(self):
         uid, etag = self.created()
 
-        def someone_else_patches(real_update):
-            other = GraphStore.from_settings(graph=self.graph_name)
-            real_update(other, guarded_bump(other, uid, "Theirs"))
-
-        with self.interleave(someone_else_patches):
+        with self.interleave(self.someone_else_patches(uid)):
             response = self.patch(uid, {"label": "Mine"}, if_match=etag)
 
         self.assertEqual(response.status_code, 409, response.data)
@@ -456,11 +461,7 @@ class InterleavedWriteTest(BundleApiTestCase):
     def test_the_losing_write_leaves_the_version_where_the_winner_put_it(self):
         uid, etag = self.created()
 
-        def someone_else_patches(real_update):
-            other = GraphStore.from_settings(graph=self.graph_name)
-            real_update(other, guarded_bump(other, uid, "Theirs"))
-
-        with self.interleave(someone_else_patches):
+        with self.interleave(self.someone_else_patches(uid)):
             self.patch(uid, {"label": "Mine"}, if_match=etag)
 
         self.assertEqual(read_version(self.store, uid).number, 2)
@@ -483,6 +484,33 @@ class InterleavedWriteTest(BundleApiTestCase):
 
         self.assertEqual(response.status_code, 409, response.data)
         self.assertFalse(self.store.ask("ASK { ?s ?p ?o }"))
+
+    def test_a_bundle_deleted_the_way_the_interface_deletes_is_not_resurrected(
+        self,
+    ):
+        # The version node points AT the bundle, so the user interface's delete
+        # -- `oekg.remove((bundle, None, None))`, outgoing triples only --
+        # leaves it behind. On the version alone the guard would match a bundle
+        # that is gone and write its fields back as untyped orphans.
+        uid, etag = self.created()
+
+        def someone_else_deletes_the_bundle(real_update):
+            other = GraphStore.from_settings(graph=self.graph_name)
+            real_update(
+                other,
+                f"WITH <{self.graph_name}> DELETE {{ {bundle_iri(uid).n3()} ?p ?o }} "
+                f"WHERE {{ {bundle_iri(uid).n3()} ?p ?o }}",
+            )
+
+        with self.interleave(someone_else_deletes_the_bundle):
+            response = self.patch(uid, {"label": "Mine"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertFalse(
+            self.store.ask("ASK { %s ?p ?o }" % bundle_iri(uid).n3()),
+            "the guarded write resurrected a bundle that had been deleted",
+        )
+        self.assertEqual(self.client.get(self.detail_url(uid)).status_code, 404)
 
     def test_two_patches_cannot_both_take_the_same_acronym(self):
         # Each satisfies its own version guard, so the version alone does not
@@ -575,13 +603,9 @@ class OwnershipTest(BundleApiTestCase):
 
     def test_a_non_owner_is_refused(self):
         uid, etag = self.created()
-        self.client.force_login(self.other_user())
 
-        response = self.client.patch(
-            self.detail_url(uid),
-            data={"label": "Renamed"},
-            content_type="application/json",
-            HTTP_IF_MATCH=etag,
+        response = self.patch(
+            uid, {"label": "Renamed"}, if_match=etag, as_user=self.other_user()
         )
 
         self.assertEqual(response.status_code, 403, response.data)
@@ -593,14 +617,8 @@ class OwnershipTest(BundleApiTestCase):
         uid, etag = self.created()
         second = self.other_user()
         ScenarioBundleAccessControl.objects.create(owner_user=second, bundle_id=uid)
-        self.client.force_login(second)
 
-        response = self.client.patch(
-            self.detail_url(uid),
-            data={"label": "Renamed"},
-            content_type="application/json",
-            HTTP_IF_MATCH=etag,
-        )
+        response = self.patch(uid, {"label": "Renamed"}, if_match=etag, as_user=second)
 
         self.assertEqual(response.status_code, 200, response.data)
 
@@ -620,14 +638,8 @@ class OwnershipTest(BundleApiTestCase):
         admin = self.other_user(name="an-admin", email="admin@example.org")
         admin.is_admin = True
         admin.save()
-        self.client.force_login(admin)
 
-        response = self.client.patch(
-            self.detail_url(uid),
-            data={"label": "Renamed"},
-            content_type="application/json",
-            HTTP_IF_MATCH=etag,
-        )
+        response = self.patch(uid, {"label": "Renamed"}, if_match=etag, as_user=admin)
 
         self.assertEqual(response.status_code, 200, response.data)
 

--- a/oekg/tests/test_bundle_patch.py
+++ b/oekg/tests/test_bundle_patch.py
@@ -1,0 +1,673 @@
+"""Changing one field of a scenario bundle, guarded by version.
+
+The three refusals are three different statuses on purpose, because they mean
+three different things to the client:
+
+- **428** you did not say which version you were editing;
+- **412** you said a version, and it is not the current one;
+- **409** the server's own guard fired -- the bundle moved between the read the
+  validation needed and the write. Re-read, re-apply, retry.
+
+The 409 window cannot be opened from a test client alone, so the tests that
+exercise it interleave a competing write inside the transport itself. That is
+the only way to reach the race the guard exists for.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from rdflib import RDF
+
+from factsheet.models import ScenarioBundleAccessControl
+from login.models import myuser
+from oekg.bundles import (
+    BUNDLE_CLASS,
+    HAS_PART,
+    OEO,
+    build_bundle_graph,
+    bundle_field,
+    bundle_iri,
+    field_triples,
+    linked_field_triples,
+)
+from oekg.graph_store import GraphStore
+from oekg.serializers import READ_ONLY_CONTAINER
+from oekg.tests.bundle_fixtures import VALID_PAYLOAD, BundleApiTestCase
+from oekg.versioning import (
+    UNVERSIONED,
+    VERSION,
+    VERSION_OF,
+    guarded_operation,
+    mint_write_token,
+    read_version,
+    version_iri,
+    version_triples,
+)
+
+
+class VersionTest(BundleApiTestCase):
+    def test_a_created_bundle_is_at_version_one(self):
+        response = self.create()
+
+        self.assertEqual(response["ETag"], '"1"')
+        self.assertEqual(response.data[READ_ONLY_CONTAINER]["version"], 1)
+
+    def test_a_read_carries_the_version_as_an_entity_tag(self):
+        uid, etag = self.created()
+
+        read = self.client.get(self.detail_url(uid))
+
+        self.assertEqual(read["ETag"], etag)
+        self.assertEqual(read.data[READ_ONLY_CONTAINER]["version"], 1)
+
+    def test_a_patch_advances_the_version(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response["ETag"], '"2"')
+        self.assertEqual(self.client.get(self.detail_url(uid))["ETag"], '"2"')
+
+    def test_the_version_triple_points_at_the_bundle(self):
+        # The bundle shape is sh:closed, so a version hung off the bundle would
+        # make every bundle this API writes invalid. The direction is what makes
+        # the guard expressible without editing the shape.
+        uid, _ = self.created()
+
+        self.assertTrue(
+            self.store.ask(
+                "ASK { %s %s %s }"
+                % (version_iri(uid).n3(), VERSION_OF.n3(), bundle_iri(uid).n3())
+            )
+        )
+
+    def test_the_bundle_carries_no_version_property_of_its_own(self):
+        uid, _ = self.created()
+
+        self.assertFalse(
+            self.store.ask(
+                "ASK { %s ?p ?o . FILTER(?p IN (%s, %s)) }"
+                % (bundle_iri(uid).n3(), VERSION.n3(), VERSION_OF.n3())
+            )
+        )
+
+    def test_a_read_does_not_return_the_version_triples_as_fields(self):
+        # The read walks outward from the bundle and the version node points
+        # inward, so the bookkeeping stays out of the payload for free.
+        uid, _ = self.created()
+
+        read = self.client.get(self.detail_url(uid)).data
+
+        self.assertNotIn(str(VERSION), read)
+        self.assertNotIn("version", set(read) - {READ_ONLY_CONTAINER})
+
+
+class UnversionedBundleTest(BundleApiTestCase):
+    """Bundles written before this API exists carry no version node."""
+
+    def existing_bundle_without_a_version(self):
+        uid = "11111111-2222-3333-4444-555555555555"
+        self.store.insert(build_bundle_graph(uid, VALID_PAYLOAD))
+        ScenarioBundleAccessControl.objects.create(owner_user=self.user, bundle_id=uid)
+        return uid
+
+    def test_it_reads_as_version_zero(self):
+        uid = self.existing_bundle_without_a_version()
+
+        read = self.client.get(self.detail_url(uid))
+
+        self.assertEqual(read["ETag"], '"0"')
+        self.assertEqual(read.data[READ_ONLY_CONTAINER]["version"], UNVERSIONED)
+
+    def test_the_first_write_creates_the_version_node(self):
+        uid = self.existing_bundle_without_a_version()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match='"0"')
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(response["ETag"], '"1"')
+        self.assertEqual(read_version(self.store, uid).number, 1)
+
+    def test_a_stale_precondition_on_an_unversioned_bundle_is_refused(self):
+        uid = self.existing_bundle_without_a_version()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match='"1"')
+
+        self.assertEqual(response.status_code, 412, response.data)
+
+
+class PatchOneFieldTest(BundleApiTestCase):
+    def test_patching_one_field_leaves_the_others_intact(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        read = self.client.get(self.detail_url(uid)).data
+        self.assertEqual(read["label"], "Renamed")
+        self.assertEqual(read["acronym"], VALID_PAYLOAD["acronym"])
+        self.assertEqual(read["abstract"], VALID_PAYLOAD["abstract"])
+        self.assertEqual(read["technologies"], VALID_PAYLOAD["technologies"])
+
+    def test_the_response_is_the_bundle_as_it_now_stands(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        self.assertEqual(response.data["label"], "Renamed")
+        self.assertEqual(response.data, self.client.get(self.detail_url(uid)).data)
+
+    def test_a_set_valued_field_is_replaced_completely(self):
+        uid, etag = self.created()
+        replacement = [str(OEO.OEO_00010423)]
+
+        response = self.patch(uid, {"technologies": replacement}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(
+            self.client.get(self.detail_url(uid)).data["technologies"], replacement
+        )
+
+    def test_an_empty_list_on_a_required_field_is_a_validation_failure(self):
+        # Never a silent wipe: the shape requires at least one technology, so
+        # emptying the set is a rejection rather than an accepted deletion.
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"technologies": []}, if_match=etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(
+            self.client.get(self.detail_url(uid)).data["technologies"],
+            VALID_PAYLOAD["technologies"],
+        )
+
+    def test_an_optional_literal_can_be_cleared(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"abstract": None}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertIsNone(self.client.get(self.detail_url(uid)).data["abstract"])
+
+    def test_an_unknown_key_is_refused(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"labelz": "typo"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn("labelz", response.data)
+
+    def test_a_patch_cannot_reach_into_a_sub_resource(self):
+        # Sub-resources have their own URLs. A bundle patch that could carry
+        # them would be able to drop them by omission, which is exactly the
+        # power this API withholds from every verb but replace.
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"scenarios": []}, if_match=etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn("scenarios", response.data)
+
+    def test_an_empty_patch_is_refused(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {}, if_match=etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_a_patch_that_names_only_the_read_only_container_is_refused(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {READ_ONLY_CONTAINER: {"uid": uid}}, if_match=etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_a_patch_does_not_re_mint_the_parts_it_did_not_name(self):
+        # Rebuilding the whole bundle from a read would mint fresh nodes for
+        # every framework and model, so an unrelated patch would churn every
+        # identifier in the bundle and fill a later history with false deletes.
+        uid, etag = self.created(
+            {**VALID_PAYLOAD, "frameworks": [{"label": "A framework"}]}
+        )
+        before = self.part_nodes(uid)
+
+        self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        self.assertEqual(self.part_nodes(uid), before)
+        self.assertEqual(len(before), 1)
+
+    def test_replacing_a_part_set_unlinks_the_old_node(self):
+        uid, etag = self.created(
+            {**VALID_PAYLOAD, "frameworks": [{"label": "A framework"}]}
+        )
+
+        self.patch(uid, {"frameworks": [{"label": "Another"}]}, if_match=etag)
+
+        read = self.client.get(self.detail_url(uid)).data
+        self.assertEqual([f["label"] for f in read["frameworks"]], ["Another"])
+
+    def test_patching_frameworks_leaves_models_alone(self):
+        # They share the has-part predicate; only their type tells them apart,
+        # so a predicate-scoped delete would take both.
+        uid, etag = self.created(
+            {
+                **VALID_PAYLOAD,
+                "frameworks": [{"label": "A framework"}],
+                "models": [{"label": "A model"}],
+            }
+        )
+
+        self.patch(uid, {"frameworks": [{"label": "Another"}]}, if_match=etag)
+
+        read = self.client.get(self.detail_url(uid)).data
+        self.assertEqual([m["label"] for m in read["models"]], ["A model"])
+        self.assertEqual([f["label"] for f in read["frameworks"]], ["Another"])
+
+    def test_the_patched_bundle_still_round_trips(self):
+        uid, etag = self.created()
+        self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        read = self.client.get(self.detail_url(uid)).data
+        sent_back = self.client.post(
+            self.collection_url,
+            data={**read, "acronym": "API-TEST-COPY"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(sent_back.status_code, 201, sent_back.data)
+
+    def test_renaming_a_shared_node_through_a_patch_is_refused(self):
+        first, etag = self.created({**VALID_PAYLOAD, "contacts": [{"label": "A name"}]})
+        iri = self.client.get(self.detail_url(first)).data["contacts"][0]["iri"]
+
+        response = self.patch(
+            first,
+            {"contacts": [{"iri": iri, "label": "A different name"}]},
+            if_match='"1"',
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data["conflicts"][0]["iri"], iri)
+
+    def test_a_patch_is_one_request_to_the_store(self):
+        uid, etag = self.created()
+        real_update = GraphStore.update
+        updates = []
+
+        def counting_update(store, *operations):
+            updates.append(operations)
+            return real_update(store, *operations)
+
+        with patch.object(GraphStore, "update", counting_update):
+            response = self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(updates), 1, updates)
+
+    def part_nodes(self, uid):
+        return {
+            row["node"]
+            for row in self.store.select(
+                "SELECT ?node WHERE { %s %s ?node }"
+                % (bundle_iri(uid).n3(), HAS_PART.n3())
+            )
+        }
+
+
+class PatchAcronymTest(BundleApiTestCase):
+    """An acronym is how a pipeline finds its bundle again."""
+
+    def test_an_acronym_can_be_changed(self):
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"acronym": "RENAMED"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(
+            self.client.get(self.detail_url(uid)).data["acronym"], "RENAMED"
+        )
+
+    def test_renaming_onto_a_taken_acronym_is_refused(self):
+        # Uniqueness enforced only on create would hold just until somebody
+        # patched, and the acronym lookup re-import depends on would then be
+        # able to return the wrong bundle.
+        uid, etag = self.created()
+        self.create({**VALID_PAYLOAD, "acronym": "TAKEN"})
+
+        response = self.patch(uid, {"acronym": "TAKEN"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(
+            self.client.get(self.detail_url(uid)).data["acronym"],
+            VALID_PAYLOAD["acronym"],
+        )
+
+    def test_sending_the_acronym_back_unchanged_is_accepted(self):
+        # The round trip a client and, later, replace both rely on: a bundle's
+        # own acronym must not read as taken by somebody else.
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"acronym": VALID_PAYLOAD["acronym"]}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_an_acronym_is_checked_and_stored_as_the_same_value(self):
+        uid, etag = self.created()
+        self.create({**VALID_PAYLOAD, "acronym": "TAKEN"})
+
+        response = self.patch(uid, {"acronym": "TAKEN "}, if_match=etag)
+
+        self.assertEqual(response.status_code, 409, response.data)
+
+
+class PreconditionTest(BundleApiTestCase):
+    def test_a_missing_precondition_is_refused(self):
+        uid, _ = self.created()
+
+        response = self.patch(uid, {"label": "Renamed"})
+
+        self.assertEqual(response.status_code, 428, response.data)
+
+    def test_a_stale_precondition_is_refused(self):
+        uid, etag = self.created()
+        self.patch(uid, {"label": "First"}, if_match=etag)
+
+        response = self.patch(uid, {"label": "Second"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 412, response.data)
+        self.assertEqual(self.client.get(self.detail_url(uid)).data["label"], "First")
+
+    def test_a_wildcard_precondition_is_refused(self):
+        # `*` would let a client satisfy the header without saying which
+        # version it read, which is the whole point of requiring it.
+        uid, _ = self.created()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match="*")
+
+        self.assertEqual(response.status_code, 428, response.data)
+
+    def test_a_precondition_that_is_not_a_version_is_refused(self):
+        uid, _ = self.created()
+
+        for value in ['"abc"', "abc", '""', 'W/"nope"']:
+            with self.subTest(if_match=value):
+                response = self.patch(uid, {"label": "Renamed"}, if_match=value)
+                self.assertEqual(response.status_code, 412, response.data)
+
+    def test_an_unquoted_precondition_is_accepted(self):
+        uid, _ = self.created()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match="1")
+
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_a_precondition_may_name_several_versions(self):
+        uid, _ = self.created()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match='"9", "1"')
+
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_a_refused_precondition_writes_nothing(self):
+        uid, etag = self.created()
+        before = self.triples()
+
+        self.patch(uid, {"label": "Renamed"}, if_match='"99"')
+
+        self.assertEqual(self.triples(), before)
+
+    def triples(self):
+        return len(self.store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"))
+
+
+class InterleavedWriteTest(BundleApiTestCase):
+    """The window between the read validation needs and the guarded write."""
+
+    def interleave(self, competitor):
+        """Run ``competitor`` once, just before the view's own update lands."""
+        real_update = GraphStore.update
+        done = []
+
+        def update_after_a_competitor(store, *operations):
+            if not done:
+                done.append(True)
+                competitor(real_update)
+            return real_update(store, *operations)
+
+        return patch.object(GraphStore, "update", update_after_a_competitor)
+
+    def test_two_writes_against_the_same_version_cannot_both_succeed(self):
+        uid, etag = self.created()
+
+        def someone_else_patches(real_update):
+            other = GraphStore.from_settings(graph=self.graph_name)
+            real_update(other, guarded_bump(other, uid, "Theirs"))
+
+        with self.interleave(someone_else_patches):
+            response = self.patch(uid, {"label": "Mine"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(self.client.get(self.detail_url(uid)).data["label"], "Theirs")
+
+    def test_the_losing_write_leaves_the_version_where_the_winner_put_it(self):
+        uid, etag = self.created()
+
+        def someone_else_patches(real_update):
+            other = GraphStore.from_settings(graph=self.graph_name)
+            real_update(other, guarded_bump(other, uid, "Theirs"))
+
+        with self.interleave(someone_else_patches):
+            self.patch(uid, {"label": "Mine"}, if_match=etag)
+
+        self.assertEqual(read_version(self.store, uid).number, 2)
+
+    def test_a_bundle_that_vanished_mid_write_is_not_recreated(self):
+        uid, etag = self.created()
+
+        def someone_else_deletes_everything(real_update):
+            other = GraphStore.from_settings(graph=self.graph_name)
+            # Scoped by hand: `update` sends what it is given, so an
+            # unscoped DELETE here would empty the store's default graph --
+            # in production, the graph the platform serves.
+            real_update(
+                other,
+                f"WITH <{self.graph_name}> DELETE {{ ?s ?p ?o }} " "WHERE { ?s ?p ?o }",
+            )
+
+        with self.interleave(someone_else_deletes_everything):
+            response = self.patch(uid, {"label": "Mine"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertFalse(self.store.ask("ASK { ?s ?p ?o }"))
+
+    def test_two_patches_cannot_both_take_the_same_acronym(self):
+        # Each satisfies its own version guard, so the version alone does not
+        # settle this: the acronym has to be tested in the request that takes
+        # it.
+        uid, etag = self.created()
+        rival, _ = self.created({**VALID_PAYLOAD, "acronym": "RIVAL"})
+
+        def the_rival_renames_itself_first(real_update):
+            other = GraphStore.from_settings(graph=self.graph_name)
+            real_update(other, guarded_rename(other, rival, "WANTED"))
+
+        with self.interleave(the_rival_renames_itself_first):
+            response = self.patch(uid, {"acronym": "WANTED"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(
+            self.client.get(self.detail_url(uid)).data["acronym"],
+            VALID_PAYLOAD["acronym"],
+        )
+
+    def test_two_creates_cannot_both_take_the_same_acronym(self):
+        # Slice 3 checked the acronym and then inserted, which are two
+        # requests: both creates passed the check and both landed. The check is
+        # now bound inside the write.
+        def someone_else_creates_it_first(real_update):
+            other = GraphStore.from_settings(graph=self.graph_name)
+            graph = build_bundle_graph(
+                "aaaaaaaa-0000-0000-0000-000000000000", VALID_PAYLOAD
+            )
+            real_update(other, other.insert_data(graph))
+
+        with self.interleave(someone_else_creates_it_first):
+            response = self.create()
+
+        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(len(self.bundles()), 1, self.bundles())
+
+    def bundles(self):
+        return self.store.select("SELECT ?b WHERE { ?b a %s }" % BUNDLE_CLASS.n3())
+
+
+def guarded_rename(store, uid, acronym):
+    """A competing writer taking an acronym, using the API's own mechanism."""
+    return _guarded_field(store, uid, "acronym", acronym)
+
+
+def guarded_bump(store, uid, label):
+    """A competing writer, using the API's own compare-and-set."""
+    return _guarded_field(store, uid, "label", label)
+
+
+def _guarded_field(store, uid, name, value):
+    field = bundle_field(name)
+    return guarded_operation(
+        store,
+        uid,
+        read_version(store, uid),
+        mint_write_token(),
+        delete=linked_field_triples(
+            store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"),
+            uid,
+            field,
+        ),
+        insert=field_triples(uid, field, value),
+    )
+
+
+class OwnershipTest(BundleApiTestCase):
+    def other_user(self, **kwargs):
+        return myuser.objects.create_user(
+            name=kwargs.pop("name", "someone-else"),
+            email=kwargs.pop("email", "else@example.org"),
+            affiliation="",
+            **kwargs,
+        )
+
+    def test_an_unauthenticated_patch_is_refused(self):
+        uid, etag = self.created()
+        self.client.logout()
+
+        response = self.patch(
+            uid, {"label": "Renamed"}, if_match=etag, authenticate=False
+        )
+
+        self.assertIn(response.status_code, (401, 403))
+        self.assertEqual(
+            self.client.get(self.detail_url(uid)).data["label"], VALID_PAYLOAD["label"]
+        )
+
+    def test_a_non_owner_is_refused(self):
+        uid, etag = self.created()
+        self.client.force_login(self.other_user())
+
+        response = self.client.patch(
+            self.detail_url(uid),
+            data={"label": "Renamed"},
+            content_type="application/json",
+            HTTP_IF_MATCH=etag,
+        )
+
+        self.assertEqual(response.status_code, 403, response.data)
+
+    def test_a_second_owner_may_write(self):
+        # Multi-owner bundles are reachable today through the admin command, so
+        # ownership is asked of the access-control model rather than compared
+        # against a single creator.
+        uid, etag = self.created()
+        second = self.other_user()
+        ScenarioBundleAccessControl.objects.create(owner_user=second, bundle_id=uid)
+        self.client.force_login(second)
+
+        response = self.client.patch(
+            self.detail_url(uid),
+            data={"label": "Renamed"},
+            content_type="application/json",
+            HTTP_IF_MATCH=etag,
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_an_ownerless_bundle_is_refused_to_a_normal_user(self):
+        uid, etag = self.created()
+        ScenarioBundleAccessControl.objects.filter(bundle_id=uid).delete()
+
+        response = self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 403, response.data)
+
+    def test_an_ownerless_bundle_is_writable_by_an_administrator(self):
+        # Documented as intended: records of unknown provenance fail closed for
+        # everyone but an administrator.
+        uid, etag = self.created()
+        ScenarioBundleAccessControl.objects.filter(bundle_id=uid).delete()
+        admin = self.other_user(name="an-admin", email="admin@example.org")
+        admin.is_admin = True
+        admin.save()
+        self.client.force_login(admin)
+
+        response = self.client.patch(
+            self.detail_url(uid),
+            data={"label": "Renamed"},
+            content_type="application/json",
+            HTTP_IF_MATCH=etag,
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+
+    def test_a_patch_on_an_unknown_bundle_is_a_404(self):
+        response = self.patch(
+            "11111111-2222-3333-4444-555555555555",
+            {"label": "Renamed"},
+            if_match='"1"',
+        )
+
+        self.assertEqual(response.status_code, 404, response.data)
+
+    def test_a_patch_on_an_identifier_that_is_not_minted_is_a_404(self):
+        response = self.patch("not-a-uuid", {"label": "Renamed"}, if_match='"1"')
+
+        self.assertEqual(response.status_code, 404, response.data)
+
+
+class VersioningUnitTest(SimpleTestCase):
+    """The version node, without a store."""
+
+    def test_the_version_node_is_derived_from_the_bundle(self):
+        # Derived rather than looked up, so the compare-and-set can address it
+        # in the same request that reads it.
+        self.assertEqual(version_iri("u1"), version_iri("u1"))
+        self.assertNotEqual(version_iri("u1"), version_iri("u2"))
+
+    def test_the_version_triples_point_at_the_bundle(self):
+        triples = version_triples("u1", 3)
+
+        self.assertIn((version_iri("u1"), VERSION_OF, bundle_iri("u1")), triples)
+        self.assertIsNone(triples.value(bundle_iri("u1"), VERSION))
+
+    def test_the_version_is_an_integer_literal(self):
+        value = version_triples("u1", 3).value(version_iri("u1"), VERSION)
+
+        self.assertEqual(int(value), 3)
+
+    def test_the_version_node_is_untyped(self):
+        # Nothing in the shape targets it, and nothing should start to.
+        triples = version_triples("u1", 3)
+
+        self.assertIsNone(triples.value(version_iri("u1"), RDF.type))

--- a/oekg/tests/test_bundle_patch.py
+++ b/oekg/tests/test_bundle_patch.py
@@ -19,12 +19,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
-from rdflib import RDF
+from rdflib import RDF, Literal
 
 from factsheet.models import ScenarioBundleAccessControl
 from login.models import myuser
 from oekg.bundles import (
     BUNDLE_CLASS,
+    DC,
     HAS_PART,
     OEO,
     build_bundle_graph,
@@ -319,7 +320,17 @@ class PatchOneFieldTest(BundleApiTestCase):
 
 
 class PatchAcronymTest(BundleApiTestCase):
-    """An acronym is how a pipeline finds its bundle again."""
+    """What a patch does to an acronym -- including what it does NOT do.
+
+    Uniqueness is enforced on a create and not thereafter, deliberately: the
+    read side is where the acronym becomes load-bearing, because that is where
+    a pipeline looks a bundle up by it, so the check belongs with the endpoint
+    that makes the promise rather than being scattered across every write.
+
+    The gap is pinned down here rather than left to be discovered. When the
+    read side closes it, `test_renaming_onto_a_taken_acronym_is_currently_allowed`
+    is the test that has to be turned around, and it says so.
+    """
 
     def test_an_acronym_can_be_changed(self):
         uid, etag = self.created()
@@ -331,19 +342,21 @@ class PatchAcronymTest(BundleApiTestCase):
             self.client.get(self.detail_url(uid)).data["acronym"], "RENAMED"
         )
 
-    def test_renaming_onto_a_taken_acronym_is_refused(self):
-        # Uniqueness enforced only on create would hold just until somebody
-        # patched, and the acronym lookup re-import depends on would then be
-        # able to return the wrong bundle.
+    def test_renaming_onto_a_taken_acronym_is_currently_allowed(self):
+        # CHARACTERISATION, not an endorsement: two bundles can end up sharing
+        # an acronym, and a lookup by acronym then has two answers. Deferred to
+        # the read-side slice, which is the one that promises the lookup.
+        # Turning this around is what closing the gap looks like.
         uid, etag = self.created()
         self.create({**VALID_PAYLOAD, "acronym": "TAKEN"})
 
         response = self.patch(uid, {"acronym": "TAKEN"}, if_match=etag)
 
-        self.assertEqual(response.status_code, 409, response.data)
+        self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(
-            self.client.get(self.detail_url(uid)).data["acronym"],
-            VALID_PAYLOAD["acronym"],
+            len(self.bundles_with_acronym("TAKEN")),
+            2,
+            "the acronym is now ambiguous -- this is the deferred gap",
         )
 
     def test_sending_the_acronym_back_unchanged_is_accepted(self):
@@ -355,13 +368,20 @@ class PatchAcronymTest(BundleApiTestCase):
 
         self.assertEqual(response.status_code, 200, response.data)
 
-    def test_an_acronym_is_checked_and_stored_as_the_same_value(self):
-        uid, etag = self.created()
-        self.create({**VALID_PAYLOAD, "acronym": "TAKEN"})
+    def test_a_create_still_refuses_a_duplicate_acronym(self):
+        # The create-side guarantee is untouched by the patch-side gap, and it
+        # is bound inside the write rather than checked in front of it.
+        self.created()
 
-        response = self.patch(uid, {"acronym": "TAKEN "}, if_match=etag)
+        response = self.create({**VALID_PAYLOAD, "acronym": VALID_PAYLOAD["acronym"]})
 
         self.assertEqual(response.status_code, 409, response.data)
+
+    def bundles_with_acronym(self, acronym):
+        return self.store.select(
+            "SELECT ?bundle WHERE { ?bundle a %s ; %s %s }"
+            % (BUNDLE_CLASS.n3(), DC.acronym.n3(), Literal(acronym).n3())
+        )
 
 
 class PreconditionTest(BundleApiTestCase):
@@ -512,26 +532,6 @@ class InterleavedWriteTest(BundleApiTestCase):
         )
         self.assertEqual(self.client.get(self.detail_url(uid)).status_code, 404)
 
-    def test_two_patches_cannot_both_take_the_same_acronym(self):
-        # Each satisfies its own version guard, so the version alone does not
-        # settle this: the acronym has to be tested in the request that takes
-        # it.
-        uid, etag = self.created()
-        rival, _ = self.created({**VALID_PAYLOAD, "acronym": "RIVAL"})
-
-        def the_rival_renames_itself_first(real_update):
-            other = GraphStore.from_settings(graph=self.graph_name)
-            real_update(other, guarded_rename(other, rival, "WANTED"))
-
-        with self.interleave(the_rival_renames_itself_first):
-            response = self.patch(uid, {"acronym": "WANTED"}, if_match=etag)
-
-        self.assertEqual(response.status_code, 409, response.data)
-        self.assertEqual(
-            self.client.get(self.detail_url(uid)).data["acronym"],
-            VALID_PAYLOAD["acronym"],
-        )
-
     def test_two_creates_cannot_both_take_the_same_acronym(self):
         # Slice 3 checked the acronym and then inserted, which are two
         # requests: both creates passed the check and both landed. The check is
@@ -551,11 +551,6 @@ class InterleavedWriteTest(BundleApiTestCase):
 
     def bundles(self):
         return self.store.select("SELECT ?b WHERE { ?b a %s }" % BUNDLE_CLASS.n3())
-
-
-def guarded_rename(store, uid, acronym):
-    """A competing writer taking an acronym, using the API's own mechanism."""
-    return _guarded_field(store, uid, "acronym", acronym)
 
 
 def guarded_bump(store, uid, label):

--- a/oekg/tests/test_graph_store.py
+++ b/oekg/tests/test_graph_store.py
@@ -16,6 +16,7 @@ from oekg.graph_store import (
     GraphStore,
     GraphStoreUnavailable,
     GraphUpdateRejected,
+    NothingToModifyError,
     UnsafeClearError,
 )
 from oekg.tests import OekgGraphTestCase
@@ -269,3 +270,77 @@ class OneRequestIsOneTransactionTest(OekgGraphTestCase):
 
         for subject in subjects:
             self.assertTrue(self.wrote(subject))
+
+
+class GuardedModificationTest(OekgGraphTestCase):
+    """A compare-and-set: the guard is inside the write, not in front of it."""
+
+    def label_of(self, subject):
+        rows = self.store.select(
+            "SELECT ?label WHERE { <%s> <%s> ?label }" % (subject, RDFS.label)
+        )
+        return [row["label"] for row in rows]
+
+    def test_it_applies_when_the_guard_matches(self):
+        subject = EX + str(uuid.uuid4())
+        self.store.insert(labelled(subject, "before"))
+
+        self.store.update(
+            self.store.guarded_modification(
+                "<%s> <%s> %s" % (subject, RDFS.label, Literal("before").n3()),
+                delete=labelled(subject, "before"),
+                insert=labelled(subject, "after"),
+            )
+        )
+
+        self.assertEqual(self.label_of(subject), ["after"])
+
+    def test_it_applies_nothing_when_the_guard_does_not_match(self):
+        subject = EX + str(uuid.uuid4())
+        self.store.insert(labelled(subject, "before"))
+
+        self.store.update(
+            self.store.guarded_modification(
+                "<%s> <%s> %s" % (subject, RDFS.label, Literal("stale").n3()),
+                delete=labelled(subject, "before"),
+                insert=labelled(subject, "after"),
+            )
+        )
+
+        self.assertEqual(self.label_of(subject), ["before"])
+
+    def test_a_guard_that_does_not_match_is_still_a_success(self):
+        # The reason every caller has to read back: the store cannot tell us
+        # whether the guard held, and it does not consider the difference an
+        # error.
+        subject = EX + str(uuid.uuid4())
+
+        self.store.update(
+            self.store.guarded_modification(
+                "<%s> <%s> %s" % (subject, RDFS.label, Literal("absent").n3()),
+                insert=labelled(subject, "should not land"),
+            )
+        )
+
+        self.assertEqual(self.label_of(subject), [])
+
+    def test_it_writes_only_this_store_s_graph(self):
+        # Scoped by WITH. Unscoped, the same operation would write the default
+        # graph -- in production, the graph the platform serves.
+        subject = EX + str(uuid.uuid4())
+
+        self.store.update(
+            self.store.guarded_modification(
+                "FILTER(true)", insert=labelled(subject, "isolated")
+            )
+        )
+
+        default_graph = GraphStore.from_settings(graph=None)
+        self.assertFalse(default_graph.ask("ASK { <%s> ?p ?o }" % subject))
+        self.assertEqual(self.label_of(subject), ["isolated"])
+
+    def test_a_modification_with_nothing_to_change_is_refused(self):
+        # Such a request is valid SPARQL the store answers 200 to, which is the
+        # one answer a guarded write must never produce without having written.
+        with self.assertRaises(NothingToModifyError):
+            self.store.guarded_modification("FILTER(true)")

--- a/oekg/versioning.py
+++ b/oekg/versioning.py
@@ -114,7 +114,6 @@ def guarded_operation(
     token: str,
     delete: Optional[Graph] = None,
     insert: Optional[Graph] = None,
-    also_require: Optional[str] = None,
 ) -> str:
     """One update operation that applies ``delete``/``insert`` at ``version``.
 
@@ -122,10 +121,11 @@ def guarded_operation(
     cannot come apart: one request is one transaction, and the guard is the
     request's own ``WHERE``.
 
-    ``also_require`` is a further pattern the write must satisfy, for a
-    condition the version cannot express. Uniqueness is one: two bundles being
-    patched at the same moment each satisfy their own version guard, so an
-    acronym they both claim has to be tested in the same request that takes it.
+    The guard is the version and the bundle's existence, and nothing else. A
+    condition the version cannot express -- uniqueness, say, where two bundles
+    each satisfy their own version guard while claiming the same value -- needs
+    to be bound into this ``WHERE`` too, by the caller that has one. None does
+    yet; ``GraphStore.guarded_modification`` takes the pattern directly.
     """
     node = version_iri(uid)
     bundle = bundle_iri(uid)
@@ -166,9 +166,6 @@ def guarded_operation(
             # triple per write and make the next read-back ambiguous the other
             # way round.
             to_delete.add((node, WRITE_TOKEN, Literal(version.token)))
-
-    if also_require:
-        where = f"{where} {also_require}"
 
     to_insert += version_triples(uid, version.number + 1, token)
     return store.guarded_modification(where, delete=to_delete, insert=to_insert)

--- a/oekg/versioning.py
+++ b/oekg/versioning.py
@@ -145,7 +145,15 @@ def guarded_operation(
             bundle.n3(),
         )
     else:
-        where = "%s %s %s ; %s %s ." % (
+        # The bundle's own existence is asserted alongside the version, and it
+        # is not redundant: the version node points AT the bundle, so a delete
+        # that removes the bundle's outgoing triples -- which is exactly what
+        # the user interface's delete does -- leaves the version node behind.
+        # On the version alone the guard would then match a bundle that is
+        # gone, and the write would resurrect it as untyped orphan triples.
+        where = "%s a %s . %s %s %s ; %s %s ." % (
+            bundle.n3(),
+            BUNDLE_CLASS.n3(),
             node.n3(),
             VERSION_OF.n3(),
             bundle.n3(),
@@ -166,7 +174,7 @@ def guarded_operation(
     return store.guarded_modification(where, delete=to_delete, insert=to_insert)
 
 
-def stamped(store: GraphStore, uid: str, token: str) -> bool:
+def write_applied(store: GraphStore, uid: str, token: str) -> bool:
     """Whether the write that stamped ``token`` is the one that applied.
 
     The signal the guarded update cannot give. ``False`` means the bundle moved

--- a/oekg/versioning.py
+++ b/oekg/versioning.py
@@ -1,0 +1,186 @@
+"""A bundle's version: what it is, where it lives, and how a write guards on it.
+
+Two writers on the same field is the failure no amount of shape validation
+catches -- a perfectly valid change silently destroying one made a second
+earlier -- and a programmatic API makes it likelier than the user interface
+does, because scripts retry, run in parallel and do not look at the screen
+first.
+
+The version is a **monotonic counter**, not an opaque token, because two other
+parts of this API need it to be one: the two-step delete uses it as its
+confirmation, and the history uses it as the natural key of "which change
+produced this state".
+
+**The triple points at the bundle, not away from it.** The bundle's shape is
+``sh:closed`` with only ``rdf:type`` ignored, so ``<bundle> oekg:version 17``
+would make every bundle this API writes invalid. ``sh:closed`` constrains a
+focus node's *outgoing* properties, so the bundle as an *object* is untouched,
+and nothing in the shape targets the version node: it is untyped, and
+``oekg:versionOf`` is not one of the predicates whose objects the shape
+validates. The guard therefore works without editing the shape -- and the
+version triples stay out of a read for free, because a read walks outward from
+the bundle and these point inward.
+
+The version node's IRI is **derived** from the bundle's, so a compare-and-set
+can address it in the same request that tests it, with no lookup first.
+
+**Why a write token.** SPARQL's ``DELETE/INSERT/WHERE`` guard applies only when
+its pattern matches, but the store answers ``200`` and changes nothing when it
+does not, so the write itself carries no signal. Reading the version back is
+not enough either: two writers guarding on version 17 both intend 18, so
+finding 18 afterwards does not tell a loser from a winner. Each write therefore
+stamps a token only its own writer could have chosen, and reads that back. It
+costs no extra round trip -- the token comes back with the version the write
+already has to read -- and it is the difference between reporting a conflict
+and reporting a success that did not happen.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+
+from rdflib import Graph, Literal, URIRef
+
+from oekg.bundles import BUNDLE_CLASS, OEKG, bundle_iri
+from oekg.graph_store import GraphStore
+
+VERSION = OEKG.version
+VERSION_OF = OEKG.versionOf
+WRITE_TOKEN = OEKG.writeToken
+
+# What a bundle written before this API existed reports. The first write
+# through the API creates the node and takes it to FIRST_VERSION.
+UNVERSIONED = 0
+FIRST_VERSION = UNVERSIONED + 1
+
+
+@dataclass(frozen=True)
+class BundleVersion:
+    """The version a read saw, and the token the write before it left behind.
+
+    Both come from one query, because a write needs both: the number to guard
+    on, and the token to clear so the next read-back stays unambiguous.
+    """
+
+    number: int
+    token: Optional[str] = None
+
+    @property
+    def etag(self) -> str:
+        return f'"{self.number}"'
+
+
+def version_iri(uid: str) -> URIRef:
+    """The version node for a bundle -- derived, never looked up."""
+    return OEKG[f"version/{uid}"]
+
+
+def version_triples(uid: str, number: int, token: Optional[str] = None) -> Graph:
+    """The version node as triples, at ``number``."""
+    triples = Graph()
+    node = version_iri(uid)
+    triples.add((node, VERSION_OF, bundle_iri(uid)))
+    triples.add((node, VERSION, Literal(int(number))))
+    if token is not None:
+        triples.add((node, WRITE_TOKEN, Literal(token)))
+    return triples
+
+
+def read_version(store: GraphStore, uid: str) -> BundleVersion:
+    """The version a bundle is at. ``UNVERSIONED`` if it has no version node."""
+    node = version_iri(uid)
+    rows = store.select(
+        "SELECT ?number ?token WHERE { %s %s ?number "
+        "OPTIONAL { %s %s ?token } }"
+        % (node.n3(), VERSION.n3(), node.n3(), WRITE_TOKEN.n3())
+    )
+    if not rows:
+        return BundleVersion(UNVERSIONED)
+    return BundleVersion(int(rows[0]["number"]), rows[0].get("token"))
+
+
+def mint_write_token() -> str:
+    """A value no competing writer would choose, so a read-back can tell."""
+    return str(uuid.uuid4())
+
+
+def guarded_operation(
+    store: GraphStore,
+    uid: str,
+    version: BundleVersion,
+    token: str,
+    delete: Optional[Graph] = None,
+    insert: Optional[Graph] = None,
+    also_require: Optional[str] = None,
+) -> str:
+    """One update operation that applies ``delete``/``insert`` at ``version``.
+
+    The version bump rides in the same operation as the change, so the two
+    cannot come apart: one request is one transaction, and the guard is the
+    request's own ``WHERE``.
+
+    ``also_require`` is a further pattern the write must satisfy, for a
+    condition the version cannot express. Uniqueness is one: two bundles being
+    patched at the same moment each satisfy their own version guard, so an
+    acronym they both claim has to be tested in the same request that takes it.
+    """
+    node = version_iri(uid)
+    bundle = bundle_iri(uid)
+    # Copies: the version bookkeeping is added here, and a caller's own delta
+    # graph should not come back carrying it.
+    to_delete = _copy(delete)
+    to_insert = _copy(insert)
+
+    if version.number == UNVERSIONED:
+        # Bootstrapping a bundle the user interface wrote. The guard is the
+        # absence of a version node, so two first writes cannot both see it
+        # missing and both apply.
+        where = "%s a %s . FILTER NOT EXISTS { ?node %s %s }" % (
+            bundle.n3(),
+            BUNDLE_CLASS.n3(),
+            VERSION_OF.n3(),
+            bundle.n3(),
+        )
+    else:
+        where = "%s %s %s ; %s %s ." % (
+            node.n3(),
+            VERSION_OF.n3(),
+            bundle.n3(),
+            VERSION.n3(),
+            Literal(version.number).n3(),
+        )
+        to_delete.add((node, VERSION, Literal(version.number)))
+        if version.token is not None:
+            # Left behind, the previous writer's token would accumulate one
+            # triple per write and make the next read-back ambiguous the other
+            # way round.
+            to_delete.add((node, WRITE_TOKEN, Literal(version.token)))
+
+    if also_require:
+        where = f"{where} {also_require}"
+
+    to_insert += version_triples(uid, version.number + 1, token)
+    return store.guarded_modification(where, delete=to_delete, insert=to_insert)
+
+
+def stamped(store: GraphStore, uid: str, token: str) -> bool:
+    """Whether the write that stamped ``token`` is the one that applied.
+
+    The signal the guarded update cannot give. ``False`` means the bundle moved
+    between the read the validation needed and the write -- or vanished
+    entirely -- so nothing of this request was applied.
+    """
+    return store.ask(
+        "ASK { %s %s %s }"
+        % (version_iri(uid).n3(), WRITE_TOKEN.n3(), Literal(token).n3())
+    )
+
+
+def _copy(triples: Optional[Graph]) -> Graph:
+    copied = Graph()
+    if triples is not None:
+        copied += triples
+    return copied

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -86,6 +86,22 @@ SPDX-License-Identifier: CC0-1.0
   write is one atomic request. Reads are public; writes need authentication
   [(#2435)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2435)
 
+- `PATCH /api/v0/scenario-bundles/<uid>/` changes single fields of a scenario
+  bundle without sending the rest. A field the payload does not name is left
+  alone; a set-valued field it does name is replaced whole, and emptying one the
+  shape requires is refused rather than silently applied. Only an owner may
+  write - a bundle with no recorded owner stays administrator-only. Every bundle
+  now carries a version, returned as an `ETag` on reads, and a write must send
+  it back as `If-Match`: without it the request is refused (`428`), with a
+  version that is no longer current it is refused (`412`), and if the bundle
+  moves while the request is being prepared nothing is written and the answer is
+  `409`. The version check is part of the write itself, so two clients cannot
+  both succeed against the same version
+
+- Creating a bundle now binds the acronym uniqueness check inside the write, so
+  two simultaneous creates can no longer both take an acronym both of them found
+  free
+
 - New management command `repair_factsheet_tags` repairs the factsheets the old
   tag editor damaged - on production 23 of 339 carry a copy of the whole tag
   table, holding 95% of all factsheet tag assignments. It reports by default and

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -81,9 +81,10 @@ SPDX-License-Identifier: CC0-1.0
 
 - The OEKG scenario-bundle REST API: `POST /api/v0/scenario-bundles/` creates a
   bundle and `GET /api/v0/scenario-bundles/<uid>/` reads it back. The server
-  mints the identifier, the acronym is enforced unique, the bundle is validated
-  against the canonical SHACL shape **before** anything is written, and the
-  write is one atomic request. Reads are public; writes need authentication
+  mints the identifier, the acronym is enforced unique on creation, the bundle
+  is validated against the canonical SHACL shape **before** anything is written,
+  and the write is one atomic request. Reads are public; writes need
+  authentication
   [(#2435)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2435)
 
 - `PATCH /api/v0/scenario-bundles/<uid>/` changes single fields of a scenario
@@ -96,7 +97,9 @@ SPDX-License-Identifier: CC0-1.0
   version that is no longer current it is refused (`412`), and if the bundle
   moves while the request is being prepared nothing is written and the answer is
   `409`. The version check is part of the write itself, so two clients cannot
-  both succeed against the same version
+  both succeed against the same version. Note that acronym uniqueness is
+  enforced when a bundle is created but not when one is renamed, so a patch can
+  still give two bundles the same acronym
   [(#2438)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2438)
 
 - Creating a bundle now binds the acronym uniqueness check inside the write, so

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -97,10 +97,11 @@ SPDX-License-Identifier: CC0-1.0
   moves while the request is being prepared nothing is written and the answer is
   `409`. The version check is part of the write itself, so two clients cannot
   both succeed against the same version
+  [(#2438)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2438)
 
 - Creating a bundle now binds the acronym uniqueness check inside the write, so
   two simultaneous creates can no longer both take an acronym both of them found
-  free
+  free [(#2438)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2438)
 
 - New management command `repair_factsheet_tags` repairs the factsheets the old
   tag editor damaged - on production 23 of 339 carry a copy of the whole tag


### PR DESCRIPTION
## Summary of the discussion

Fourth of the twelve slices of the OEKG REST API, from the wayfinder map's spec and
tickets notes (`Spec`/`Tickets - OEKG REST API from the shape`, derived from
WF-01..WF-12). It implements the ticket **"Change one field, guarded by version"** and
closes the limit the create slice (#2434 / #2435) named for itself.

**The problem.** `POST` and `GET` shipped in #2435, so a bundle could be created and
read but not edited, and the only way to change one field was to create a new bundle.
Worse, editing at all opens a failure that no amount of shape validation catches: two
writers, last one wins, silently. A perfectly valid `PATCH` can destroy a change
somebody made a second earlier and both requests succeed. That gets materially more
likely with a programmatic API than with the browser UI, because scripts retry, run in
parallel and do not look at the screen first — and multi-owner bundles are reachable
today through `factsheet/management/commands/add_bundle_access.py`, so this is not
hypothetical-until-groups-land.

**What was decided (WF-09).** Defend the *silent* races; document the visible one. The
resource model already removes most conflicts — a `PATCH` touches only the predicates it
names, so two writers on different fields never collide, and field-level merge is the
semantics rather than an option. What is defended is the read-modify-write window that
shape validation itself opens (validation needs the *post-state* of a whole bundle, so a
patch has to read before it writes) and the patch whose target vanished in that window.

**The mechanism.** A monotonic version, carried as a triple pointing **at** the bundle
from a version node, bound in the update's own `WHERE`. Three points are worth stating
because each was forced rather than chosen:

- **The triple points inward.** The bundle shape is `sh:closed` with only `rdf:type`
  ignored, so `<bundle> oekg:version 3` would invalidate every bundle this API writes.
  `sh:closed` constrains a focus node's *outgoing* properties, so the bundle as an
  *object* is untouched, and nothing in the shape targets the version node. Two things
  then fall out for free: the shape needs no edit, and the version stays out of the read
  payload without any filtering, because a read walks outward from the bundle.
- **The guard is inside the write, not in front of it.** One SPARQL request is one
  transaction (the measured claim from WF-04, now re-proved in this repo's own suite), so
  a `DELETE/INSERT/WHERE` binding the expected version cannot be overtaken between the
  test and the change.
- **That guard produces no signal of its own.** The store answers `200` and changes
  nothing whether or not the pattern matched, so a read-back is required. WF-09 specified
  reading the version back; on contact with the code that turned out to be insufficient —
  two writers guarding on version 3 both intend 4, so finding 4 afterwards does not
  distinguish the loser from the winner, and the loser would be told `200`. Each write
  therefore also stamps an `oekg:writeToken` on the version node and reads *that* back.
  It costs no extra round trip, since the token comes back with the version the write
  already has to read.

**One deliberate divergence from WF-09, flagged for the record.** WF-09's resolution
left `If-Match` *optional* — server-side guard always on, client precondition opt-in,
same-field overwrite last-write-wins — and explicitly offered the alternative: *"If you
would rather require `If-Match` on every mutating call, that is a one-line change here
— it makes clients strictly safer and strictly more annoying, and it is your call rather
than mine."* The tickets note takes that offer ("Mutating calls require the
precondition. Missing precondition and stale precondition are **different statuses**, and
the server's own guard failing is a **third**"), so this PR requires it and answers three
codes:

| Situation | Code |
|---|---|
| no `If-Match` — the client did not say which version it was editing | `428` |
| an `If-Match` naming a version that is not the current one | `412` |
| the server's own guard fired: the bundle moved between the read and the write | `409`, retryable |

`If-Match: *` is refused as absent. It is a legal header value and it satisfies the
letter of the precondition while withholding the one thing the precondition is for. This
is a documented, deliberate deviation from RFC 9110.

**Consequence for the spec note, which needs a text edit rather than a code change:**
requiring the header retires the spec's line *"Same-field overwrite stays
last-write-wins, **written down** rather than silently true"* — a stale same-field writer
now gets `412` — and the spec's endpoint table names no `428`.

**Also fixed here: the create-side race the previous slice named.** #2435 checked the
acronym and then inserted, which is two requests, so two concurrent creates could both
pass the check and both land. The check is now bound inside the create's own write.

**A rename is deliberately NOT checked for acronym uniqueness.** The check was built here
and then removed again on review: it belongs to the endpoint that makes the promise —
**the read side**, where the `?acronym=` lookup lives and where a pipeline re-identifies
its bundle — rather than scattered across every write, and that slice has to close it for
`PATCH` and `replace` at once. So **uniqueness holds from creation and not thereafter**: a
`PATCH` can currently give two bundles the same acronym, and a lookup by acronym then has
two answers. The gap is pinned down rather than left to be discovered —
`PatchAcronymTest.test_renaming_onto_a_taken_acronym_is_currently_allowed` asserts the
`200` and the resulting ambiguity as characterisation, and says in its own comment that
turning it around is what closing the gap looks like — and the changelog says it too,
because a client would otherwise reasonably assume uniqueness.

**Found by the review pass, and it was live.** The versioned guard originally bound only
the version node. Because that node points *at* the bundle, the UI's delete
(`factsheet/views.py:1394`, `oekg.remove((bundle, None, None))` — outgoing triples only)
leaves it behind, so the guard matched a bundle that was already gone: the patch wrote
its fields back as untyped orphan triples, bumped the version and answered `200`. The
guard now asserts the bundle's own type beside the version. The first test for that
requirement wiped the whole graph and so passed over the hole; the replacement deletes
the way the interface deletes, and was watched failing against the reverted fix before
being kept. See #2439 for the residue this leaves in the UI's delete path.

**What is deliberately not here.** No history: that is the next slice, and it lands
directly after this one so that the later slices are not retrofitted with entries. Two
seams are left ready for it — `bundle_delta()` already returns the removed and added
triples a lossless diff needs, and `BundleVersion` gives it the version-before /
version-after pair, both without an extra read.

## Type of change (CHANGELOG.md)

### Features

- `PATCH /api/v0/scenario-bundles/<uid>/` changes single fields of a scenario
  bundle without sending the rest. A field the payload does not name is left
  alone; a set-valued field it does name is replaced whole, and emptying one the
  shape requires is refused rather than silently applied. Only an owner may
  write - a bundle with no recorded owner stays administrator-only. Every bundle
  now carries a version, returned as an `ETag` on reads, and a write must send
  it back as `If-Match`: without it the request is refused (`428`), with a
  version that is no longer current it is refused (`412`), and if the bundle
  moves while the request is being prepared nothing is written and the answer is
  `409`. The version check is part of the write itself, so two clients cannot
  both succeed against the same version
  [(#2438)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2438)

- Creating a bundle now binds the acronym uniqueness check inside the write, so
  two simultaneous creates can no longer both take an acronym both of them found
  free [(#2438)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2438)

### Changes

None beyond the entries above. `GET` gaining an `ETag` and `_meta.version` is part of
the same unreleased endpoint (#2435), so it is described in the feature entry rather
than as a change to shipped behaviour.

### Bugs

None as a separate entry. Both races closed here are in code that has not been
released — the create-side one is #2435's, still unreleased, and the version-guard hole
was introduced and fixed inside this PR. Recording them under Bugs would tell a reader
of the release notes that something they were running was broken, which is not true.

### Removed

None.

### Documentation updates

None. The API's own documentation is a separate, currently blocked strand of the map:
WF-13 (where the API description comes from) gates WF-14 (developer documentation), and
`drf-spectacular` is already wired on an unmerged branch
(`origin/feature-1971-api-documentation`) which that ticket has to reconcile with. The
existing `docs/oeplatform-code/web-api/oekg-api/oekg.yaml` describes the SPARQL
passthrough, not the bundle CRUD, so extending it here would deepen the thing WF-13 has
to undo. The reasoning is carried in the module docstrings meanwhile —
`oekg/versioning.py` states why the version triple points inward and why the read-back
needs a token.

## Workflow checklist

### Automation

Closes #2439

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/) — deliberately not
      done, see *Documentation updates* above

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done

---

## Reviewer's guide to the diff

Three commits, in the order they happened: the slice, then the review's yield, then the
changelog link.

| File | What to look at |
|---|---|
| `oekg/versioning.py` (new, 186 lines) | The whole mechanism. The module docstring carries the reasoning; `guarded_operation` is the compare-and-set and `write_applied` is the read-back. Note the two branches: an existing bundle guards on its version, a bundle written before this API existed guards on the *absence* of a version node and is taken to 1 by its first write. No data migration needed because of that second branch. |
| `oekg/graph_store.py` | One method, `guarded_modification`. Scoped by `WITH` rather than `GRAPH` blocks, so the target graph is decided once instead of in three clauses — forgetting one of them writes the default graph, which in production is the graph the platform serves. It refuses a modification with nothing to change, because such a request is valid SPARQL the store answers `200` to, and that is the one answer a guarded write must never give without having written. |
| `oekg/bundles.py` | `field_triples` / `linked_field_triples` / `bundle_delta` — the field-scoped delta, which is what makes an unnamed key *untouched* rather than rewritten identically. `linked_field_triples` removes links only; the "unlink, never delete" rule and what it costs are stated in its docstring. `bundle_subgraph` narrows a post-state to what a read would return, so validation is asked about the bundlethat will actually exist. |
| `oekg/permissions.py` (new) | One function, because four more endpoints are about to ask the same question. Ownership is asked of `ScenarioBundleAccessControl`, not compared against a creator, since multi-owner bundles already exist. |
| `oekg/api_views.py` | The order of operations in `patch()`. Existence first (matching the two-step delete's documented order), then ownership, then the precondition. Nothing is written before the guarded update. |
| `oekg/tests/test_bundle_patch.py` (new, 51 tests) | `InterleavedWriteTest` is the interesting class: the `409` window cannot be opened from a test client, so a competing write is injected inside the transport, using the API's own compare-and-set as the competitor. |
| `oekg/tests/test_graph_store.py` | Five tests on the new builder, including `test_a_guard_that_does_not_match_is_still_a_success` — the property that forces every caller to read back. |

**Tests: 807 green** (751 before this branch), against a real Fuseki and the fetched
shape artifacts. Without a store or artifacts the graph tests skip with a stated reason,
so a local run remains green.