### PR TITLE
Record every write to a bundle, and read the record back

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -73,6 +73,7 @@ from api.views import (
     usrprop_api_view,
 )
 from oekg.api_views import ScenarioBundleAPIView, ScenarioBundleCollectionAPIView
+from oekg.history_views import ScenarioBundleHistoryAPIView
 
 app_name = "api"
 
@@ -311,6 +312,11 @@ urlpatterns_v0 = [
         "scenario-bundles/<uid>/",
         ScenarioBundleAPIView.as_view(),
         name="scenario-bundle",
+    ),
+    path(
+        "scenario-bundles/<uid>/history/",
+        ScenarioBundleHistoryAPIView.as_view(),
+        name="scenario-bundle-history",
     ),
     path(
         "datasets/",

--- a/factsheet/migrations/0012_oekg_modifications_api_history.py
+++ b/factsheet/migrations/0012_oekg_modifications_api_history.py
@@ -1,21 +1,26 @@
 """Room in the modifications table for what the REST API records.
 
-Purely additive: every new column is nullable and nothing backfills. Rows
-written before the API keep their values untouched -- `verb` stays NULL on
-them, which is what lets a reader tell the two generations apart without a
-migration that rewrites the one table whose value is being an unaltered record.
+**Purely additive, and literally so**: seven nullable columns and one index.
+Nothing backfills, nothing is altered, and no existing value is read or
+rewritten. Rows written before the API keep everything they have -- `verb`
+stays NULL on them, which is what lets a reader tell the two generations apart
+without touching the one table whose value is being an unaltered record.
 
-`old_state` and `new_state` become nullable for the same reason from the other
-side: API rows carry their diff in `removed` / `added` as real structured JSON,
-so they leave the double-encoded legacy columns empty rather than writing a
-second representation into them and breaking the existing diff viewer.
+The index is the only non-column change. `bundle_id` is the sole query key this
+table has and it had no index at all. Declared as a plain btree rather than
+`db_index=True`, because on a CharField that shortcut also builds a second
+varchar_pattern_ops index for LIKE queries nothing here makes.
 
-The index on `bundle_id` is the only sensible query key and there was none.
+Deploy note: the CREATE INDEX is not CONCURRENT, so it takes a write lock on
+the table for as long as it runs. The table holds one row per scenario-bundle
+edit made through the browser since 2023, so that is short -- but it is a lock
+on the audit table, not nothing.
 
 SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
 SPDX-License-Identifier: AGPL-3.0-or-later
 """  # noqa: 501
 
+from django.conf import settings
 from django.db import migrations, models
 
 
@@ -23,6 +28,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("factsheet", "0011_scenariobundleaccesscontrol"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 
     operations = [
@@ -61,19 +67,8 @@ class Migration(migrations.Migration):
             name="version_before",
             field=models.IntegerField(blank=True, null=True),
         ),
-        migrations.AlterField(
+        migrations.AddIndex(
             model_name="oekg_modifications",
-            name="bundle_id",
-            field=models.CharField(db_index=True, default="none", max_length=400),
-        ),
-        migrations.AlterField(
-            model_name="oekg_modifications",
-            name="new_state",
-            field=models.JSONField(blank=True, null=True),
-        ),
-        migrations.AlterField(
-            model_name="oekg_modifications",
-            name="old_state",
-            field=models.JSONField(blank=True, null=True),
+            index=models.Index(fields=["bundle_id"], name="oekg_mod_bundle_idx"),
         ),
     ]

--- a/factsheet/migrations/0012_oekg_modifications_api_history.py
+++ b/factsheet/migrations/0012_oekg_modifications_api_history.py
@@ -1,0 +1,79 @@
+"""Room in the modifications table for what the REST API records.
+
+Purely additive: every new column is nullable and nothing backfills. Rows
+written before the API keep their values untouched -- `verb` stays NULL on
+them, which is what lets a reader tell the two generations apart without a
+migration that rewrites the one table whose value is being an unaltered record.
+
+`old_state` and `new_state` become nullable for the same reason from the other
+side: API rows carry their diff in `removed` / `added` as real structured JSON,
+so they leave the double-encoded legacy columns empty rather than writing a
+second representation into them and breaking the existing diff viewer.
+
+The index on `bundle_id` is the only sensible query key and there was none.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("factsheet", "0011_scenariobundleaccesscontrol"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="oekg_modifications",
+            name="added",
+            field=models.JSONField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="oekg_modifications",
+            name="removed",
+            field=models.JSONField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="oekg_modifications",
+            name="resource_type",
+            field=models.CharField(blank=True, max_length=400, null=True),
+        ),
+        migrations.AddField(
+            model_name="oekg_modifications",
+            name="resource_uuid",
+            field=models.CharField(blank=True, max_length=400, null=True),
+        ),
+        migrations.AddField(
+            model_name="oekg_modifications",
+            name="verb",
+            field=models.CharField(blank=True, max_length=10, null=True),
+        ),
+        migrations.AddField(
+            model_name="oekg_modifications",
+            name="version_after",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="oekg_modifications",
+            name="version_before",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name="oekg_modifications",
+            name="bundle_id",
+            field=models.CharField(db_index=True, default="none", max_length=400),
+        ),
+        migrations.AlterField(
+            model_name="oekg_modifications",
+            name="new_state",
+            field=models.JSONField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name="oekg_modifications",
+            name="old_state",
+            field=models.JSONField(blank=True, null=True),
+        ),
+    ]

--- a/factsheet/models.py
+++ b/factsheet/models.py
@@ -59,9 +59,9 @@ class OEKG_Modifications(models.Model):
     row.
     """
 
-    bundle_id = CharField(max_length=400, default="none", db_index=True)
-    old_state = JSONField(null=True, blank=True)
-    new_state = JSONField(null=True, blank=True)
+    bundle_id = CharField(max_length=400, default="none")
+    old_state = JSONField()
+    new_state = JSONField()
     user = ForeignKey("login.myuser", on_delete=models.CASCADE, null=True)
     timestamp = DateTimeField(default=timezone.now)
 
@@ -73,6 +73,14 @@ class OEKG_Modifications(models.Model):
     version_after = IntegerField(null=True, blank=True)
     removed = JSONField(null=True, blank=True)
     added = JSONField(null=True, blank=True)
+
+    class Meta:
+        # A plain btree, declared here rather than as `db_index=True` on the
+        # field: on a CharField that shortcut also creates a second index with
+        # varchar_pattern_ops, for the LIKE queries nothing here makes. One
+        # index is the one this table needs -- it is queried by bundle and had
+        # none at all.
+        indexes = [models.Index(fields=["bundle_id"], name="oekg_mod_bundle_idx")]
 
     @property
     def era(self) -> str:

--- a/factsheet/models.py
+++ b/factsheet/models.py
@@ -9,16 +9,75 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 """  # noqa: 501
 
 from django.db import models
-from django.db.models import CharField, DateTimeField, ForeignKey, JSONField
+from django.db.models import (
+    CharField,
+    DateTimeField,
+    ForeignKey,
+    IntegerField,
+    JSONField,
+)
 from django.utils import timezone
+
+# What wrote a row. The table predates the REST API, and rows from before it
+# are kept exactly as they were rather than migrated -- so a reader has to be
+# able to tell the two apart, and `verb` is what tells it: only the API sets it.
+PRE_API_ERA = "pre_api"
+API_ERA = "api"
+
+# What an API row puts in the legacy payload columns. Empty, not null: the
+# user interface feeds those two straight into a text-diff component that
+# splits them, and one null would throw out of a page that renders every row.
+EMPTY_LEGACY_PAYLOAD = ""
 
 
 class OEKG_Modifications(models.Model):
-    bundle_id = CharField(max_length=400, default="none")
-    old_state = JSONField()
-    new_state = JSONField()
+    """One recorded change to a scenario bundle.
+
+    **Extended, not replaced.** The REST API writes here rather than to a table
+    of its own, because two histories split by which client did the writing is
+    the completeness problem this model already has, in a new form.
+
+    That leaves two generations of row in one table, and they are deliberately
+    not reconciled:
+
+    - **Pre-API rows** carry their changed triples in ``old_state`` /
+      ``new_state`` as JSON-LD **strings inside a JSON column** -- double
+      encoded, because ``Graph.serialize()`` returns a ``str``. The user
+      interface's diff viewer depends on that, so rewriting them in place would
+      break it while editing the one table whose value is being an unaltered
+      record.
+    - **API rows** carry theirs in ``removed`` / ``added`` as real structured
+      JSON, and fill the columns that make the table answerable: which
+      operation, which resource, and which version it produced. A timestamp
+      alone cannot answer "which change produced this state". They leave the
+      legacy columns **empty rather than null**: the diff viewer hands them
+      straight to a component that splits them, so a null there would throw and
+      take the whole page down with it -- it renders every row in one map.
+
+    The diff is stored **losslessly and untranslated** -- no field names, no
+    serializer vocabulary -- so a later shape change never re-interprets an old
+    row.
+    """
+
+    bundle_id = CharField(max_length=400, default="none", db_index=True)
+    old_state = JSONField(null=True, blank=True)
+    new_state = JSONField(null=True, blank=True)
     user = ForeignKey("login.myuser", on_delete=models.CASCADE, null=True)
     timestamp = DateTimeField(default=timezone.now)
+
+    # Set by the API and by nothing else, which is what makes `era` decidable.
+    verb = CharField(max_length=10, null=True, blank=True)
+    resource_type = CharField(max_length=400, null=True, blank=True)
+    resource_uuid = CharField(max_length=400, null=True, blank=True)
+    version_before = IntegerField(null=True, blank=True)
+    version_after = IntegerField(null=True, blank=True)
+    removed = JSONField(null=True, blank=True)
+    added = JSONField(null=True, blank=True)
+
+    @property
+    def era(self) -> str:
+        """Which generation of writer produced this row."""
+        return API_ERA if self.verb else PRE_API_ERA
 
 
 class ScenarioBundleAccessControl(models.Model):

--- a/oekg/api_support.py
+++ b/oekg/api_support.py
@@ -1,0 +1,93 @@
+"""What every endpoint of the OEKG API shares: its ceilings and its refusals.
+
+Extracted when the second view module appeared and had to import five names
+from the first. That import is the signal: helpers every endpoint needs are not
+the bundle endpoint's property, and five more view modules are coming --
+scenarios, study reports, dataset links, delete, replace. Left where they were,
+`api_views` would become a utility module by accident, and would change
+whenever any endpoint's conventions changed.
+
+What belongs here: throttling, the refusals more than one endpoint gives, and
+the existence check they all make first. What does not: anything specific to
+one resource, which stays with that resource's view.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+import logging
+import uuid
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+from oekg.bundles import BUNDLE_CLASS, bundle_iri
+from oekg.graph_store import GraphStore
+
+logger = logging.getLogger("oeplatform")
+
+
+class ScenarioBundleThrottle(AnonRateThrottle):
+    """Reads are public, so the public endpoints need a ceiling of their own."""
+
+    scope = "oekg_bundles_anon"
+
+
+class ScenarioBundleUserThrottle(UserRateThrottle):
+    scope = "oekg_bundles_user"
+
+
+def is_minted_identifier(uid: str) -> bool:
+    """Whether ``uid`` could have come from this API.
+
+    Checked before a value reaches a query: an IRI-unsafe character makes
+    rdflib refuse to build the IRI, which would surface as a 500 rather than
+    the 404 it actually is. That refusal is also what keeps the query free of
+    injection.
+    """
+    try:
+        uuid.UUID(str(uid))
+    except (ValueError, AttributeError, TypeError):
+        return False
+    return True
+
+
+def bundle_exists(uid: str) -> bool:
+    """Whether there is a bundle at ``uid``. Asked of the graph, not of a table.
+
+    Raises ``GraphStoreError`` rather than answering ``False`` when the store
+    cannot be reached: "there is no such bundle" and "I could not find out" are
+    different answers, and a caller has to be able to say 503 instead of 404.
+
+    An ASK rather than the read a GET does -- this asks whether the bundle is
+    there, and pulling its whole subgraph across to answer that would make
+    every caller pay for data it throws away.
+    """
+    if not is_minted_identifier(uid):
+        return False
+    return GraphStore.from_settings().ask(
+        "ASK { %s a %s }" % (bundle_iri(uid).n3(), BUNDLE_CLASS.n3())
+    )
+
+
+def no_such_bundle(uid: str) -> Response:
+    return Response(
+        {"detail": f"No scenario bundle {uid}."}, status=status.HTTP_404_NOT_FOUND
+    )
+
+
+def store_unavailable(error: Exception, action: str) -> Response:
+    logger.error("OEKG API %s failed: %s", action, error)
+    return Response(
+        {"detail": f"The OEKG graph store could not be {action}."},
+        status=status.HTTP_503_SERVICE_UNAVAILABLE,
+    )
+
+
+def shape_unavailable(error: Exception) -> Response:
+    logger.error("OEKG API cannot validate: %s", error)
+    return Response(
+        {"detail": "The OEKG shape is not available on this server."},
+        status=status.HTTP_503_SERVICE_UNAVAILABLE,
+    )

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -40,7 +40,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 """  # noqa: 501
 
 import logging
-import uuid
 from typing import Optional
 
 from django.db import DatabaseError
@@ -49,10 +48,17 @@ from rdflib import RDFS, Graph, Literal, URIRef
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from rest_framework.views import APIView
 
 from factsheet.models import ScenarioBundleAccessControl
+from oekg.api_support import (
+    ScenarioBundleThrottle,
+    ScenarioBundleUserThrottle,
+    is_minted_identifier,
+    no_such_bundle,
+    shape_unavailable,
+    store_unavailable,
+)
 from oekg.bundles import (
     BUNDLE_CLASS,
     DC,
@@ -82,16 +88,6 @@ from oekg.versioning import (
 )
 
 logger = logging.getLogger("oeplatform")
-
-
-class ScenarioBundleThrottle(AnonRateThrottle):
-    """Reads are public, so the public endpoint needs a ceiling of its own."""
-
-    scope = "oekg_bundles_anon"
-
-
-class ScenarioBundleUserThrottle(UserRateThrottle):
-    scope = "oekg_bundles_user"
 
 
 class ScenarioBundleCollectionAPIView(APIView):
@@ -143,7 +139,7 @@ class ScenarioBundleCollectionAPIView(APIView):
                 # wrong, so it would have to distinguish them first.
                 return _acronym_conflict(acronym)
         except ShapeUnavailable as error:
-            return _shape_unavailable(error)
+            return shape_unavailable(error)
         except GraphStoreError as error:
             return store_unavailable(error, "written to")
 
@@ -184,8 +180,7 @@ class ScenarioBundleCollectionAPIView(APIView):
         body = _represent(uid, bundle_payload(post_state, uid), version)
         if not owned:
             body[READ_ONLY_CONTAINER]["ownership_recorded"] = False
-        if not recorded:
-            body[READ_ONLY_CONTAINER]["history_recorded"] = False
+        _note_history_gap(body, recorded)
         response = Response(body, status=status.HTTP_201_CREATED)
         response["Location"] = reverse("api:scenario-bundle", kwargs={"uid": uid})
         response["ETag"] = version.etag
@@ -211,7 +206,7 @@ class ScenarioBundleAPIView(APIView):
         # Identifiers are minted here, so anything that is not one cannot name a
         # bundle. Checked before it reaches a query, where an IRI-unsafe
         # character would raise out of rdflib as a 500 rather than a 404.
-        if not _is_minted_identifier(uid):
+        if not is_minted_identifier(uid):
             return no_such_bundle(uid)
 
         store = GraphStore.from_settings()
@@ -226,7 +221,7 @@ class ScenarioBundleAPIView(APIView):
         return _bundle_response(uid, bundle_payload(subgraph, uid), version)
 
     def patch(self, request, uid):
-        if not _is_minted_identifier(uid):
+        if not is_minted_identifier(uid):
             return no_such_bundle(uid)
 
         serializer = ScenarioBundleSerializer(data=request.data, partial=True)
@@ -295,7 +290,7 @@ class ScenarioBundleAPIView(APIView):
                     status=status.HTTP_409_CONFLICT,
                 )
         except ShapeUnavailable as error:
-            return _shape_unavailable(error)
+            return shape_unavailable(error)
         except GraphStoreError as error:
             return store_unavailable(error, "written to")
 
@@ -371,28 +366,6 @@ def _versions_named(request):
     return named
 
 
-def bundle_exists(uid: str) -> bool:
-    """Whether there is a bundle at ``uid``. Asked of the graph, not of a table.
-
-    Shared with the history endpoint, which must not answer 404 for a real
-    bundle that simply has no entries yet -- every bundle the user interface
-    wrote is one of those.
-
-    Raises ``GraphStoreError`` rather than answering ``False`` when the store
-    cannot be reached: "there is no such bundle" and "I could not find out" are
-    different answers, and a caller has to be able to say 503 instead of 404.
-
-    An ASK rather than the read a GET does -- this asks whether the bundle is
-    there, and pulling its whole subgraph across to answer that would make
-    every history read pay for data it throws away.
-    """
-    if not _is_minted_identifier(uid):
-        return False
-    return GraphStore.from_settings().ask(
-        "ASK { %s a %s }" % (bundle_iri(uid).n3(), BUNDLE_CLASS.n3())
-    )
-
-
 def _read_bundle(store: GraphStore, uid: str) -> Optional[Graph]:
     """A bundle and one hop out, or ``None`` if there is no such bundle.
 
@@ -413,14 +386,6 @@ def _read_bundle(store: GraphStore, uid: str) -> Optional[Graph]:
     if (bundle_iri(uid), None, None) not in subgraph:
         return None
     return subgraph
-
-
-def _is_minted_identifier(uid: str) -> bool:
-    try:
-        uuid.UUID(str(uid))
-    except (ValueError, AttributeError, TypeError):
-        return False
-    return True
 
 
 def _labels_of(store: GraphStore, iris: list) -> dict:
@@ -509,30 +474,29 @@ def _represent(uid: str, payload: dict, version: BundleVersion) -> dict:
     }
 
 
+def _note_history_gap(body: dict, recorded: bool) -> dict:
+    """Say so when the history was lost, and say nothing when it was not.
+
+    The key appears only when it is ``False``. A client should not have to
+    check something on every response to learn that the ordinary thing
+    happened; it is there to name the exception.
+    """
+    if not recorded:
+        body[READ_ONLY_CONTAINER]["history_recorded"] = False
+    return body
+
+
 def _bundle_response(
     uid: str,
     payload: dict,
     version: BundleVersion,
     history_recorded: bool = True,
 ) -> Response:
-    """The body, plus the entity tag every read has to carry.
-
-    ``history_recorded`` appears only when it is ``False``. A client should not
-    have to check a key on every response to learn that the ordinary thing
-    happened; it is there to name the exception.
-    """
-    body = _represent(uid, payload, version)
-    if not history_recorded:
-        body[READ_ONLY_CONTAINER]["history_recorded"] = False
+    """The body, plus the entity tag every read has to carry."""
+    body = _note_history_gap(_represent(uid, payload, version), history_recorded)
     response = Response(body)
     response["ETag"] = version.etag
     return response
-
-
-def no_such_bundle(uid: str) -> Response:
-    return Response(
-        {"detail": f"No scenario bundle {uid}."}, status=status.HTTP_404_NOT_FOUND
-    )
 
 
 def _not_the_owner() -> Response:
@@ -582,20 +546,4 @@ def _does_not_conform(violations: list) -> Response:
             "violations": [violation.as_dict() for violation in violations],
         },
         status=status.HTTP_400_BAD_REQUEST,
-    )
-
-
-def _shape_unavailable(error: Exception) -> Response:
-    logger.error("OEKG API cannot validate: %s", error)
-    return Response(
-        {"detail": "The OEKG shape is not available on this server."},
-        status=status.HTTP_503_SERVICE_UNAVAILABLE,
-    )
-
-
-def store_unavailable(error: Exception, action: str) -> Response:
-    logger.error("OEKG API %s failed: %s", action, error)
-    return Response(
-        {"detail": f"The OEKG graph store could not be {action}."},
-        status=status.HTTP_503_SERVICE_UNAVAILABLE,
     )

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -65,12 +65,14 @@ from oekg.bundles import (
     referenced_node_iris,
 )
 from oekg.graph_store import GraphStore, GraphStoreError
+from oekg.history import CREATE, UPDATE, record_write
 from oekg.permissions import may_write_bundle
 from oekg.serializers import READ_ONLY_CONTAINER, ScenarioBundleSerializer
 from oekg.shape import ShapeUnavailable
 from oekg.validation import validate_post_state
 from oekg.versioning import (
     FIRST_VERSION,
+    UNVERSIONED,
     BundleVersion,
     guarded_operation,
     mint_write_token,
@@ -143,7 +145,7 @@ class ScenarioBundleCollectionAPIView(APIView):
         except ShapeUnavailable as error:
             return _shape_unavailable(error)
         except GraphStoreError as error:
-            return _store_unavailable(error, "written to")
+            return store_unavailable(error, "written to")
 
         # Ownership is recorded now so the creator can edit later: a bundle with
         # no ownership record is administrator-only by design, which would make
@@ -166,10 +168,24 @@ class ScenarioBundleCollectionAPIView(APIView):
                 uid,
             )
 
+        # The graph has committed. From here nothing may turn a successful
+        # write into an error -- a failure is reported alongside the success it
+        # qualifies, never instead of it.
+        recorded = record_write(
+            bundle_uid=uid,
+            verb=CREATE,
+            actor=request.user,
+            version_before=UNVERSIONED,
+            version_after=FIRST_VERSION,
+            added=post_state,
+        )
+
         version = BundleVersion(FIRST_VERSION, token)
         body = _represent(uid, bundle_payload(post_state, uid), version)
         if not owned:
             body[READ_ONLY_CONTAINER]["ownership_recorded"] = False
+        if not recorded:
+            body[READ_ONLY_CONTAINER]["history_recorded"] = False
         response = Response(body, status=status.HTTP_201_CREATED)
         response["Location"] = reverse("api:scenario-bundle", kwargs={"uid": uid})
         response["ETag"] = version.etag
@@ -196,22 +212,22 @@ class ScenarioBundleAPIView(APIView):
         # bundle. Checked before it reaches a query, where an IRI-unsafe
         # character would raise out of rdflib as a 500 rather than a 404.
         if not _is_minted_identifier(uid):
-            return _no_such_bundle(uid)
+            return no_such_bundle(uid)
 
         store = GraphStore.from_settings()
         try:
             subgraph = _read_bundle(store, uid)
             if subgraph is None:
-                return _no_such_bundle(uid)
+                return no_such_bundle(uid)
             version = read_version(store, uid)
         except GraphStoreError as error:
-            return _store_unavailable(error, "read")
+            return store_unavailable(error, "read")
 
         return _bundle_response(uid, bundle_payload(subgraph, uid), version)
 
     def patch(self, request, uid):
         if not _is_minted_identifier(uid):
-            return _no_such_bundle(uid)
+            return no_such_bundle(uid)
 
         serializer = ScenarioBundleSerializer(data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
@@ -236,7 +252,7 @@ class ScenarioBundleAPIView(APIView):
             # not.
             pre_state = _read_bundle(store, uid)
             if pre_state is None:
-                return _no_such_bundle(uid)
+                return no_such_bundle(uid)
 
             if not may_write_bundle(request.user, uid):
                 return _not_the_owner()
@@ -281,10 +297,24 @@ class ScenarioBundleAPIView(APIView):
         except ShapeUnavailable as error:
             return _shape_unavailable(error)
         except GraphStoreError as error:
-            return _store_unavailable(error, "written to")
+            return store_unavailable(error, "written to")
 
         written = BundleVersion(version.number + 1, token)
-        return _bundle_response(uid, bundle_payload(post_state, uid), written)
+        recorded = record_write(
+            bundle_uid=uid,
+            verb=UPDATE,
+            actor=request.user,
+            version_before=version.number,
+            version_after=written.number,
+            removed=removed,
+            added=added,
+        )
+        return _bundle_response(
+            uid,
+            bundle_payload(post_state, uid),
+            written,
+            history_recorded=recorded,
+        )
 
 
 def _precondition_refusal(request, version: BundleVersion) -> Optional[Response]:
@@ -339,6 +369,28 @@ def _versions_named(request):
             entry = entry[2:].strip()
         named.append(entry.strip('"'))
     return named
+
+
+def bundle_exists(uid: str) -> bool:
+    """Whether there is a bundle at ``uid``. Asked of the graph, not of a table.
+
+    Shared with the history endpoint, which must not answer 404 for a real
+    bundle that simply has no entries yet -- every bundle the user interface
+    wrote is one of those.
+
+    Raises ``GraphStoreError`` rather than answering ``False`` when the store
+    cannot be reached: "there is no such bundle" and "I could not find out" are
+    different answers, and a caller has to be able to say 503 instead of 404.
+
+    An ASK rather than the read a GET does -- this asks whether the bundle is
+    there, and pulling its whole subgraph across to answer that would make
+    every history read pay for data it throws away.
+    """
+    if not _is_minted_identifier(uid):
+        return False
+    return GraphStore.from_settings().ask(
+        "ASK { %s a %s }" % (bundle_iri(uid).n3(), BUNDLE_CLASS.n3())
+    )
 
 
 def _read_bundle(store: GraphStore, uid: str) -> Optional[Graph]:
@@ -457,14 +509,27 @@ def _represent(uid: str, payload: dict, version: BundleVersion) -> dict:
     }
 
 
-def _bundle_response(uid: str, payload: dict, version: BundleVersion) -> Response:
-    """The body, plus the entity tag every read has to carry."""
-    response = Response(_represent(uid, payload, version))
+def _bundle_response(
+    uid: str,
+    payload: dict,
+    version: BundleVersion,
+    history_recorded: bool = True,
+) -> Response:
+    """The body, plus the entity tag every read has to carry.
+
+    ``history_recorded`` appears only when it is ``False``. A client should not
+    have to check a key on every response to learn that the ordinary thing
+    happened; it is there to name the exception.
+    """
+    body = _represent(uid, payload, version)
+    if not history_recorded:
+        body[READ_ONLY_CONTAINER]["history_recorded"] = False
+    response = Response(body)
     response["ETag"] = version.etag
     return response
 
 
-def _no_such_bundle(uid: str) -> Response:
+def no_such_bundle(uid: str) -> Response:
     return Response(
         {"detail": f"No scenario bundle {uid}."}, status=status.HTTP_404_NOT_FOUND
     )
@@ -528,7 +593,7 @@ def _shape_unavailable(error: Exception) -> Response:
     )
 
 
-def _store_unavailable(error: Exception, action: str) -> Response:
+def store_unavailable(error: Exception, action: str) -> Response:
     logger.error("OEKG API %s failed: %s", action, error)
     return Response(
         {"detail": f"The OEKG graph store could not be {action}."},

--- a/oekg/history.py
+++ b/oekg/history.py
@@ -1,0 +1,158 @@
+"""What a write leaves behind, and how it reads back.
+
+Two rules, and the second is the one that is easy to get wrong.
+
+**Every write records.** Not "every write that destroys information" -- the
+judgement call is what makes an audit trail patchy, and "no entry" would then
+be ambiguous between *created* and *never touched*. So the rule is flat: the
+history is the log of writes.
+
+**The graph commits first, and a failed history write does not fail the
+request.** The two stores cannot share a transaction. The data is the truth and
+the history is the note about it, so answering `500` for a write that succeeded
+would provoke exactly the retry that creates duplicates. The price is a
+possible gap in the audit trail, and it is **named rather than hidden** -- in
+the response, and in one structured log line -- because a phantom entry would
+be worse: it looks like truth.
+
+What is stored is the changed triples, **losslessly and untranslated**. No
+field names, no serializer vocabulary, nothing that a later shape change could
+re-interpret. Field names are computed here at read time instead, from the same
+field table that builds the triples, so a rendering can never drift from what
+was stored -- it is derived from it on every read.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+import json
+import logging
+from typing import Optional
+
+from django.db import DatabaseError, transaction
+from rdflib import RDF, Graph, URIRef
+
+from factsheet.models import EMPTY_LEGACY_PAYLOAD, OEKG_Modifications
+from oekg.bundles import BUNDLE_CLASS, BUNDLE_FIELDS, PART, bundle_iri
+
+logger = logging.getLogger("oeplatform.oekg_history")
+
+CREATE = "POST"
+UPDATE = "PATCH"
+# Deletes join this list with the slice that implements them, not before: a
+# verb named here but never written would say the history records something it
+# does not.
+VERBS = (CREATE, UPDATE)
+
+
+def record_write(
+    *,
+    bundle_uid: str,
+    verb: str,
+    actor,
+    version_before: int,
+    version_after: int,
+    removed: Optional[Graph] = None,
+    added: Optional[Graph] = None,
+    resource_type=BUNDLE_CLASS,
+    resource_uuid: Optional[str] = None,
+) -> bool:
+    """Record one write. Returns whether it was recorded.
+
+    Never raises: the caller's graph write has already committed, so there is
+    nothing left to undo and nothing useful to tell the client beyond the fact
+    that this note was lost.
+    """
+    if verb not in VERBS:
+        # Not a runtime guard against clients -- they cannot reach this. It
+        # catches a caller inventing a verb the readers will not understand.
+        raise ValueError(f"{verb!r} is not one of {', '.join(VERBS)}.")
+    try:
+        # The savepoint keeps a rejected insert from poisoning the surrounding
+        # transaction. Without it a real database error would be caught here
+        # and then raised again by the next query -- turning a write that
+        # succeeded into a 500, which is the one outcome this whole ordering
+        # exists to avoid.
+        with transaction.atomic():
+            OEKG_Modifications.objects.create(
+                bundle_id=bundle_uid,
+                user=actor if getattr(actor, "is_authenticated", False) else None,
+                verb=verb,
+                resource_type=str(resource_type) if resource_type else None,
+                resource_uuid=resource_uuid,
+                version_before=version_before,
+                version_after=version_after,
+                removed=_as_json(removed),
+                added=_as_json(added),
+                # Not null: the user interface's diff viewer reads these two
+                # and would throw on one, taking its whole page down.
+                old_state=EMPTY_LEGACY_PAYLOAD,
+                new_state=EMPTY_LEGACY_PAYLOAD,
+            )
+    except DatabaseError:
+        # One structured line, the house format, so the gap is greppable. It is
+        # the only place this becomes visible: there is no Django admin on this
+        # platform to inspect the table through.
+        logger.error(
+            "oekg_history bundle=%s verb=%s user=%s version=%s->%s "
+            "outcome=not_recorded",
+            bundle_uid,
+            verb,
+            getattr(actor, "name", None) or "-",
+            version_before,
+            version_after,
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def changed_fields(uid: str, removed: Graph, added: Graph) -> list:
+    """The diff, in the vocabulary a client writes in.
+
+    Computed on every read rather than stored, so it cannot drift from the
+    triples it describes and a shape change never re-interprets an old row.
+
+    A triple this cannot attribute to a field -- the type and label a minted
+    contact brings with it, say -- is reported under a ``None`` field rather
+    than dropped. Dropping it would make the summary look complete when it is
+    not, which is the one thing a history must not do.
+    """
+    fields = {}
+    for side, graph in (("removed", removed), ("added", added)):
+        for subject, predicate, obj in graph:
+            name = _field_name(uid, subject, predicate, obj, graph)
+            entry = fields.setdefault(name, {"removed": [], "added": []})
+            entry[side].append(str(obj))
+    return [
+        {"field": name, "removed": sides["removed"], "added": sides["added"]}
+        for name, sides in sorted(fields.items(), key=lambda item: (item[0] or "",))
+    ]
+
+
+def _field_name(uid, subject, predicate, obj, graph) -> Optional[str]:
+    """Which bundle field a triple belongs to, if any.
+
+    Two predicates in the field table are shared between fields -- frameworks
+    and models both hang off has-part -- so the object's type decides. An added
+    part carries its type in the same diff; a removed one does not, because a
+    patch unlinks and never deletes, and then the field is honestly unknown.
+    """
+    if subject != bundle_iri(uid):
+        return None
+    candidates = [
+        field for field in BUNDLE_FIELDS if field.predicate == URIRef(predicate)
+    ]
+    if len(candidates) == 1:
+        return candidates[0].name
+    for field in candidates:
+        if field.kind == PART and (obj, RDF.type, field.node_class) in graph:
+            return field.name
+    return None
+
+
+def _as_json(graph: Optional[Graph]):
+    """JSON-LD as structured data, not as a string inside a JSON column."""
+    if graph is None or not len(graph):
+        return None
+    return json.loads(graph.serialize(format="json-ld"))

--- a/oekg/history.py
+++ b/oekg/history.py
@@ -29,7 +29,7 @@ import json
 import logging
 from typing import Optional
 
-from django.db import DatabaseError, transaction
+from django.db import transaction
 from rdflib import RDF, Graph, URIRef
 
 from factsheet.models import EMPTY_LEGACY_PAYLOAD, OEKG_Modifications
@@ -59,9 +59,12 @@ def record_write(
 ) -> bool:
     """Record one write. Returns whether it was recorded.
 
-    Never raises: the caller's graph write has already committed, so there is
-    nothing left to undo and nothing useful to tell the client beyond the fact
-    that this note was lost.
+    **Never raises**, and that is load-bearing rather than polite: the caller's
+    graph write has already committed, so there is nothing left to undo and
+    nothing useful to tell the client beyond the fact that this note was lost.
+    Anything raised from here would become a 500 for a write that succeeded --
+    the one outcome the whole ordering exists to avoid -- so the net is cast
+    around every failure and not only around the database's.
     """
     if verb not in VERBS:
         # Not a runtime guard against clients -- they cannot reach this. It
@@ -70,9 +73,8 @@ def record_write(
     try:
         # The savepoint keeps a rejected insert from poisoning the surrounding
         # transaction. Without it a real database error would be caught here
-        # and then raised again by the next query -- turning a write that
-        # succeeded into a 500, which is the one outcome this whole ordering
-        # exists to avoid.
+        # and then raised again by the next query -- which would produce the
+        # same 500 by a slower route.
         with transaction.atomic():
             OEKG_Modifications.objects.create(
                 bundle_id=bundle_uid,
@@ -89,7 +91,11 @@ def record_write(
                 old_state=EMPTY_LEGACY_PAYLOAD,
                 new_state=EMPTY_LEGACY_PAYLOAD,
             )
-    except DatabaseError:
+    except Exception:
+        # Deliberately every exception, not just the database's: serialising
+        # the diff runs in here too, and an rdflib failure would otherwise
+        # escape and undo the guarantee this function's contract makes.
+        #
         # One structured line, the house format, so the gap is greppable. It is
         # the only place this becomes visible: there is no Django admin on this
         # platform to inspect the table through.
@@ -114,19 +120,30 @@ def changed_fields(uid: str, removed: Graph, added: Graph) -> list:
     triples it describes and a shape change never re-interprets an old row.
 
     A triple this cannot attribute to a field -- the type and label a minted
-    contact brings with it, say -- is reported under a ``None`` field rather
+    contact brings with it, say -- is reported with a ``None`` field rather
     than dropped. Dropping it would make the summary look complete when it is
     not, which is the one thing a history must not do.
+
+    **Every change names its predicate**, attributed or not. Without it an
+    unattributed entry would be a list of bare values with nothing saying what
+    they were values of, which is only marginally better than dropping them.
     """
-    fields = {}
+    changes = {}
     for side, graph in (("removed", removed), ("added", added)):
         for subject, predicate, obj in graph:
-            name = _field_name(uid, subject, predicate, obj, graph)
-            entry = fields.setdefault(name, {"removed": [], "added": []})
+            key = (_field_name(uid, subject, predicate, obj, graph), str(predicate))
+            entry = changes.setdefault(key, {"removed": [], "added": []})
             entry[side].append(str(obj))
     return [
-        {"field": name, "removed": sides["removed"], "added": sides["added"]}
-        for name, sides in sorted(fields.items(), key=lambda item: (item[0] or "",))
+        {
+            "field": name,
+            "predicate": predicate,
+            "removed": sides["removed"],
+            "added": sides["added"],
+        }
+        for (name, predicate), sides in sorted(
+            changes.items(), key=lambda item: (item[0][0] or "", item[0][1])
+        )
     ]
 
 

--- a/oekg/history_views.py
+++ b/oekg/history_views.py
@@ -27,7 +27,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from factsheet.models import API_ERA, OEKG_Modifications
-from oekg.api_views import (
+from oekg.api_support import (
     ScenarioBundleThrottle,
     ScenarioBundleUserThrottle,
     bundle_exists,

--- a/oekg/history_views.py
+++ b/oekg/history_views.py
@@ -1,0 +1,135 @@
+"""Reading a bundle's history.
+
+**Public, but per bundle and paginated.** The reasoning that makes bundle reads
+public does not transfer: that one rests on the SPARQL endpoint already serving
+the same data, and the history is in no graph -- it is in the relational
+database, and what it exposes is not bundle content but *who edited what, and
+when*. A per-bundle log is a record about a bundle; a global one is a profile
+of a person's activity across the platform. So this endpoint is scoped to one
+bundle, it is paginated with a ceiling, and the actor is a username rather than
+the internal identifier the existing global dump hands out.
+
+Changes are rendered in **field names, computed here at read time** from the
+stored triples. The triples themselves stay reachable through `?expand=triples`
+so that a legible summary never becomes the only account.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+import json
+
+from rdflib import Graph
+from rest_framework import status
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from factsheet.models import API_ERA, OEKG_Modifications
+from oekg.api_views import (
+    ScenarioBundleThrottle,
+    ScenarioBundleUserThrottle,
+    bundle_exists,
+    no_such_bundle,
+    store_unavailable,
+)
+from oekg.graph_store import GraphStoreError
+from oekg.history import changed_fields
+
+TRIPLES = "triples"
+
+
+class HistoryPagination(PageNumberPagination):
+    """A ceiling, not a default: there is no unbounded mode on a public read."""
+
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
+class ScenarioBundleHistoryAPIView(APIView):
+    """`GET` returns one bundle's change history."""
+
+    permission_classes = [AllowAny]
+    throttle_classes = [ScenarioBundleThrottle, ScenarioBundleUserThrottle]
+
+    def get(self, request, uid):
+        expand = request.query_params.get("expand")
+        if expand not in (None, "", TRIPLES):
+            return Response(
+                {
+                    "detail": (
+                        f"{expand!r} is not something this endpoint can expand. "
+                        f"The only value is {TRIPLES!r}."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Existence is asked of the graph, not of the history: a bundle with no
+        # entries is a real bundle the user interface wrote, and answering 404
+        # for it would say it does not exist.
+        try:
+            if not bundle_exists(uid):
+                return no_such_bundle(uid)
+        except GraphStoreError as error:
+            # "There is no such bundle" and "I could not find out" are
+            # different answers, and only one of them is this endpoint's to
+            # give when the graph is unreachable.
+            return store_unavailable(error, "read")
+
+        entries = OEKG_Modifications.objects.filter(bundle_id=uid).select_related(
+            "user"
+        )
+        # Newest first: a history is read from the present backwards.
+        entries = entries.order_by("-timestamp", "-id")
+
+        paginator = HistoryPagination()
+        page = paginator.paginate_queryset(entries, request, view=self)
+        return paginator.get_paginated_response(
+            [_represent(entry, uid, with_triples=expand == TRIPLES) for entry in page]
+        )
+
+
+def _represent(entry: OEKG_Modifications, uid: str, with_triples: bool) -> dict:
+    body = {
+        "era": entry.era,
+        "verb": entry.verb,
+        "actor": entry.user.name if entry.user else None,
+        "timestamp": entry.timestamp,
+        "resource": {"type": entry.resource_type, "uid": entry.resource_uuid},
+        "version_before": entry.version_before,
+        "version_after": entry.version_after,
+        "changes": _changes(entry, uid),
+    }
+    if with_triples:
+        body["triples"] = _triples(entry)
+    return body
+
+
+def _changes(entry: OEKG_Modifications, uid: str):
+    """The field-level summary, or ``None`` where there cannot be one.
+
+    ``None`` rather than an empty list for a pre-API row: an empty list would
+    say that nothing changed, and what is actually known is that this row was
+    written before anything recorded which fields it touched.
+    """
+    if entry.era != API_ERA:
+        return None
+    return changed_fields(uid, _graph(entry.removed), _graph(entry.added))
+
+
+def _triples(entry: OEKG_Modifications) -> dict:
+    """The stored payload, untouched -- whichever generation of row this is."""
+    if entry.era == API_ERA:
+        return {"removed": entry.removed, "added": entry.added}
+    return {"removed": entry.old_state, "added": entry.new_state}
+
+
+def _graph(payload) -> Graph:
+    graph = Graph()
+    if payload:
+        # `parse` wants a document; the column holds already-parsed JSON.
+        graph.parse(data=json.dumps(payload), format="json-ld")
+    return graph

--- a/oekg/tests/test_bundle_history.py
+++ b/oekg/tests/test_bundle_history.py
@@ -419,7 +419,15 @@ class ChangedFieldsTest(SimpleTestCase):
         changes = changed_fields("u1", removed, added)
 
         self.assertEqual(
-            changes, [{"field": "abstract", "removed": [], "added": ["neu"]}]
+            changes,
+            [
+                {
+                    "field": "abstract",
+                    "predicate": str(DC.abstract),
+                    "removed": [],
+                    "added": ["neu"],
+                }
+            ],
         )
 
     def test_both_sides_of_one_field_are_one_change(self):
@@ -464,6 +472,16 @@ class ChangedFieldsTest(SimpleTestCase):
         changes = changed_fields("u1", Graph(), added)
 
         self.assertEqual(changes[0]["field"], None)
+
+    def test_an_unattributed_change_still_says_what_it_was_about(self):
+        # A bare list of values with no predicate would be barely better than
+        # dropping them.
+        added = Graph()
+        added.add((URIRef("https://example.org/c1"), RDFS.label, Literal("A contact")))
+
+        changes = changed_fields("u1", Graph(), added)
+
+        self.assertEqual(changes[0]["predicate"], str(RDFS.label))
 
     def test_nothing_changed_renders_as_nothing(self):
         self.assertEqual(changed_fields("u1", Graph(), Graph()), [])

--- a/oekg/tests/test_bundle_history.py
+++ b/oekg/tests/test_bundle_history.py
@@ -1,0 +1,490 @@
+"""Every write leaves a record, and the record reads back.
+
+Two properties carry this slice, and both are easy to lose:
+
+- **The record is complete.** Today only the user interface's update path
+  records anything; creates, deletes and every API write are silent. The rule
+  here is "the history is the log of writes", with no per-operation judgement
+  to make or to get wrong.
+- **The graph is the truth and the history is the note about it.** They cannot
+  share a transaction, so the graph commits first and a failed history write
+  still answers success -- the gap is named in the response and in the log
+  rather than hidden, because a phantom entry would be worse.
+
+The stored diff is lossless and untranslated; field names are computed at read
+time, so a later shape change never re-interprets an old row.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+import json
+from unittest.mock import patch
+
+from django.db import DatabaseError
+from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import RDFS
+
+from factsheet.models import API_ERA, PRE_API_ERA, OEKG_Modifications
+from login.models import myuser
+from oekg.bundles import BUNDLE_CLASS, DC, HAS_PART, OEO, bundle_iri
+from oekg.history import CREATE, UPDATE, changed_fields, record_write
+from oekg.serializers import READ_ONLY_CONTAINER
+from oekg.tests.bundle_fixtures import VALID_PAYLOAD, BundleApiTestCase
+
+
+class HistoryTestCase(BundleApiTestCase):
+    def history_url(self, uid):
+        return reverse("api:scenario-bundle-history", kwargs={"uid": uid})
+
+    def entries(self, uid):
+        return list(OEKG_Modifications.objects.filter(bundle_id=uid).order_by("id"))
+
+    def read_history(self, uid, **params):
+        return self.client.get(self.history_url(uid), params)
+
+
+class EveryWriteRecordsTest(HistoryTestCase):
+    def test_a_create_writes_one_entry(self):
+        uid, _ = self.created()
+
+        entries = self.entries(uid)
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].verb, CREATE)
+        self.assertEqual(entries[0].user, self.user)
+
+    def test_a_create_records_the_version_it_produced(self):
+        # A timestamp cannot answer "which change produced this state"; the
+        # version pair can.
+        uid, _ = self.created()
+
+        entry = self.entries(uid)[0]
+
+        self.assertEqual(entry.version_before, 0)
+        self.assertEqual(entry.version_after, 1)
+
+    def test_a_patch_writes_one_entry(self):
+        uid, etag = self.created()
+
+        self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        entries = self.entries(uid)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[1].verb, UPDATE)
+        self.assertEqual((entries[1].version_before, entries[1].version_after), (1, 2))
+
+    def test_an_entry_names_the_resource_it_touched(self):
+        uid, _ = self.created()
+
+        entry = self.entries(uid)[0]
+
+        self.assertEqual(entry.resource_type, str(BUNDLE_CLASS))
+        self.assertIsNone(entry.resource_uuid)
+
+    def test_a_refused_write_records_nothing(self):
+        uid, etag = self.created()
+
+        self.patch(uid, {"technologies": []}, if_match=etag)
+
+        self.assertEqual(len(self.entries(uid)), 1)
+
+    def test_entries_are_written_as_the_api_era(self):
+        uid, _ = self.created()
+
+        self.assertEqual(self.entries(uid)[0].era, API_ERA)
+
+
+class TheStoredDiffTest(HistoryTestCase):
+    def test_a_patch_stores_what_changed_and_nothing_else(self):
+        uid, etag = self.created()
+
+        self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        entry = self.entries(uid)[1]
+        self.assertEqual(self.labels_in(entry.removed), [VALID_PAYLOAD["label"]])
+        self.assertEqual(self.labels_in(entry.added), ["Renamed"])
+
+    def test_a_create_stores_the_whole_bundle_as_added(self):
+        uid, _ = self.created()
+
+        entry = self.entries(uid)[0]
+
+        self.assertIn(VALID_PAYLOAD["label"], self.labels_in(entry.added))
+        self.assertEqual(self.triples_in(entry.removed), 0)
+
+    def test_the_payload_is_real_json_and_not_a_string(self):
+        # The pre-API rows hold a JSON-LD *string* inside a JSON column. New
+        # rows do not repeat that: the column holds structured data.
+        uid, _ = self.created()
+
+        self.assertNotIsInstance(self.entries(uid)[0].added, str)
+
+    def test_the_legacy_columns_stay_empty_on_an_api_row(self):
+        # Empty and not null. Writing a second representation into them would
+        # break the diff viewer that reads them as strings -- and so would a
+        # null, which is why these are "" rather than None.
+        uid, _ = self.created()
+
+        entry = self.entries(uid)[0]
+        self.assertEqual(entry.old_state, "")
+        self.assertEqual(entry.new_state, "")
+
+    def test_an_api_row_survives_the_existing_diff_viewer(self):
+        # That viewer renders every row of the global dump in one pass and
+        # hands both columns to a component that splits them, so one row of a
+        # type it cannot take would blank the whole page.
+        uid, _ = self.created()
+
+        entry = self.entries(uid)[0]
+        for value in (entry.old_state, entry.new_state):
+            self.assertIsInstance(value, str)
+
+    def test_the_stored_diff_round_trips_as_triples(self):
+        # Lossless: what was stored parses back to the triples that changed.
+        uid, etag = self.created()
+        self.patch(uid, {"abstract": "Ein anderer Text"}, if_match=etag)
+
+        added = self.graph_of(self.entries(uid)[1].added)
+
+        self.assertIn(
+            (bundle_iri(uid), DC.abstract, Literal("Ein anderer Text")), added
+        )
+
+    def graph_of(self, payload):
+        # The column holds structured JSON, not a JSON-LD document, so it has
+        # to be re-serialised to be parsed. That is the property under test.
+        graph = Graph()
+        if payload:
+            graph.parse(data=json.dumps(payload), format="json-ld")
+        return graph
+
+    def labels_in(self, payload):
+        return [str(o) for o in self.graph_of(payload).objects(None, RDFS.label)]
+
+    def triples_in(self, payload):
+        return len(self.graph_of(payload))
+
+
+class RenderedChangesTest(HistoryTestCase):
+    def test_the_summary_names_the_field_that_changed(self):
+        uid, etag = self.created()
+        self.patch(uid, {"abstract": "Ein anderer Text"}, if_match=etag)
+
+        entry = self.read_history(uid).data["results"][0]
+
+        changed = {change["field"] for change in entry["changes"]}
+        self.assertIn("abstract", changed)
+
+    def test_the_summary_carries_the_values_on_both_sides(self):
+        uid, etag = self.created()
+        self.patch(uid, {"abstract": "Ein anderer Text"}, if_match=etag)
+
+        changes = self.read_history(uid).data["results"][0]["changes"]
+
+        abstract = next(c for c in changes if c["field"] == "abstract")
+        self.assertEqual(abstract["removed"], [VALID_PAYLOAD["abstract"]])
+        self.assertEqual(abstract["added"], ["Ein anderer Text"])
+
+    def test_the_summary_matches_the_stored_triples(self):
+        # The rendering is computed from the diff at read time, so it cannot
+        # drift from it -- this is the test that says so.
+        uid, etag = self.created()
+        self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        entry = self.read_history(uid, expand="triples").data["results"][0]
+
+        rendered = next(c for c in entry["changes"] if c["field"] == "label")
+        stored = Graph()
+        stored.parse(data=json.dumps(entry["triples"]["added"]), format="json-ld")
+        self.assertEqual(
+            rendered["added"], [str(o) for o in stored.objects(None, RDFS.label)]
+        )
+
+    def test_a_triple_that_names_no_field_is_reported_rather_than_dropped(self):
+        # A minted contact brings its own type and label with it. Those are not
+        # bundle fields, and silently dropping them would make the summary look
+        # complete when it is not.
+        uid, etag = self.created()
+
+        self.patch(uid, {"contacts": [{"label": "A contact"}]}, if_match=etag)
+
+        changes = self.read_history(uid).data["results"][0]["changes"]
+        self.assertTrue(any(change["field"] is None for change in changes))
+        self.assertTrue(any(change["field"] == "contacts" for change in changes))
+
+    def test_the_triples_are_only_returned_when_asked_for(self):
+        uid, _ = self.created()
+
+        self.assertNotIn("triples", self.read_history(uid).data["results"][0])
+        self.assertIn(
+            "triples", self.read_history(uid, expand="triples").data["results"][0]
+        )
+
+    def test_an_unknown_expansion_is_refused(self):
+        uid, _ = self.created()
+
+        response = self.read_history(uid, expand="everything")
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+
+class HistoryReadTest(HistoryTestCase):
+    def test_the_history_is_public(self):
+        uid, _ = self.created()
+        self.client.logout()
+
+        self.assertEqual(self.read_history(uid).status_code, 200)
+
+    def test_the_actor_is_a_username_and_not_an_internal_identifier(self):
+        uid, _ = self.created()
+
+        entry = self.read_history(uid).data["results"][0]
+
+        self.assertEqual(entry["actor"], self.user.name)
+        self.assertNotIn(str(self.user.pk), str(entry["actor"]))
+
+    def test_the_newest_change_comes_first(self):
+        uid, etag = self.created()
+        self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        results = self.read_history(uid).data["results"]
+
+        self.assertEqual([entry["verb"] for entry in results], [UPDATE, CREATE])
+
+    def test_it_is_paginated(self):
+        uid, etag = self.created()
+        for number in range(1, 4):
+            etag = self.patch(uid, {"label": f"Rename {number}"}, if_match=etag)["ETag"]
+
+        page = self.read_history(uid, page_size=2)
+
+        self.assertEqual(len(page.data["results"]), 2)
+        self.assertEqual(page.data["count"], 4)
+        self.assertIsNotNone(page.data["next"])
+
+    def test_a_page_size_beyond_the_ceiling_is_capped(self):
+        # A public endpoint with an unbounded mode is a dump waiting to happen.
+        uid, _ = self.created()
+
+        page = self.read_history(uid, page_size=100000)
+
+        self.assertLessEqual(len(page.data["results"]), 100)
+
+    def test_it_shows_only_this_bundle(self):
+        first, _ = self.created()
+        second, _ = self.created({**VALID_PAYLOAD, "acronym": "OTHER"})
+
+        results = self.read_history(first).data["results"]
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(self.read_history(second).data["count"], 1)
+
+    def test_an_unknown_bundle_is_a_404(self):
+        response = self.read_history("11111111-2222-3333-4444-555555555555")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_an_identifier_that_is_not_minted_is_a_404(self):
+        self.assertEqual(self.read_history("not-a-uuid").status_code, 404)
+
+
+class LegacyRowTest(HistoryTestCase):
+    """Rows the user interface wrote, which are not migrated."""
+
+    def legacy_row(self, uid):
+        return OEKG_Modifications.objects.create(
+            bundle_id=uid,
+            user=self.user,
+            old_state='{"@graph": []}',
+            new_state='{"@graph": []}',
+        )
+
+    def test_a_legacy_row_reads_as_the_era_it_came_from(self):
+        uid, _ = self.created()
+        self.legacy_row(uid)
+
+        eras = {entry["era"] for entry in self.read_history(uid).data["results"]}
+
+        self.assertEqual(eras, {API_ERA, PRE_API_ERA})
+
+    def test_a_legacy_row_claims_no_field_level_summary(self):
+        # Null rather than an empty list: an empty list would claim that
+        # nothing changed, which is not what is known about these rows.
+        uid, _ = self.created()
+        self.legacy_row(uid)
+
+        entry = next(
+            e for e in self.read_history(uid).data["results"] if e["era"] == PRE_API_ERA
+        )
+
+        self.assertIsNone(entry["changes"])
+        self.assertIsNone(entry["verb"])
+
+    def test_a_legacy_row_keeps_its_double_encoded_payload(self):
+        uid, _ = self.created()
+        row = self.legacy_row(uid)
+
+        row.refresh_from_db()
+
+        self.assertIsInstance(row.old_state, str)
+
+
+class HistoryWriteFailureTest(HistoryTestCase):
+    """The graph is the truth; the history is the note about it."""
+
+    def failing_history(self):
+        return patch(
+            "oekg.history.OEKG_Modifications.objects.create",
+            side_effect=DatabaseError("no room at the inn"),
+        )
+
+    def test_a_create_still_succeeds(self):
+        with self.failing_history():
+            response = self.create()
+
+        self.assertEqual(response.status_code, 201, response.data)
+        uid = response.data[READ_ONLY_CONTAINER]["uid"]
+        self.assertEqual(self.client.get(self.detail_url(uid)).status_code, 200)
+
+    def test_the_gap_is_named_in_the_response(self):
+        with self.failing_history():
+            response = self.create()
+
+        self.assertFalse(response.data[READ_ONLY_CONTAINER]["history_recorded"])
+
+    def test_a_patch_still_succeeds_and_names_the_gap(self):
+        uid, etag = self.created()
+
+        with self.failing_history():
+            response = self.patch(uid, {"label": "Renamed"}, if_match=etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertFalse(response.data[READ_ONLY_CONTAINER]["history_recorded"])
+        self.assertEqual(self.client.get(self.detail_url(uid)).data["label"], "Renamed")
+
+    def test_a_successful_write_does_not_claim_a_gap(self):
+        # The key is only there when there is something to say; a client should
+        # not have to check it on every response.
+        response = self.create()
+
+        self.assertNotIn("history_recorded", response.data[READ_ONLY_CONTAINER])
+
+    def test_the_failure_is_logged(self):
+        with self.failing_history():
+            with self.assertLogs("oeplatform.oekg_history", level="ERROR") as logs:
+                self.create()
+
+        self.assertIn("oekg_history", logs.output[0])
+        self.assertIn("outcome=not_recorded", logs.output[0])
+
+
+class RealHistoryFailureTest(TestCase):
+    """A real database error, not a mocked one.
+
+    Mocking the insert proves the caller handles a raised exception; it cannot
+    prove the transaction survives it. Only a genuine rejection does that, and
+    without the savepoint the next query raises instead -- which would turn a
+    write that succeeded into a 500.
+    """
+
+    def test_a_rejected_row_does_not_poison_the_transaction(self):
+        user = myuser.objects.create_user(
+            name="history-author", email="history@example.org", affiliation=""
+        )
+
+        recorded = record_write(
+            bundle_uid="x" * 401,  # longer than the column
+            verb=CREATE,
+            actor=user,
+            version_before=0,
+            version_after=1,
+        )
+
+        self.assertFalse(recorded)
+        # The connection is still usable. This is the assertion the savepoint
+        # exists for; without it this line raises TransactionManagementError.
+        self.assertEqual(OEKG_Modifications.objects.count(), 0)
+
+
+class ChangedFieldsTest(SimpleTestCase):
+    """The renderer, without a store."""
+
+    def test_a_bundle_predicate_becomes_its_field_name(self):
+        removed, added = Graph(), Graph()
+        added.add((bundle_iri("u1"), DC.abstract, Literal("neu")))
+
+        changes = changed_fields("u1", removed, added)
+
+        self.assertEqual(
+            changes, [{"field": "abstract", "removed": [], "added": ["neu"]}]
+        )
+
+    def test_both_sides_of_one_field_are_one_change(self):
+        removed, added = Graph(), Graph()
+        removed.add((bundle_iri("u1"), DC.abstract, Literal("alt")))
+        added.add((bundle_iri("u1"), DC.abstract, Literal("neu")))
+
+        changes = changed_fields("u1", removed, added)
+
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0]["removed"], ["alt"])
+
+    def test_a_shared_predicate_is_told_apart_by_the_type_in_the_diff(self):
+        # Frameworks and models both hang off has-part, so the predicate alone
+        # cannot name the field. An added part carries its type in the same
+        # diff, and that decides it.
+        added = Graph()
+        node = URIRef("https://example.org/m1")
+        added.add((bundle_iri("u1"), HAS_PART, node))
+        added += _typed(node, OEO.OEO_00000277)
+
+        named = {change["field"] for change in changed_fields("u1", Graph(), added)}
+
+        self.assertIn("models", named)
+        self.assertNotIn("frameworks", named)
+
+    def test_an_unlinked_part_is_reported_as_unknown_rather_than_guessed(self):
+        # A patch unlinks and never deletes, so a removed part brings no type
+        # with it and the field is honestly not knowable. Guessing one of the
+        # two would put the change under the wrong heading.
+        removed = Graph()
+        removed.add((bundle_iri("u1"), HAS_PART, URIRef("https://example.org/m1")))
+
+        named = {change["field"] for change in changed_fields("u1", removed, Graph())}
+
+        self.assertEqual(named, {None})
+
+    def test_a_triple_about_another_subject_names_no_field(self):
+        added = Graph()
+        added.add((URIRef("https://example.org/c1"), RDFS.label, Literal("A contact")))
+
+        changes = changed_fields("u1", Graph(), added)
+
+        self.assertEqual(changes[0]["field"], None)
+
+    def test_nothing_changed_renders_as_nothing(self):
+        self.assertEqual(changed_fields("u1", Graph(), Graph()), [])
+
+
+class RecordWriteTest(SimpleTestCase):
+    def test_it_refuses_to_guess_a_verb(self):
+        with self.assertRaises(ValueError):
+            record_write(
+                bundle_uid="u1",
+                verb="PUT",
+                actor=None,
+                version_before=1,
+                version_after=2,
+            )
+
+
+def _typed(node, node_class):
+    from rdflib import RDF
+
+    graph = Graph()
+    graph.add((node, RDF.type, node_class))
+    graph.add((node, RDFS.label, Literal("A part")))
+    return graph

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -11,6 +11,12 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Changes
 
+- The scenario-bundle changelog page under Factsheets now also lists changes
+  made through the REST API. Those rows show who changed what and when, but no
+  side-by-side diff: the API records what changed in a newer form that this page
+  does not read yet
+  [(#2441)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2441)
+
 - The dev compose stack names the graph store host explicitly
   (`RDF_DATABASE_HOST: fuseki`) and waits for that service. Previously it relied
   on the local `securitysettings.py`, whose shipped default resolves the host to
@@ -115,6 +121,7 @@ SPDX-License-Identifier: CC0-1.0
   but per bundle and paginated, and names the actor by username rather than by
   internal id. Entries written before this release are kept exactly as they are
   and read as coming from before the API
+  [(#2441)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2441)
 
 - New management command `repair_factsheet_tags` repairs the factsheets the old
   tag editor damaged - on production 23 of 339 carry a copy of the whole tag

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -106,6 +106,16 @@ SPDX-License-Identifier: CC0-1.0
   two simultaneous creates can no longer both take an acronym both of them found
   free [(#2438)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2438)
 
+- Every write to a scenario bundle through the REST API now leaves a record, and
+  `GET /api/v0/scenario-bundles/<uid>/history/` reads it back. Previously only
+  the browser's edit path recorded anything, so creates and API writes were
+  silent. An entry says which operation it was, who made it, when, which version
+  it produced, and which triples changed; the reader renders those as field
+  names and returns the raw triples on `?expand=triples`. The history is public
+  but per bundle and paginated, and names the actor by username rather than by
+  internal id. Entries written before this release are kept exactly as they are
+  and read as coming from before the API
+
 - New management command `repair_factsheet_tags` repairs the factsheets the old
   tag editor damaged - on production 23 of 339 carry a copy of the whole tag
   table, holding 95% of all factsheet tag assignments. It reports by default and


### PR DESCRIPTION
## Summary of the discussion

Fifth of the twelve slices of the OEKG REST API, from the wayfinder map's tickets note
(slice *"Every write leaves a record, and the record reads back"*, derived from WF-08).
It lands deliberately early — directly after the guarded patch — so that every later
slice writes its own entries instead of being retrofitted with them.

The audit trail stops being silent. Today only the browser's update path writes an entry;
creates and every API write leave nothing behind. The rule here is flat — **the history is
the log of writes** — because a per-operation judgement about what is worth recording is
what makes a trail patchy, and "no entry" would then be ambiguous between *created* and
*never touched*.

**The existing model is extended rather than replaced.** Two histories split by which
client did the writing is this table's own completeness problem in a new form, so the API
writes here. That leaves two generations of row and they are deliberately not reconciled:
pre-API rows keep their JSON-LD strings inside a JSON column, untouched by any data
migration, because rewriting them in place would edit the one table whose value is being an
unaltered record — and would break the diff viewer that reads them. `verb IS NULL` is what
tells the generations apart. New rows fill the columns that make the table answerable:
which operation, which resource, which version pair. A timestamp cannot say *which change
produced a given state*; `version_before` and `version_after` can.

**The stored diff is lossless and untranslated** — no field names, no serializer
vocabulary — so a later shape change never re-interprets an old row. Field names are
computed instead at read time, from the same field table that builds the triples, so a
rendering cannot drift from what it describes. A triple that names no field is reported
under a null field rather than dropped: the type and label a minted contact brings with it
are not bundle fields, and dropping them would make a summary look complete when it is not.
Where a predicate is shared — frameworks and models both hang off has-part — the type in
the diff decides, and an unlinked part carries no type, so the field is reported as unknown
rather than guessed at. Every rendered change also names its predicate, so an entry that
could not be attributed still says what it was about.

**The graph commits first and a failed history write does not fail the request.** The two
stores cannot share a transaction; the data is the truth and the history is the note about
it, so answering `500` for a write that succeeded would provoke exactly the retry that
creates duplicates. The gap is named rather than hidden — `_meta.history_recorded` and one
structured log line — because a phantom entry would be worse: it looks like truth.

Two things about that which are worth the reviewer's attention, because both were found by
reviewing rather than by writing:

- **The insert takes a savepoint, and that is not decoration.** Without it a real rejection
  poisons the surrounding transaction and the next query raises, producing precisely the
  `500` this ordering exists to avoid. The test for it uses a real over-long value rather
  than a mock, because a mocked exception cannot poison anything — the first version of that
  test passed over the hole.
- **`record_write` says it never raises, and at first it did not hold.** Only
  `DatabaseError` was caught while serialising the diff ran inside the same `try`, so an
  rdflib failure would have escaped and turned a committed graph write into a `500`. The net
  now covers every exception, which is load-bearing rather than defensive.

**Reads are public but per bundle and paginated with a ceiling**, and name the actor by
username. WF-07's reasoning for public reads does not transfer: it rests on the SPARQL
endpoint already serving the same data, and this is in no graph. A per-bundle log is a
record about a bundle; a global one is a profile of a person's activity — which is what the
existing global dump is, and it is filed separately.

Two smaller things found while wiring it up. **API rows write `""` into the legacy payload
columns rather than `NULL`**, because the existing diff viewer hands both straight to a
component that splits them and renders every row in one pass, so one null would blank the
whole page. And **`bundle_exists` asks with an `ASK` and lets a store outage raise**: "there
is no such bundle" and "I could not find out" are different answers, and only one of them is
a `404`.

## Type of change (CHANGELOG.md)

### Features

- Every write to a scenario bundle through the REST API now leaves a record,
  and `GET /api/v0/scenario-bundles/<uid>/history/` reads it back. Previously
  only the browser's edit path recorded anything, so creates and API writes were
  silent. An entry says which operation it was, who made it, when, which version
  it produced, and which triples changed; the reader renders those as field
  names and returns the raw triples on `?expand=triples`. The history is public
  but per bundle and paginated, and names the actor by username rather than by
  internal id. Entries written before this release are kept exactly as they are
  and read as coming from before the API
  [(#2441)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2441)

### Changes

- The scenario-bundle changelog page under Factsheets now also lists changes
  made through the REST API. Those rows show who changed what and when, but no
  side-by-side diff: the API records what changed in a newer form that this page
  does not read yet
  [(#2441)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2441)

### Bugs

None as a separate entry. Nothing released was broken: both defects fixed here —
the un-savepointed insert and the too-narrow exception net — were introduced and
fixed inside this PR. Recording them under Bugs would tell a reader of the release
notes that something they were running had failed, which is not true.

### Removed

None.

### Documentation updates

None, for the same reason as #2438: the API's own documentation is a separate,
currently blocked strand of the map. WF-13 (where the API description comes from)
gates WF-14 (developer documentation), `drf-spectacular` is already wired on an
unmerged branch that ticket has to reconcile with, and the existing
`docs/oeplatform-code/web-api/oekg-api/oekg.yaml` describes the SPARQL passthrough
rather than the bundle CRUD. The reasoning lives in the module docstrings meanwhile
— `oekg/history.py` states why the diff is stored untranslated and why the graph
commits first.

**This is now the second slice to leave documentation open, and the gap is the map's
actual frontier.** WF-13 has been the next unblocked ticket since 2026-09-08 and
nothing has been done on it, while each slice adds endpoints that will have to be
described afterwards.

## Workflow checklist

### Automation

Closes #2442

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/) — deliberately not
      done, see *Documentation updates* above

### Reviewer

- [ ] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done