### PR TITLE
Give scenario factsheets their own URLs

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -74,6 +74,7 @@ from api.views import (
 )
 from oekg.api_views import ScenarioBundleAPIView, ScenarioBundleCollectionAPIView
 from oekg.history_views import ScenarioBundleHistoryAPIView
+from oekg.scenario_views import ScenarioAPIView, ScenarioCollectionAPIView
 
 app_name = "api"
 
@@ -317,6 +318,18 @@ urlpatterns_v0 = [
         "scenario-bundles/<uid>/history/",
         ScenarioBundleHistoryAPIView.as_view(),
         name="scenario-bundle-history",
+    ),
+    # Scenario factsheets are sub-resources because the shape gives them their
+    # own has-uuid. Plural, like the bundle collection above it.
+    path(
+        "scenario-bundles/<uid>/scenarios/",
+        ScenarioCollectionAPIView.as_view(),
+        name="scenario-bundle-scenarios",
+    ),
+    path(
+        "scenario-bundles/<uid>/scenarios/<sid>/",
+        ScenarioAPIView.as_view(),
+        name="scenario-bundle-scenario",
     ),
     path(
         "datasets/",

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -40,11 +40,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 """  # noqa: 501
 
 import logging
-from typing import Optional
 
 from django.db import DatabaseError
 from django.urls import reverse
-from rdflib import RDFS, Graph, Literal, URIRef
+from rdflib import Graph, Literal
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -66,26 +65,30 @@ from oekg.bundles import (
     bundle_delta,
     bundle_iri,
     bundle_payload,
-    bundle_subgraph,
     mint_bundle_uid,
     referenced_node_iris,
 )
 from oekg.graph_store import GraphStore, GraphStoreError
 from oekg.history import CREATE, UPDATE, record_write
-from oekg.permissions import may_write_bundle
-from oekg.serializers import READ_ONLY_CONTAINER, ScenarioBundleSerializer
+from oekg.reads import labels_of, read_bundle
+from oekg.scenario_views import scenario_bodies
+from oekg.serializers import (
+    READ_ONLY_CONTAINER,
+    ScenarioBundleCreateSerializer,
+    ScenarioBundleSerializer,
+)
 from oekg.shape import ShapeUnavailable
 from oekg.validation import validate_post_state
 from oekg.versioning import (
     FIRST_VERSION,
     UNVERSIONED,
     BundleVersion,
-    guarded_operation,
     mint_write_token,
     read_version,
     version_triples,
     write_applied,
 )
+from oekg.writes import Refused, open_write
 
 logger = logging.getLogger("oeplatform")
 
@@ -97,7 +100,7 @@ class ScenarioBundleCollectionAPIView(APIView):
     throttle_classes = [ScenarioBundleThrottle, ScenarioBundleUserThrottle]
 
     def post(self, request):
-        serializer = ScenarioBundleSerializer(data=request.data)
+        serializer = ScenarioBundleCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         payload = serializer.validated_data
 
@@ -110,7 +113,7 @@ class ScenarioBundleCollectionAPIView(APIView):
             if _acronym_taken(store, acronym):
                 return _acronym_conflict(acronym)
 
-            known_labels = _labels_of(store, referenced_node_iris(payload))
+            known_labels = labels_of(store, referenced_node_iris(payload))
             renamed = _renames(payload, known_labels)
             if renamed:
                 return _rename_refused(renamed)
@@ -120,7 +123,13 @@ class ScenarioBundleCollectionAPIView(APIView):
 
             violations = validate_post_state(post_state)
             if violations:
-                return _does_not_conform(violations)
+                return Response(
+                    {
+                        "detail": "The bundle does not conform to the OEKG shape.",
+                        "violations": [v.as_dict() for v in violations],
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
             # The uniqueness check above is friendly, not sufficient: it is a
             # separate request, so two creates can both pass it. The guard here
@@ -177,7 +186,7 @@ class ScenarioBundleCollectionAPIView(APIView):
         )
 
         version = BundleVersion(FIRST_VERSION, token)
-        body = _represent(uid, bundle_payload(post_state, uid), version)
+        body = _represent(uid, post_state, version)
         if not owned:
             body[READ_ONLY_CONTAINER]["ownership_recorded"] = False
         _note_history_gap(body, recorded)
@@ -211,19 +220,16 @@ class ScenarioBundleAPIView(APIView):
 
         store = GraphStore.from_settings()
         try:
-            subgraph = _read_bundle(store, uid)
+            subgraph = read_bundle(store, uid)
             if subgraph is None:
                 return no_such_bundle(uid)
             version = read_version(store, uid)
         except GraphStoreError as error:
             return store_unavailable(error, "read")
 
-        return _bundle_response(uid, bundle_payload(subgraph, uid), version)
+        return _bundle_response(uid, subgraph, version)
 
     def patch(self, request, uid):
-        if not is_minted_identifier(uid):
-            return no_such_bundle(uid)
-
         serializer = ScenarioBundleSerializer(data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         payload = dict(serializer.validated_data)
@@ -239,165 +245,28 @@ class ScenarioBundleAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        store = GraphStore.from_settings()
         try:
-            # Existence first, as it is for the two-step delete: one order for
-            # the whole API rather than one per endpoint. Reads are public, so
-            # answering 404 before authorisation reveals nothing a GET would
-            # not.
-            pre_state = _read_bundle(store, uid)
-            if pre_state is None:
-                return no_such_bundle(uid)
-
-            if not may_write_bundle(request.user, uid):
-                return _not_the_owner()
-
-            version = read_version(store, uid)
-            refusal = _precondition_refusal(request, version)
-            if refusal is not None:
-                return refusal
-
-            known_labels = _labels_of(store, referenced_node_iris(payload))
+            write = open_write(request, uid)
+            known_labels = write.labels_of(referenced_node_iris(payload))
             renamed = _renames(payload, known_labels)
             if renamed:
                 return _rename_refused(renamed)
 
-            removed, added = bundle_delta(uid, payload, pre_state, known_labels)
-            post_state = bundle_subgraph(pre_state - removed + added, uid)
-
-            violations = validate_post_state(post_state)
-            if violations:
-                return _does_not_conform(violations)
-
-            token = mint_write_token()
-            store.update(
-                guarded_operation(
-                    store, uid, version, token, delete=removed, insert=added
-                )
-            )
-            if not write_applied(store, uid, token):
-                # The guard held nothing back that the client could have known
-                # about: the bundle moved -- or went away -- after the read this
-                # request had to make.
-                return Response(
-                    {
-                        "detail": (
-                            "The bundle changed while this request was being "
-                            "prepared, so nothing was written. Read it again, "
-                            "apply the change to what you get back, and retry."
-                        )
-                    },
-                    status=status.HTTP_409_CONFLICT,
-                )
+            removed, added = bundle_delta(uid, payload, write.pre_state, known_labels)
+            write.apply(removed=removed, added=added, verb=UPDATE)
+        except Refused as refusal:
+            return refusal.response
         except ShapeUnavailable as error:
             return shape_unavailable(error)
         except GraphStoreError as error:
             return store_unavailable(error, "written to")
 
-        written = BundleVersion(version.number + 1, token)
-        recorded = record_write(
-            bundle_uid=uid,
-            verb=UPDATE,
-            actor=request.user,
-            version_before=version.number,
-            version_after=written.number,
-            removed=removed,
-            added=added,
-        )
         return _bundle_response(
             uid,
-            bundle_payload(post_state, uid),
-            written,
-            history_recorded=recorded,
+            write.post_state,
+            write.version,
+            history_recorded=write.history_recorded,
         )
-
-
-def _precondition_refusal(request, version: BundleVersion) -> Optional[Response]:
-    """Why this request may not proceed on its precondition, if it may not."""
-    named = _versions_named(request)
-    if named is None:
-        return Response(
-            {
-                "detail": (
-                    "This write needs an If-Match header carrying the version "
-                    "you read, so that it cannot silently overwrite a change "
-                    f"made since. The bundle is at {version.etag}."
-                )
-            },
-            status=status.HTTP_428_PRECONDITION_REQUIRED,
-        )
-    if str(version.number) not in named:
-        return Response(
-            {
-                "detail": (
-                    "The bundle is not at the version this request expects, so "
-                    "nothing was written. It is at "
-                    f"{version.etag}. Read it again and apply the change to "
-                    "what you get back."
-                )
-            },
-            status=status.HTTP_412_PRECONDITION_FAILED,
-        )
-    return None
-
-
-def _versions_named(request):
-    """The versions an ``If-Match`` names, or ``None`` if it names none.
-
-    Lenient in what it accepts and strict in what it emits: a weak validator or
-    a bare number is read as the version it plainly is, while a value that is
-    not a version simply matches nothing and is refused as stale.
-
-    ``*`` names no version. It is a legal header value, and it satisfies the
-    letter of the precondition while withholding the one thing the precondition
-    is for, so it reads here as an absent header rather than as a match.
-    """
-    header = request.headers.get("If-Match")
-    if header is None:
-        return None
-    named = []
-    for entry in header.split(","):
-        entry = entry.strip()
-        if entry == "*":
-            return None
-        if entry.startswith("W/"):
-            entry = entry[2:].strip()
-        named.append(entry.strip('"'))
-    return named
-
-
-def _read_bundle(store: GraphStore, uid: str) -> Optional[Graph]:
-    """A bundle and one hop out, or ``None`` if there is no such bundle.
-
-    One hop is the whole bundle: its fields are either literals, picked IRIs,
-    or nodes carrying a type and a label. The version node is unreachable from
-    here, because it points at the bundle rather than away from it -- which is
-    what keeps bookkeeping out of the payload without any filtering.
-    """
-    subgraph = store.construct(
-        "CONSTRUCT { ?s ?p ?o } WHERE { "
-        f"  VALUES ?root {{ {bundle_iri(uid).n3()} }} "
-        f"  ?root a {BUNDLE_CLASS.n3()} . "
-        "  { ?root ?p ?o . BIND(?root AS ?s) } "
-        "  UNION "
-        "  { ?root ?q ?s . ?s ?p ?o } "
-        "}"
-    )
-    if (bundle_iri(uid), None, None) not in subgraph:
-        return None
-    return subgraph
-
-
-def _labels_of(store: GraphStore, iris: list) -> dict:
-    """The label each of these nodes already carries, for the ones that exist."""
-    if not iris:
-        return {}
-    values = " ".join(URIRef(iri).n3() for iri in iris)
-    rows = store.select(
-        "SELECT ?node ?label WHERE { VALUES ?node { %s } ?node %s ?label }"
-        % (values, RDFS.label.n3())
-    )
-    return {row["node"]: row["label"] for row in rows}
 
 
 def _renames(payload: dict, known_labels: dict) -> list:
@@ -462,16 +331,29 @@ def _acronym_pattern(acronym: str) -> str:
     )
 
 
-def _represent(uid: str, payload: dict, version: BundleVersion) -> dict:
-    """A read returns exactly what a write accepts, plus read-only data."""
-    return {
-        **payload,
+def _represent(
+    uid: str, graph: Graph, version: BundleVersion, scenarios: bool = True
+) -> dict:
+    """A read returns exactly what a write accepts, plus read-only data.
+
+    **Scenarios are nested here and rejected on `PATCH`.** That looks
+    inconsistent until you notice which write each is for: a read sent back to
+    `POST` copies the whole bundle, scenarios included, and later the replace
+    endpoint takes exactly this shape -- while a `PATCH` is partial by nature
+    and nobody sends a whole read to one. Nesting on read is what lets a client
+    send back what it read without stripping anything.
+    """
+    body = {
+        **bundle_payload(graph, uid),
         READ_ONLY_CONTAINER: {
             "uid": uid,
             "iri": str(bundle_iri(uid)),
             "version": version.number,
         },
     }
+    if scenarios:
+        body["scenarios"] = scenario_bodies(graph, uid)
+    return body
 
 
 def _note_history_gap(body: dict, recorded: bool) -> dict:
@@ -488,28 +370,15 @@ def _note_history_gap(body: dict, recorded: bool) -> dict:
 
 def _bundle_response(
     uid: str,
-    payload: dict,
+    graph: Graph,
     version: BundleVersion,
     history_recorded: bool = True,
 ) -> Response:
     """The body, plus the entity tag every read has to carry."""
-    body = _note_history_gap(_represent(uid, payload, version), history_recorded)
+    body = _note_history_gap(_represent(uid, graph, version), history_recorded)
     response = Response(body)
     response["ETag"] = version.etag
     return response
-
-
-def _not_the_owner() -> Response:
-    return Response(
-        {
-            "detail": (
-                "Only an owner of this scenario bundle may change it. A bundle "
-                "with no recorded owner can be changed by an administrator "
-                "only."
-            )
-        },
-        status=status.HTTP_403_FORBIDDEN,
-    )
 
 
 def _acronym_conflict(acronym: str) -> Response:
@@ -534,16 +403,6 @@ def _rename_refused(renamed: list) -> Response:
                 "to mint a new node."
             ),
             "conflicts": renamed,
-        },
-        status=status.HTTP_400_BAD_REQUEST,
-    )
-
-
-def _does_not_conform(violations: list) -> Response:
-    return Response(
-        {
-            "detail": "The bundle does not conform to the OEKG shape.",
-            "violations": [violation.as_dict() for violation in violations],
         },
         status=status.HTTP_400_BAD_REQUEST,
     )

--- a/oekg/api_views.py
+++ b/oekg/api_views.py
@@ -60,7 +60,9 @@ from oekg.api_support import (
 )
 from oekg.bundles import (
     BUNDLE_CLASS,
+    BUNDLE_FIELDS,
     DC,
+    SCENARIO_FIELDS,
     build_bundle_graph,
     bundle_delta,
     bundle_iri,
@@ -88,7 +90,7 @@ from oekg.versioning import (
     version_triples,
     write_applied,
 )
-from oekg.writes import Refused, open_write
+from oekg.writes import open_bundle, refuse_renames
 
 logger = logging.getLogger("oeplatform")
 
@@ -113,10 +115,10 @@ class ScenarioBundleCollectionAPIView(APIView):
             if _acronym_taken(store, acronym):
                 return _acronym_conflict(acronym)
 
-            known_labels = labels_of(store, referenced_node_iris(payload))
-            renamed = _renames(payload, known_labels)
-            if renamed:
-                return _rename_refused(renamed)
+            known_labels = labels_of(store, _all_referenced_iris(payload))
+            refuse_renames(payload, known_labels, BUNDLE_FIELDS)
+            for scenario in payload.get("scenarios") or []:
+                refuse_renames(scenario, known_labels, SCENARIO_FIELDS)
 
             uid = mint_bundle_uid()
             post_state = build_bundle_graph(uid, payload, known_labels)
@@ -246,16 +248,13 @@ class ScenarioBundleAPIView(APIView):
             )
 
         try:
-            write = open_write(request, uid)
+            write = open_bundle(request, uid)
+            write.require_write(request)
             known_labels = write.labels_of(referenced_node_iris(payload))
-            renamed = _renames(payload, known_labels)
-            if renamed:
-                return _rename_refused(renamed)
+            refuse_renames(payload, known_labels, BUNDLE_FIELDS)
 
             removed, added = bundle_delta(uid, payload, write.pre_state, known_labels)
             write.apply(removed=removed, added=added, verb=UPDATE)
-        except Refused as refusal:
-            return refusal.response
         except ShapeUnavailable as error:
             return shape_unavailable(error)
         except GraphStoreError as error:
@@ -269,36 +268,12 @@ class ScenarioBundleAPIView(APIView):
         )
 
 
-def _renames(payload: dict, known_labels: dict) -> list:
-    """Referenced nodes whose label the payload disagrees with.
-
-    The API offers no rename. Shared IRIs stay shared -- that is the point of a
-    graph -- but a shared contact or organisation is cited by other bundles, so
-    letting one payload rewrite its label would change every one of them.
-    """
-    conflicts = []
-    for iri in referenced_node_iris(payload):
-        if iri not in known_labels:
-            continue
-        for entry in _entries_for(payload, iri):
-            if entry["label"] != known_labels[iri]:
-                conflicts.append(
-                    {
-                        "iri": iri,
-                        "stored_label": known_labels[iri],
-                        "sent_label": entry["label"],
-                    }
-                )
-    return conflicts
-
-
-def _entries_for(payload: dict, iri: str) -> list:
-    return [
-        entry
-        for field_name in ("contacts", "organisations", "funders")
-        for entry in (payload.get(field_name) or [])
-        if entry.get("iri") == iri
-    ]
+def _all_referenced_iris(payload: dict) -> list:
+    """Existing node IRIs a create points at, its nested scenarios included."""
+    iris = referenced_node_iris(payload, BUNDLE_FIELDS)
+    for scenario in payload.get("scenarios") or []:
+        iris += referenced_node_iris(scenario, SCENARIO_FIELDS)
+    return iris
 
 
 def _acronym_taken(store: GraphStore, acronym: str) -> bool:
@@ -331,9 +306,7 @@ def _acronym_pattern(acronym: str) -> str:
     )
 
 
-def _represent(
-    uid: str, graph: Graph, version: BundleVersion, scenarios: bool = True
-) -> dict:
+def _represent(uid: str, graph: Graph, version: BundleVersion) -> dict:
     """A read returns exactly what a write accepts, plus read-only data.
 
     **Scenarios are nested here and rejected on `PATCH`.** That looks
@@ -351,8 +324,7 @@ def _represent(
             "version": version.number,
         },
     }
-    if scenarios:
-        body["scenarios"] = scenario_bodies(graph, uid)
+    body["scenarios"] = scenario_bodies(graph, uid)
     return body
 
 
@@ -391,18 +363,4 @@ def _acronym_conflict(acronym: str) -> Response:
             )
         },
         status=status.HTTP_409_CONFLICT,
-    )
-
-
-def _rename_refused(renamed: list) -> Response:
-    return Response(
-        {
-            "detail": (
-                "A shared node cannot be renamed through this API. Reference "
-                "it by iri and send the label it already has, or omit the iri "
-                "to mint a new node."
-            ),
-            "conflicts": renamed,
-        },
-        status=status.HTTP_400_BAD_REQUEST,
     )

--- a/oekg/bundles.py
+++ b/oekg/bundles.py
@@ -1,8 +1,15 @@
-"""A scenario bundle, as triples and as a payload.
+"""A scenario bundle and its parts, as triples and as payloads.
 
-One field table drives both directions, so a read returns exactly what a write
-accepts and neither can drift from the other. The table is traceable to the
-shape: every entry names the property the shape validates.
+One field table per resource drives both directions, so a read returns exactly
+what a write accepts and neither can drift from the other. Each table is
+traceable to the shape: every entry names the property the shape validates.
+
+The machinery below is written against a *subject and a table*, not against the
+bundle, because a scenario factsheet is the same problem one level down -- a
+closed set of fields, some literal, some picked from the shape's own lists,
+some minted nodes. Two tables today; study reports and dataset links make four,
+and that is the point at which the machinery should probably move into a module
+of its own.
 
 Three decisions are worth stating here rather than leaving to be inferred:
 
@@ -34,18 +41,28 @@ OBO = Namespace("http://purl.obolibrary.org/obo/")
 DC = Namespace("http://purl.org/dc/terms/")
 
 BUNDLE_CLASS = OEO.OEO_00020227
+SCENARIO_CLASS = OEO.OEO_00000365
 HAS_PART = OBO.BFO_0000051
 HAS_IRI = OEO.OEO_00390094
+HAS_UUID = OEO.OEO_00390095
+
+# How deep a resource's own graph goes. Bundle -> scenario -> study region ->
+# reference is the longest chain the shape allows, so a read that goes three
+# hops sees a whole bundle and a read that goes fewer does not. Bounded rather
+# than a transitive closure: this is a public endpoint, and a fixed depth
+# cannot be talked into walking somewhere large.
+BUNDLE_DEPTH = 3
 
 # Kinds of field, which decide how a value becomes triples and back again.
-LITERAL = "literal"  # a plain string on the bundle
+LITERAL = "literal"  # a plain string on the resource
 ENUM = "enum"  # IRIs picked from one of the shape's sh:in lists
 NODE = "node"  # a referenced or minted node: {iri, label}
-PART = "part"  # a bundle-local node reached by has-part: {label, iri}
+PART = "part"  # a resource-local node reached by has-part: {label, iri}
+DATES = "dates"  # a set of xsd:dateTime literals
 
 
 @dataclass(frozen=True)
-class BundleField:
+class ResourceField:
     name: str
     predicate: URIRef
     kind: str
@@ -55,24 +72,45 @@ class BundleField:
 
 # The closed bundle field set: these and nothing else.
 BUNDLE_FIELDS = (
-    BundleField("label", RDFS.label, LITERAL),
-    BundleField("acronym", DC.acronym, LITERAL),
-    BundleField("abstract", DC.abstract, LITERAL),
-    BundleField("descriptors", OEO.OEO_00390071, ENUM),
-    BundleField("sector_divisions", OEO.OEO_00390079, ENUM),
-    BundleField("sectors", OEO.OEO_00020439, ENUM),
-    BundleField("technologies", OEO.OEO_00020438, ENUM),
-    BundleField("energy_carriers", OEO.OEO_00020432, ENUM),
-    BundleField("contacts", OEO.OEO_00000508, NODE, OEO.OEO_00000107, "contact"),
-    BundleField(
+    ResourceField("label", RDFS.label, LITERAL),
+    ResourceField("acronym", DC.acronym, LITERAL),
+    ResourceField("abstract", DC.abstract, LITERAL),
+    ResourceField("descriptors", OEO.OEO_00390071, ENUM),
+    ResourceField("sector_divisions", OEO.OEO_00390079, ENUM),
+    ResourceField("sectors", OEO.OEO_00020439, ENUM),
+    ResourceField("technologies", OEO.OEO_00020438, ENUM),
+    ResourceField("energy_carriers", OEO.OEO_00020432, ENUM),
+    ResourceField("contacts", OEO.OEO_00000508, NODE, OEO.OEO_00000107, "contact"),
+    ResourceField(
         "organisations", OEO.OEO_00000510, NODE, OEO.OEO_00030022, "organisation"
     ),
-    BundleField("funders", OEO.OEO_00000509, NODE, OEO.OEO_00090001, "funder"),
-    BundleField("frameworks", HAS_PART, PART, OEO.OEO_00000172, "framework"),
-    BundleField("models", HAS_PART, PART, OEO.OEO_00000277, "model"),
+    ResourceField("funders", OEO.OEO_00000509, NODE, OEO.OEO_00090001, "funder"),
+    ResourceField("frameworks", HAS_PART, PART, OEO.OEO_00000172, "framework"),
+    ResourceField("models", HAS_PART, PART, OEO.OEO_00000277, "model"),
 )
 
-_FIELDS_BY_NAME = {field.name: field for field in BUNDLE_FIELDS}
+# The closed scenario-factsheet field set. A scenario carries its own has-uuid,
+# which is what makes it addressable rather than a field of its parent -- and
+# that uuid is the server's to mint, so it is not in this table: no client
+# supplies an identifier anywhere in this API.
+SCENARIO_FIELDS = (
+    ResourceField("label", RDFS.label, LITERAL),
+    ResourceField("acronym", DC.acronym, LITERAL),
+    ResourceField("abstract", DC.abstract, LITERAL),
+    ResourceField("scenario_types", OEO.OEO_00390073, ENUM),
+    ResourceField("study_regions", OEO.OEO_00020220, NODE, OEO.OEO_00020032, "region"),
+    ResourceField(
+        "interacting_regions", OEO.OEO_00020222, NODE, OEO.OEO_00020036, "region"
+    ),
+    ResourceField("years", OEO.OEO_00020440, DATES),
+)
+
+# Keyed by the table itself -- tuples of frozen dataclasses are hashable, so a
+# caller asks in the table it already holds rather than naming it twice.
+_BY_NAME = {
+    table: {field.name: field for field in table}
+    for table in (BUNDLE_FIELDS, SCENARIO_FIELDS)
+}
 
 
 def mint_bundle_uid() -> str:
@@ -85,25 +123,75 @@ def bundle_iri(uid: str) -> URIRef:
     return OEKG[uid]
 
 
-def referenced_node_iris(payload: dict) -> list:
+def mint_scenario_uid() -> str:
+    """A new scenario identifier. The server's to give, never the client's."""
+    return str(uuid.uuid4())
+
+
+def scenario_iri(sid: str) -> URIRef:
+    """The IRI a scenario this API minted lives at.
+
+    Derived, but **not** the identity: the identity is the has-uuid literal, so
+    a scenario the user interface wrote -- whose IRI this API did not choose --
+    is still reachable by the same identifier its URL carries.
+    """
+    return OEKG[f"scenario/{sid}"]
+
+
+def scenario_nodes(graph: Graph, uid: str) -> list:
+    """Every scenario factsheet hanging off this bundle, in the graph given."""
+    return [
+        node
+        for node in graph.objects(bundle_iri(uid), HAS_PART)
+        if (node, RDF.type, SCENARIO_CLASS) in graph
+    ]
+
+
+def scenario_uid(graph: Graph, node: URIRef) -> Optional[str]:
+    """The identifier a scenario node carries, as the shape requires it to."""
+    value = graph.value(node, HAS_UUID)
+    return None if value is None else str(value)
+
+
+def find_scenario(graph: Graph, uid: str, sid: str) -> Optional[URIRef]:
+    """The scenario of this bundle with identifier ``sid``, if it has one.
+
+    By the has-uuid literal rather than by rebuilding the IRI, so a scenario
+    written before this API existed is addressable too.
+    """
+    for node in scenario_nodes(graph, uid):
+        if scenario_uid(graph, node) == sid:
+            return node
+    return None
+
+
+def referenced_node_iris(payload: dict, fields: tuple = BUNDLE_FIELDS) -> list:
     """Every existing node IRI the payload points at, across all node fields."""
     iris = []
-    for field in BUNDLE_FIELDS:
+    for field in fields:
         if field.kind != NODE:
             continue
         for entry in payload.get(field.name) or []:
             if entry.get("iri"):
                 iris.append(entry["iri"])
+    for scenario in payload.get("scenarios") or []:
+        iris += referenced_node_iris(scenario, SCENARIO_FIELDS)
     return iris
 
 
-def bundle_field(name: str) -> BundleField:
-    """The one entry in the field table called ``name``."""
-    return _FIELDS_BY_NAME[name]
+def field_named(fields: tuple, name: str) -> ResourceField:
+    """The one entry in ``fields`` called ``name``."""
+    return _BY_NAME[fields][name]
 
 
-def build_bundle_graph(uid: str, payload: dict, known_labels: dict = None) -> Graph:
-    """Assemble the triples a bundle payload means.
+def resource_triples(
+    subject: URIRef,
+    node_class: URIRef,
+    fields: tuple,
+    payload: dict,
+    known_labels: dict = None,
+) -> Graph:
+    """Assemble the triples one resource's payload means.
 
     The result is the post-state to validate and, unchanged, the thing to
     write: nothing is added between validating and writing.
@@ -115,15 +203,52 @@ def build_bundle_graph(uid: str, payload: dict, known_labels: dict = None) -> Gr
     cite carrying two labels, violating sh:maxCount 1 for all of them.
     """
     graph = Graph()
-    graph.add((bundle_iri(uid), RDF.type, BUNDLE_CLASS))
-    for field in BUNDLE_FIELDS:
+    graph.add((subject, RDF.type, node_class))
+    for field in fields:
         if field.name in payload:
-            graph += field_triples(uid, field, payload[field.name], known_labels)
+            graph += field_triples(subject, field, payload[field.name], known_labels)
+    return graph
+
+
+def build_bundle_graph(uid: str, payload: dict, known_labels: dict = None) -> Graph:
+    """A whole bundle, including any scenarios nested in the payload.
+
+    Nesting is accepted here and nowhere else on the write path: a bundle
+    `POST` builds its scenarios with it, while a bundle `PATCH` cannot reach
+    one. That asymmetry is what lets a pipeline create a whole bundle in one
+    call without giving any call the power to drop its parts by omission.
+    """
+    graph = resource_triples(
+        bundle_iri(uid), BUNDLE_CLASS, BUNDLE_FIELDS, payload, known_labels
+    )
+    for scenario in payload.get("scenarios") or []:
+        graph += build_scenario_graph(
+            bundle_iri(uid), mint_scenario_uid(), scenario, known_labels
+        )
+    return graph
+
+
+def build_scenario_graph(
+    bundle: URIRef, sid: str, payload: dict, known_labels: dict = None
+) -> Graph:
+    """One scenario factsheet, linked to its bundle and carrying its identity.
+
+    The uuid goes in twice on purpose: once as the literal the shape requires
+    and the URL names, and once inside the minted IRI. The literal is the
+    identity -- a scenario the user interface wrote has an IRI this API did not
+    choose, and a lookup by literal finds it anyway.
+    """
+    node = scenario_iri(sid)
+    graph = resource_triples(
+        node, SCENARIO_CLASS, SCENARIO_FIELDS, payload, known_labels
+    )
+    graph.add((bundle, HAS_PART, node))
+    graph.add((node, HAS_UUID, Literal(sid)))
     return graph
 
 
 def field_triples(
-    uid: str, field: BundleField, value, known_labels: dict = None
+    subject: URIRef, field: ResourceField, value, known_labels: dict = None
 ) -> Graph:
     """The triples one field's value means, and nothing else.
 
@@ -134,13 +259,15 @@ def field_triples(
     """
     known_labels = known_labels or {}
     graph = Graph()
-    subject = bundle_iri(uid)
     if field.kind == LITERAL:
         if value is not None and value != "":
             graph.add((subject, field.predicate, Literal(value)))
     elif field.kind == ENUM:
         for iri in value:
             graph.add((subject, field.predicate, URIRef(iri)))
+    elif field.kind == DATES:
+        for moment in value:
+            graph.add((subject, field.predicate, Literal(moment)))
     elif field.kind == NODE:
         for entry in value:
             iri = entry.get("iri")
@@ -168,8 +295,8 @@ def field_triples(
     return graph
 
 
-def linked_field_triples(graph: Graph, uid: str, field: BundleField) -> Graph:
-    """The triples that currently attach ``field``'s values to the bundle.
+def linked_field_triples(graph: Graph, subject: URIRef, field: ResourceField) -> Graph:
+    """The triples that currently attach ``field``'s values to ``subject``.
 
     What a patch of that field removes -- **the links only.** A referenced
     contact, organisation or funder is shared with other bundles, and a
@@ -187,7 +314,6 @@ def linked_field_triples(graph: Graph, uid: str, field: BundleField) -> Graph:
     Frameworks and models share the has-part predicate, so the type is what
     tells them apart. Deleting by predicate alone would take both.
     """
-    subject = bundle_iri(uid)
     triples = Graph()
     for obj in graph.objects(subject, field.predicate):
         if field.kind == PART and (obj, RDF.type, field.node_class) not in graph:
@@ -196,8 +322,12 @@ def linked_field_triples(graph: Graph, uid: str, field: BundleField) -> Graph:
     return triples
 
 
-def bundle_delta(
-    uid: str, payload: dict, pre_state: Graph, known_labels: dict = None
+def resource_delta(
+    subject: URIRef,
+    fields: tuple,
+    payload: dict,
+    pre_state: Graph,
+    known_labels: dict = None,
 ) -> tuple:
     """What a patch of ``payload`` removes and what it adds. Nothing else.
 
@@ -212,39 +342,57 @@ def bundle_delta(
     """
     removed, added = Graph(), Graph()
     for name, value in payload.items():
-        field = bundle_field(name)
-        removed += linked_field_triples(pre_state, uid, field)
-        added += field_triples(uid, field, value, known_labels)
+        field = field_named(fields, name)
+        removed += linked_field_triples(pre_state, subject, field)
+        added += field_triples(subject, field, value, known_labels)
     return removed, added
 
 
+def bundle_delta(
+    uid: str, payload: dict, pre_state: Graph, known_labels: dict = None
+) -> tuple:
+    """``resource_delta`` for a bundle."""
+    return resource_delta(
+        bundle_iri(uid), BUNDLE_FIELDS, payload, pre_state, known_labels
+    )
+
+
 def bundle_subgraph(graph: Graph, uid: str) -> Graph:
-    """``graph`` narrowed to the bundle and one hop out, as a read returns it.
+    """``graph`` narrowed to the bundle, as deep as a read goes.
 
     Applied to a patch's post-state, this is what makes "validate the
     post-state" mean the state that will actually read back: a node a patch
     unlinked is no longer part of the bundle, so it is no longer part of what
     the shape is asked about.
+
+    It walks to the same depth the read query does, because the two have to
+    agree: the post-state validated must be the state a subsequent read
+    returns, and a pruner that stopped shorter would hide a scenario's regions
+    from the validator.
     """
-    subject = bundle_iri(uid)
     narrowed = Graph()
-    for predicate, obj in graph.predicate_objects(subject):
-        narrowed.add((subject, predicate, obj))
-        if isinstance(obj, URIRef):
-            for node_predicate, node_object in graph.predicate_objects(obj):
-                narrowed.add((obj, node_predicate, node_object))
+    reached = {bundle_iri(uid)}
+    frontier = {bundle_iri(uid)}
+    for _ in range(BUNDLE_DEPTH + 1):
+        beyond = set()
+        for subject in frontier:
+            for predicate, obj in graph.predicate_objects(subject):
+                narrowed.add((subject, predicate, obj))
+                if isinstance(obj, URIRef) and obj not in reached:
+                    reached.add(obj)
+                    beyond.add(obj)
+        frontier = beyond
     return narrowed
 
 
-def bundle_payload(graph: Graph, uid: str) -> dict:
-    """Read a bundle subgraph back into exactly what a write would accept."""
-    subject = bundle_iri(uid)
+def resource_payload(graph: Graph, subject: URIRef, fields: tuple) -> dict:
+    """Read one resource's triples back into exactly what a write would accept."""
     payload = {}
-    for field in BUNDLE_FIELDS:
+    for field in fields:
         if field.kind == LITERAL:
             value = graph.value(subject, field.predicate)
             payload[field.name] = None if value is None else str(value)
-        elif field.kind == ENUM:
+        elif field.kind in (ENUM, DATES):
             payload[field.name] = sorted(
                 str(obj) for obj in graph.objects(subject, field.predicate)
             )
@@ -275,7 +423,23 @@ def bundle_payload(graph: Graph, uid: str) -> dict:
     return payload
 
 
-def _minted(field: BundleField) -> URIRef:
+def bundle_payload(graph: Graph, uid: str) -> dict:
+    """A bundle's own fields. **Scenarios are not in here.**
+
+    They have their own URLs, so a bundle read names them rather than nesting
+    them -- the same asymmetry as the write side, from the other direction. The
+    view adds that naming; keeping it out of this function is what lets a read
+    be sent straight back to `POST`, where `scenarios` means *create these*.
+    """
+    return resource_payload(graph, bundle_iri(uid), BUNDLE_FIELDS)
+
+
+def scenario_payload(graph: Graph, node: URIRef) -> dict:
+    """One scenario factsheet's fields."""
+    return resource_payload(graph, node, SCENARIO_FIELDS)
+
+
+def _minted(field: ResourceField) -> URIRef:
     return OEKG[f"{field.mint_segment}/{uuid.uuid4()}"]
 
 

--- a/oekg/bundles.py
+++ b/oekg/bundles.py
@@ -31,6 +31,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 import uuid
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Optional
 
 from rdflib import RDF, RDFS, Graph, Literal, Namespace, URIRef
@@ -105,13 +106,6 @@ SCENARIO_FIELDS = (
     ResourceField("years", OEO.OEO_00020440, DATES),
 )
 
-# Keyed by the table itself -- tuples of frozen dataclasses are hashable, so a
-# caller asks in the table it already holds rather than naming it twice.
-_BY_NAME = {
-    table: {field.name: field for field in table}
-    for table in (BUNDLE_FIELDS, SCENARIO_FIELDS)
-}
-
 
 def mint_bundle_uid() -> str:
     """A new bundle identifier. The server's to give, never the client's."""
@@ -166,7 +160,12 @@ def find_scenario(graph: Graph, uid: str, sid: str) -> Optional[URIRef]:
 
 
 def referenced_node_iris(payload: dict, fields: tuple = BUNDLE_FIELDS) -> list:
-    """Every existing node IRI the payload points at, across all node fields."""
+    """Every existing node IRI this payload points at, for **this** table.
+
+    One table, one level. Nesting is the caller's business, because only the
+    caller knows which key holds what -- a table that reached for a key by name
+    would keep looking for it after being handed a table that has no such key.
+    """
     iris = []
     for field in fields:
         if field.kind != NODE:
@@ -174,14 +173,19 @@ def referenced_node_iris(payload: dict, fields: tuple = BUNDLE_FIELDS) -> list:
         for entry in payload.get(field.name) or []:
             if entry.get("iri"):
                 iris.append(entry["iri"])
-    for scenario in payload.get("scenarios") or []:
-        iris += referenced_node_iris(scenario, SCENARIO_FIELDS)
     return iris
+
+
+@lru_cache(maxsize=None)
+def _by_name(fields: tuple) -> dict:
+    """A table's lookup, built once. Cached rather than listed, so adding a
+    table is adding a table and nothing else."""
+    return {field.name: field for field in fields}
 
 
 def field_named(fields: tuple, name: str) -> ResourceField:
     """The one entry in ``fields`` called ``name``."""
-    return _BY_NAME[fields][name]
+    return _by_name(fields)[name]
 
 
 def resource_triples(

--- a/oekg/preconditions.py
+++ b/oekg/preconditions.py
@@ -1,0 +1,80 @@
+"""The version a mutating request says it is editing.
+
+`If-Match` is **required** on every mutating call and there is no opt-out. The
+alternative — optional, with same-field writes falling back to last-write-wins
+— was on the table with a worked example and declined: a client that does not
+know about the header would then overwrite somebody's change and neither of
+them would be told. The cost is named rather than discovered: deliberate
+overwriting is not reachable, and a repair pipeline that wants it must read
+first, every time.
+
+Three refusals, because they mean three different things to a client:
+
+- **428** you did not say which version you were editing;
+- **412** you said one, and it is not the current version;
+- **409** the server's own guard fired — the bundle moved between the read the
+  validation needed and the write. That one is raised at the write, not here.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from typing import Optional
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from oekg.versioning import BundleVersion
+
+
+def precondition_refusal(request, version: BundleVersion) -> Optional[Response]:
+    """Why this request may not proceed on its precondition, if it may not."""
+    named = versions_named(request)
+    if named is None:
+        return Response(
+            {
+                "detail": (
+                    "This write needs an If-Match header carrying the version "
+                    "you read, so that it cannot silently overwrite a change "
+                    f"made since. The bundle is at {version.etag}."
+                )
+            },
+            status=status.HTTP_428_PRECONDITION_REQUIRED,
+        )
+    if str(version.number) not in named:
+        return Response(
+            {
+                "detail": (
+                    "The bundle is not at the version this request expects, so "
+                    f"nothing was written. It is at {version.etag}. Read it "
+                    "again and apply the change to what you get back."
+                )
+            },
+            status=status.HTTP_412_PRECONDITION_FAILED,
+        )
+    return None
+
+
+def versions_named(request):
+    """The versions an ``If-Match`` names, or ``None`` if it names none.
+
+    Lenient in what it accepts and strict in what it emits: a weak validator or
+    a bare number is read as the version it plainly is, while a value that is
+    not a version simply matches nothing and is refused as stale.
+
+    ``*`` names no version. It is a legal header value, and it satisfies the
+    letter of the precondition while withholding the one thing the precondition
+    is for, so it reads here as an absent header rather than as a match.
+    """
+    header = request.headers.get("If-Match")
+    if header is None:
+        return None
+    named = []
+    for entry in header.split(","):
+        entry = entry.strip()
+        if entry == "*":
+            return None
+        if entry.startswith("W/"):
+            entry = entry[2:].strip()
+        named.append(entry.strip('"'))
+    return named

--- a/oekg/reads.py
+++ b/oekg/reads.py
@@ -1,0 +1,77 @@
+"""Reading a bundle out of the graph.
+
+**Bounded depth, not a transitive closure.** A bundle reaches its scenarios in
+one hop, a scenario's study regions in two, and a region's reference in three --
+which is the longest chain the shape allows, so three hops see a whole bundle
+and fewer do not. A closure would also be correct today and would stop needing
+thought; it would also be an unbounded walk on a public endpoint, reachable by
+anyone who can put a triple in the graph.
+
+The version node is unreachable from here, because it points *at* the bundle
+rather than away from it. That is what keeps bookkeeping out of every payload
+without a single line of filtering.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from typing import Optional
+
+from rdflib import RDFS, Graph, URIRef
+
+from oekg.bundles import BUNDLE_CLASS, BUNDLE_DEPTH, bundle_iri
+from oekg.graph_store import GraphStore
+
+
+def read_bundle(store: GraphStore, uid: str) -> Optional[Graph]:
+    """A bundle and everything reachable from it, or ``None`` if there is none."""
+    subgraph = store.construct(_query(uid))
+    if (bundle_iri(uid), None, None) not in subgraph:
+        return None
+    return subgraph
+
+
+def _query(uid: str) -> str:
+    branches = ["{ ?root ?p ?o . BIND(?root AS ?s) }"]
+    for depth in range(1, BUNDLE_DEPTH + 1):
+        # ?root -> ?n1 -> ... -> ?s, then everything ?s says.
+        hops = ["?root"] + [f"?n{step}" for step in range(1, depth)] + ["?s"]
+        steps = " ".join(
+            f"{hops[step]} ?q{step} {hops[step + 1]} ." for step in range(depth)
+        )
+        branches.append(f"{{ {steps} ?s ?p ?o }}")
+    return (
+        "CONSTRUCT { ?s ?p ?o } WHERE { "
+        f"  VALUES ?root {{ {bundle_iri(uid).n3()} }} "
+        f"  ?root a {BUNDLE_CLASS.n3()} . " + " UNION ".join(branches) + " }"
+    )
+
+
+def labels_of(store: GraphStore, iris: list, known: Optional[Graph] = None) -> dict:
+    """The label each of these nodes already carries, for the ones that exist.
+
+    A write consults this so a referenced node keeps its own label and never
+    gains a second one -- which would violate the shape for every bundle citing
+    it, not just the one being written.
+
+    ``known`` is a graph already in hand; anything answered from it costs no
+    query, so a request that has read its bundle asks the store only about
+    nodes outside it.
+    """
+    if not iris:
+        return {}
+    found, missing = {}, []
+    for iri in iris:
+        label = known.value(URIRef(iri), RDFS.label) if known is not None else None
+        if label is None:
+            missing.append(iri)
+        else:
+            found[iri] = str(label)
+    if missing:
+        values = " ".join(URIRef(iri).n3() for iri in missing)
+        rows = store.select(
+            "SELECT ?node ?label WHERE { VALUES ?node { %s } ?node %s ?label }"
+            % (values, RDFS.label.n3())
+        )
+        found.update({row["node"]: row["label"] for row in rows})
+    return found

--- a/oekg/scenario_views.py
+++ b/oekg/scenario_views.py
@@ -1,0 +1,229 @@
+"""Scenario factsheets: their own URLs, inside their bundle's guard.
+
+A scenario is a sub-resource because the shape says so -- it carries its own
+has-uuid, and that rule is checkable against the shape rather than negotiated
+per class. What follows from being one:
+
+- **It is addressable.** `POST` to the collection adds one, `GET` reads one,
+  `PATCH` changes one without touching its siblings.
+- **It is still part of its bundle for everything else.** The version guarded
+  is the bundle's, the ownership asked is the bundle's, the entity tag returned
+  is the bundle's, and the post-state validated is the whole bundle with this
+  scenario in it. A scenario has no independent existence to version or own.
+
+The last of those is not a convenience: every constraint in the shape is
+bundle-local, so a scenario alone is not a unit the shape can judge. Validating
+one on its own would pass vacuously in the places that matter.
+
+Writes are identified by the containing bundle's version, so two clients
+editing two different scenarios of one bundle do conflict. That is the price of
+one version per bundle, chosen deliberately: conflict granularity follows the
+aggregate root, and a scenario is not one.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from django.urls import reverse
+from rdflib import Graph
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from oekg.api_support import (
+    ScenarioBundleThrottle,
+    ScenarioBundleUserThrottle,
+    shape_unavailable,
+    store_unavailable,
+)
+from oekg.bundles import (
+    SCENARIO_CLASS,
+    SCENARIO_FIELDS,
+    build_scenario_graph,
+    bundle_iri,
+    find_scenario,
+    mint_scenario_uid,
+    referenced_node_iris,
+    resource_delta,
+    scenario_nodes,
+    scenario_payload,
+    scenario_uid,
+)
+from oekg.graph_store import GraphStoreError
+from oekg.history import CREATE, UPDATE
+from oekg.serializers import READ_ONLY_CONTAINER, ScenarioSerializer
+from oekg.shape import ShapeUnavailable
+from oekg.writes import BundleWrite, Refused, open_write
+
+
+class ScenarioCollectionAPIView(APIView):
+    """`GET` lists a bundle's scenarios. `POST` adds one."""
+
+    throttle_classes = [ScenarioBundleThrottle, ScenarioBundleUserThrottle]
+
+    def get_permissions(self):
+        if self.request.method in ("GET", "HEAD", "OPTIONS"):
+            return [AllowAny()]
+        return [IsAuthenticated()]
+
+    def get(self, request, uid):
+        try:
+            write = open_write(request, uid, read_only=True)
+        except Refused as refusal:
+            return refusal.response
+        except GraphStoreError as error:
+            return store_unavailable(error, "read")
+        return _listing(write)
+
+    def post(self, request, uid):
+        serializer = ScenarioSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        sid = mint_scenario_uid()
+        try:
+            write = open_write(request, uid)
+            known_labels = write.labels_of(
+                referenced_node_iris(serializer.validated_data, SCENARIO_FIELDS)
+            )
+            write.apply(
+                removed=Graph(),
+                added=build_scenario_graph(
+                    bundle_iri(uid), sid, serializer.validated_data, known_labels
+                ),
+                verb=CREATE,
+                resource_type=SCENARIO_CLASS,
+                resource_uuid=sid,
+            )
+        except Refused as refusal:
+            return refusal.response
+        except ShapeUnavailable as error:
+            return shape_unavailable(error)
+        except GraphStoreError as error:
+            return store_unavailable(error, "written to")
+
+        response = _represented(write, sid, status.HTTP_201_CREATED)
+        response["Location"] = _location(uid, sid)
+        return response
+
+
+class ScenarioAPIView(APIView):
+    """`GET` reads one scenario. `PATCH` changes the keys it names."""
+
+    throttle_classes = [ScenarioBundleThrottle, ScenarioBundleUserThrottle]
+
+    def get_permissions(self):
+        if self.request.method in ("GET", "HEAD", "OPTIONS"):
+            return [AllowAny()]
+        return [IsAuthenticated()]
+
+    def get(self, request, uid, sid):
+        try:
+            write = open_write(request, uid, read_only=True)
+        except Refused as refusal:
+            return refusal.response
+        except GraphStoreError as error:
+            return store_unavailable(error, "read")
+        if find_scenario(write.pre_state, uid, sid) is None:
+            return _no_such_scenario(sid)
+        return _represented(write, sid)
+
+    def patch(self, request, uid, sid):
+        serializer = ScenarioSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        payload = dict(serializer.validated_data)
+        if not payload:
+            return Response(
+                {
+                    "detail": (
+                        "A patch has to name at least one field to change. "
+                        "Read-only data is ignored on a write, so a payload "
+                        f"carrying only {READ_ONLY_CONTAINER!r} changes nothing."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            write = open_write(request, uid)
+            node = find_scenario(write.pre_state, uid, sid)
+            if node is None:
+                return _no_such_scenario(sid)
+
+            known_labels = write.labels_of(
+                referenced_node_iris(payload, SCENARIO_FIELDS)
+            )
+            removed, added = resource_delta(
+                node, SCENARIO_FIELDS, payload, write.pre_state, known_labels
+            )
+            write.apply(
+                removed=removed,
+                added=added,
+                verb=UPDATE,
+                resource_type=SCENARIO_CLASS,
+                resource_uuid=sid,
+            )
+        except Refused as refusal:
+            return refusal.response
+        except ShapeUnavailable as error:
+            return shape_unavailable(error)
+        except GraphStoreError as error:
+            return store_unavailable(error, "written to")
+
+        return _represented(write, sid)
+
+
+def scenario_bodies(graph: Graph, uid: str) -> list:
+    """Every scenario of this bundle, in the form a write accepts them nested."""
+    bodies = [_scenario_body(graph, node, uid) for node in scenario_nodes(graph, uid)]
+    bodies.sort(key=lambda body: body["acronym"] or "")
+    return bodies
+
+
+def _listing(write: BundleWrite) -> Response:
+    scenarios = scenario_bodies(write.pre_state, write.uid)
+    response = Response({"count": len(scenarios), "results": scenarios})
+    response["ETag"] = write.version.etag
+    return response
+
+
+def _represented(
+    write: BundleWrite, sid: str, code: int = status.HTTP_200_OK
+) -> Response:
+    """One scenario, carrying the **bundle's** entity tag.
+
+    Its own, because a sub-resource write bumps the bundle's version and the
+    next write has to send that back -- handing out anything else here would
+    guarantee a `412` on the very next call.
+    """
+    state = write.post_state if write.post_state is not None else write.pre_state
+    node = find_scenario(state, write.uid, sid)
+    body = _scenario_body(state, node, write.uid)
+    if not write.history_recorded:
+        body[READ_ONLY_CONTAINER]["history_recorded"] = False
+    response = Response(body, status=code)
+    response["ETag"] = write.version.etag
+    return response
+
+
+def _scenario_body(graph: Graph, node, uid: str) -> dict:
+    return {
+        **scenario_payload(graph, node),
+        READ_ONLY_CONTAINER: {
+            "uid": scenario_uid(graph, node),
+            "iri": str(node),
+            "type": str(SCENARIO_CLASS),
+            "bundle": uid,
+        },
+    }
+
+
+def _location(uid: str, sid: str) -> str:
+    return reverse("api:scenario-bundle-scenario", kwargs={"uid": uid, "sid": sid})
+
+
+def _no_such_scenario(sid: str) -> Response:
+    return Response(
+        {"detail": f"No scenario {sid} in this bundle."},
+        status=status.HTTP_404_NOT_FOUND,
+    )

--- a/oekg/scenario_views.py
+++ b/oekg/scenario_views.py
@@ -27,6 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 from django.urls import reverse
 from rdflib import Graph
 from rest_framework import status
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -54,7 +55,15 @@ from oekg.graph_store import GraphStoreError
 from oekg.history import CREATE, UPDATE
 from oekg.serializers import READ_ONLY_CONTAINER, ScenarioSerializer
 from oekg.shape import ShapeUnavailable
-from oekg.writes import BundleWrite, Refused, open_write
+from oekg.writes import BundleWrite, open_bundle, refuse_renames
+
+
+class ScenarioPagination(PageNumberPagination):
+    """A ceiling, not a default: no public collection has an unbounded mode."""
+
+    page_size = 50
+    page_size_query_param = "page_size"
+    max_page_size = 200
 
 
 class ScenarioCollectionAPIView(APIView):
@@ -69,12 +78,10 @@ class ScenarioCollectionAPIView(APIView):
 
     def get(self, request, uid):
         try:
-            write = open_write(request, uid, read_only=True)
-        except Refused as refusal:
-            return refusal.response
+            write = open_bundle(request, uid)
         except GraphStoreError as error:
             return store_unavailable(error, "read")
-        return _listing(write)
+        return _listing(request, write)
 
     def post(self, request, uid):
         serializer = ScenarioSerializer(data=request.data)
@@ -82,10 +89,12 @@ class ScenarioCollectionAPIView(APIView):
 
         sid = mint_scenario_uid()
         try:
-            write = open_write(request, uid)
+            write = open_bundle(request, uid)
+            write.require_write(request)
             known_labels = write.labels_of(
                 referenced_node_iris(serializer.validated_data, SCENARIO_FIELDS)
             )
+            refuse_renames(serializer.validated_data, known_labels, SCENARIO_FIELDS)
             write.apply(
                 removed=Graph(),
                 added=build_scenario_graph(
@@ -95,8 +104,6 @@ class ScenarioCollectionAPIView(APIView):
                 resource_type=SCENARIO_CLASS,
                 resource_uuid=sid,
             )
-        except Refused as refusal:
-            return refusal.response
         except ShapeUnavailable as error:
             return shape_unavailable(error)
         except GraphStoreError as error:
@@ -119,9 +126,7 @@ class ScenarioAPIView(APIView):
 
     def get(self, request, uid, sid):
         try:
-            write = open_write(request, uid, read_only=True)
-        except Refused as refusal:
-            return refusal.response
+            write = open_bundle(request, uid)
         except GraphStoreError as error:
             return store_unavailable(error, "read")
         if find_scenario(write.pre_state, uid, sid) is None:
@@ -145,14 +150,20 @@ class ScenarioAPIView(APIView):
             )
 
         try:
-            write = open_write(request, uid)
+            write = open_bundle(request, uid)
+            # Existence of the part before the precondition for the whole: a
+            # request for a scenario that is not there should hear that,
+            # rather than be told its If-Match is missing for something that
+            # does not exist.
             node = find_scenario(write.pre_state, uid, sid)
             if node is None:
                 return _no_such_scenario(sid)
+            write.require_write(request)
 
             known_labels = write.labels_of(
                 referenced_node_iris(payload, SCENARIO_FIELDS)
             )
+            refuse_renames(payload, known_labels, SCENARIO_FIELDS)
             removed, added = resource_delta(
                 node, SCENARIO_FIELDS, payload, write.pre_state, known_labels
             )
@@ -163,8 +174,6 @@ class ScenarioAPIView(APIView):
                 resource_type=SCENARIO_CLASS,
                 resource_uuid=sid,
             )
-        except Refused as refusal:
-            return refusal.response
         except ShapeUnavailable as error:
             return shape_unavailable(error)
         except GraphStoreError as error:
@@ -180,9 +189,18 @@ def scenario_bodies(graph: Graph, uid: str) -> list:
     return bodies
 
 
-def _listing(write: BundleWrite) -> Response:
+def _listing(request, write: BundleWrite) -> Response:
+    """The bundle's scenarios, paginated.
+
+    Paginated even though a bundle's scenarios are bounded by the bundle: this
+    is a public collection, and "no unbounded mode" is the rule for all of
+    them. The nested form inside a bundle read is the exception, and it is one
+    on purpose -- that one has to be complete, because a client sends it back.
+    """
     scenarios = scenario_bodies(write.pre_state, write.uid)
-    response = Response({"count": len(scenarios), "results": scenarios})
+    paginator = ScenarioPagination()
+    page = paginator.paginate_queryset(scenarios, request, view=None)
+    response = paginator.get_paginated_response(page)
     response["ETag"] = write.version.etag
     return response
 

--- a/oekg/serializers.py
+++ b/oekg/serializers.py
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 from rest_framework import serializers
 
-from oekg.bundles import BUNDLE_FIELDS, ENUM
+from oekg.bundles import BUNDLE_FIELDS, ENUM, SCENARIO_FIELDS
 from oekg.shape import constraint_message, enumeration
 
 # Everything read-only lives under one key, and writes ignore it. That is what
@@ -95,7 +95,48 @@ class EnumeratedListField(serializers.ListField):
         return values
 
 
-class ScenarioBundleSerializer(ClosedSerializer):
+class EnumeratedFieldsMixin:
+    """Declares the enumerated fields from the same table that builds triples.
+
+    Read from the shape at runtime rather than copied into Python: the lists
+    are still moving in the shape's repository, and a rejection quotes the
+    shape's own message rather than a second wording that could disagree.
+    """
+
+    field_table = ()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.field_table:
+            if field.kind == ENUM:
+                self.fields[field.name] = EnumeratedListField(
+                    field.predicate, required=False
+                )
+
+
+class ScenarioSerializer(EnumeratedFieldsMixin, ClosedSerializer):
+    """One scenario factsheet -- a sub-resource, not a field of its bundle.
+
+    What makes it one is the shape: it carries its own has-uuid. That uuid is
+    **not** a field here, because the server mints it; a client supplies no
+    identifier anywhere in this API.
+    """
+
+    field_table = SCENARIO_FIELDS
+
+    label = serializers.CharField()
+    acronym = serializers.CharField()
+    abstract = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
+    study_regions = NodeReferenceSerializer(many=True, required=False)
+    interacting_regions = NodeReferenceSerializer(many=True, required=False)
+    # The shape types these as xsd:dateTime, so they are parsed rather than
+    # passed through: a value that is not a date is this layer's to refuse, not
+    # the store's.
+    years = serializers.ListField(child=serializers.DateTimeField(), required=False)
+
+
+class ScenarioBundleSerializer(EnumeratedFieldsMixin, ClosedSerializer):
     """The closed bundle field set -- these and nothing else."""
 
     label = serializers.CharField()
@@ -115,12 +156,17 @@ class ScenarioBundleSerializer(ClosedSerializer):
     frameworks = PartSerializer(many=True, required=False)
     models = PartSerializer(many=True, required=False)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # The enumerated fields are declared from the same table that builds the
-        # triples, so a field cannot exist in one direction and not the other.
-        for field in BUNDLE_FIELDS:
-            if field.kind == ENUM:
-                self.fields[field.name] = EnumeratedListField(
-                    field.predicate, required=False
-                )
+    field_table = BUNDLE_FIELDS
+
+
+class ScenarioBundleCreateSerializer(ScenarioBundleSerializer):
+    """The bundle field set **plus** nested scenarios, for `POST` only.
+
+    The asymmetry is the whole point and it is structural rather than a flag: a
+    bundle `POST` builds its scenarios with it, and a bundle `PATCH` uses the
+    class above, which has no such key and therefore refuses one. That is what
+    lets a pipeline create a whole bundle in one call without giving any call
+    the power to drop its parts by omitting them.
+    """
+
+    scenarios = ScenarioSerializer(many=True, required=False)

--- a/oekg/tests/test_bundle_patch.py
+++ b/oekg/tests/test_bundle_patch.py
@@ -25,12 +25,13 @@ from factsheet.models import ScenarioBundleAccessControl
 from login.models import myuser
 from oekg.bundles import (
     BUNDLE_CLASS,
+    BUNDLE_FIELDS,
     DC,
     HAS_PART,
     OEO,
     build_bundle_graph,
-    bundle_field,
     bundle_iri,
+    field_named,
     field_triples,
     linked_field_triples,
 )
@@ -559,7 +560,7 @@ def guarded_bump(store, uid, label):
 
 
 def _guarded_field(store, uid, name, value):
-    field = bundle_field(name)
+    field = field_named(BUNDLE_FIELDS, name)
     return guarded_operation(
         store,
         uid,
@@ -567,10 +568,10 @@ def _guarded_field(store, uid, name, value):
         mint_write_token(),
         delete=linked_field_triples(
             store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"),
-            uid,
+            bundle_iri(uid),
             field,
         ),
-        insert=field_triples(uid, field, value),
+        insert=field_triples(bundle_iri(uid), field, value),
     )
 
 

--- a/oekg/tests/test_scenario_api.py
+++ b/oekg/tests/test_scenario_api.py
@@ -390,6 +390,139 @@ class ScenarioGuardTest(ScenarioTestCase):
         self.assertIn(response.status_code, (401, 403))
 
 
+class SharedRegionTest(ScenarioTestCase):
+    """A region cited by two scenarios is shared, and shared means unrenameable.
+
+    The rename refusal used to be driven by a hardcoded list of bundle field
+    names, so it did not see regions at all: a payload could cite an existing
+    region with a different label and be accepted. It is driven by the field
+    tables now, which is why this is the test that fails if that regresses.
+    """
+
+    def existing_region(self):
+        uid, etag = self.created()
+        added = self.add_scenario(
+            uid, etag, {**VALID_SCENARIO, "study_regions": [{"label": "Germany"}]}
+        )
+        sid = added.data[READ_ONLY_CONTAINER]["uid"]
+        region = self.client.get(self.scenario_url(uid, sid)).data["study_regions"][0]
+        return uid, added["ETag"], region["iri"]
+
+    def test_a_region_may_be_referenced_by_a_second_scenario(self):
+        uid, etag, iri = self.existing_region()
+
+        response = self.add_scenario(
+            uid,
+            etag,
+            {
+                **VALID_SCENARIO,
+                "acronym": "SECOND",
+                "study_regions": [{"iri": iri, "label": "Germany"}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+
+    def test_referencing_it_writes_no_second_label(self):
+        uid, etag, iri = self.existing_region()
+
+        self.add_scenario(
+            uid,
+            etag,
+            {
+                **VALID_SCENARIO,
+                "acronym": "SECOND",
+                "study_regions": [{"iri": iri, "label": "Germany"}],
+            },
+        )
+
+        labels = self.store.select(
+            "SELECT ?l WHERE { <%s> <http://www.w3.org/2000/01/rdf-schema#label> ?l }"
+            % iri
+        )
+        self.assertEqual(len(labels), 1, labels)
+
+    def test_renaming_a_region_through_a_scenario_is_refused(self):
+        uid, etag, iri = self.existing_region()
+
+        response = self.add_scenario(
+            uid,
+            etag,
+            {
+                **VALID_SCENARIO,
+                "acronym": "SECOND",
+                "study_regions": [{"iri": iri, "label": "Deutschland"}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(response.data["conflicts"][0]["iri"], iri)
+
+    def test_renaming_a_region_through_a_patch_is_refused(self):
+        uid, etag, iri = self.existing_region()
+        sid = self.client.get(self.scenarios_url(uid)).data["results"][0][
+            READ_ONLY_CONTAINER
+        ]["uid"]
+
+        response = self.patch_scenario(
+            uid, sid, {"study_regions": [{"iri": iri, "label": "Deutschland"}]}, etag
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_renaming_a_region_nested_in_a_bundle_create_is_refused(self):
+        _, _, iri = self.existing_region()
+
+        response = self.create(
+            {
+                **VALID_PAYLOAD,
+                "acronym": "NESTED",
+                "scenarios": [
+                    {
+                        **VALID_SCENARIO,
+                        "study_regions": [{"iri": iri, "label": "Deutschland"}],
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+
+class ScenarioNotFoundTest(ScenarioTestCase):
+    """Existence is asked before the precondition, one level down as well."""
+
+    def test_an_unknown_scenario_is_a_404_even_without_a_precondition(self):
+        # Not a 428: telling a client its If-Match is missing for something
+        # that does not exist sends it to look for a version it cannot use.
+        uid, _ = self.created()
+        self.client.force_login(self.user)
+
+        response = self.client.patch(
+            self.scenario_url(uid, "no-such-scenario"),
+            data={"label": "Renamed"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 404, response.data)
+
+    def test_an_unknown_scenario_is_a_404_with_a_stale_precondition(self):
+        uid, _ = self.created()
+
+        response = self.patch_scenario(
+            uid, "no-such-scenario", {"label": "Renamed"}, '"99"'
+        )
+
+        self.assertEqual(response.status_code, 404, response.data)
+
+    def test_an_unknown_bundle_is_still_a_404_before_anything_else(self):
+        response = self.patch_scenario(
+            "11111111-2222-3333-4444-555555555555", "any", {"label": "x"}, None
+        )
+
+        self.assertEqual(response.status_code, 404, response.data)
+
+
 class ScenarioHistoryTest(ScenarioTestCase):
     def entries(self, uid):
         return list(OEKG_Modifications.objects.filter(bundle_id=uid).order_by("id"))
@@ -511,3 +644,42 @@ class ScenarioShapeConformanceTest(RequiresShapeArtifactsMixin, SimpleTestCase):
         # never be in the serializer: no client supplies an identifier here.
         self.assertNotIn("uid", ScenarioSerializer().fields)
         self.assertNotIn("uuid", ScenarioSerializer().fields)
+
+
+class ReadDepthTest(ScenarioTestCase):
+    """The read and the post-state pruner have to agree about how deep a
+    bundle goes.
+
+    If the pruner stopped shorter than the read, the shape would be asked
+    about a bundle the client never sees; if it went deeper, a write could be
+    refused over a node no read returns. Both walk to `BUNDLE_DEPTH`, and this
+    is the test that says so against a bundle that actually uses the depth.
+    """
+
+    def test_a_node_three_hops_out_is_both_read_and_validated(self):
+        # bundle -> scenario -> study region is two hops, and the region's own
+        # triples are the third. A one-hop read returns none of it.
+        uid, etag = self.created()
+        added = self.add_scenario(
+            uid, etag, {**VALID_SCENARIO, "study_regions": [{"label": "Germany"}]}
+        )
+        sid = added.data[READ_ONLY_CONTAINER]["uid"]
+
+        read = self.client.get(self.scenario_url(uid, sid)).data
+
+        self.assertEqual(read["study_regions"][0]["label"], "Germany")
+
+    def test_the_pruner_keeps_what_the_read_returns(self):
+        from oekg.bundles import bundle_subgraph
+        from oekg.graph_store import GraphStore
+        from oekg.reads import read_bundle
+
+        uid, etag = self.created()
+        self.add_scenario(
+            uid, etag, {**VALID_SCENARIO, "study_regions": [{"label": "Germany"}]}
+        )
+
+        as_read = read_bundle(GraphStore.from_settings(), uid)
+        as_pruned = bundle_subgraph(as_read, uid)
+
+        self.assertEqual(len(as_pruned), len(as_read))

--- a/oekg/tests/test_scenario_api.py
+++ b/oekg/tests/test_scenario_api.py
@@ -1,0 +1,513 @@
+"""Scenario factsheets: addressable, but still part of their bundle.
+
+The shape decides which parts of a bundle get URLs -- a scenario carries its
+own has-uuid, a framework does not -- so the rule is checkable rather than
+negotiated per class.
+
+Two asymmetries carry this slice and both are easy to lose:
+
+- **Nested on create, addressable on update.** A bundle `POST` builds its
+  scenarios with it; a bundle `PATCH` cannot reach one. That is what lets a
+  pipeline create a whole bundle in one call without giving any call the power
+  to drop its parts by omitting them.
+- **The bundle owns the version, the ownership and the entity tag.** A scenario
+  has no independent existence to guard, and every constraint in the shape is
+  bundle-local, so a scenario alone is not a unit the shape could judge.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from django.test import SimpleTestCase
+from django.urls import reverse
+from rdflib.namespace import SH
+
+from factsheet.models import OEKG_Modifications, ScenarioBundleAccessControl
+from login.models import myuser
+from oekg.bundles import HAS_UUID, OEO, SCENARIO_CLASS, SCENARIO_FIELDS, bundle_iri
+from oekg.history import CREATE, UPDATE
+from oekg.serializers import READ_ONLY_CONTAINER, ScenarioSerializer
+from oekg.shape import shape_graph
+from oekg.tests import RequiresShapeArtifactsMixin
+from oekg.tests.bundle_fixtures import VALID_PAYLOAD, BundleApiTestCase
+
+# The three the scenario shape requires, and a real pick from its sh:in list.
+VALID_SCENARIO = {
+    "label": "A high renewables scenario",
+    "acronym": "HIGH-RE",
+    "scenario_types": [str(OEO.OEO_00000364)],
+}
+
+
+class ScenarioTestCase(BundleApiTestCase):
+    def scenarios_url(self, uid):
+        return reverse("api:scenario-bundle-scenarios", kwargs={"uid": uid})
+
+    def scenario_url(self, uid, sid):
+        return reverse("api:scenario-bundle-scenario", kwargs={"uid": uid, "sid": sid})
+
+    def add_scenario(self, uid, etag, payload=None, as_user=None):
+        self.client.force_login(as_user or self.user)
+        return self.client.post(
+            self.scenarios_url(uid),
+            data=payload if payload is not None else VALID_SCENARIO,
+            content_type="application/json",
+            HTTP_IF_MATCH=etag,
+        )
+
+    def patch_scenario(self, uid, sid, payload, etag, as_user=None):
+        self.client.force_login(as_user or self.user)
+        return self.client.patch(
+            self.scenario_url(uid, sid),
+            data=payload,
+            content_type="application/json",
+            HTTP_IF_MATCH=etag,
+        )
+
+    def with_one_scenario(self):
+        """A bundle plus one scenario. Returns uid, sid and the current etag."""
+        uid, etag = self.created()
+        response = self.add_scenario(uid, etag)
+        self.assertEqual(response.status_code, 201, response.data)
+        return uid, response.data[READ_ONLY_CONTAINER]["uid"], response["ETag"]
+
+
+class NestedCreateTest(ScenarioTestCase):
+    def test_a_bundle_is_created_with_its_scenarios_in_one_call(self):
+        # The modelling pipeline's batch case: one request, whole bundle.
+        uid, _ = self.created({**VALID_PAYLOAD, "scenarios": [VALID_SCENARIO]})
+
+        read = self.client.get(self.detail_url(uid)).data
+
+        self.assertEqual(len(read["scenarios"]), 1)
+        self.assertEqual(read["scenarios"][0]["acronym"], VALID_SCENARIO["acronym"])
+
+    def test_two_nested_scenarios_get_different_identifiers(self):
+        uid, _ = self.created(
+            {
+                **VALID_PAYLOAD,
+                "scenarios": [
+                    VALID_SCENARIO,
+                    {**VALID_SCENARIO, "acronym": "LOW-RE"},
+                ],
+            }
+        )
+
+        read = self.client.get(self.detail_url(uid)).data
+
+        identifiers = {s[READ_ONLY_CONTAINER]["uid"] for s in read["scenarios"]}
+        self.assertEqual(len(identifiers), 2)
+
+    def test_a_nested_scenario_is_typed_and_carries_its_uuid(self):
+        # Both are shape requirements: the type makes it a scenario, the uuid
+        # makes it addressable.
+        uid, _ = self.created({**VALID_PAYLOAD, "scenarios": [VALID_SCENARIO]})
+        sid = self.client.get(self.detail_url(uid)).data["scenarios"][0][
+            READ_ONLY_CONTAINER
+        ]["uid"]
+
+        self.assertTrue(
+            self.store.ask(
+                "ASK { ?node a %s ; %s %s }"
+                % (SCENARIO_CLASS.n3(), HAS_UUID.n3(), f'"{sid}"')
+            )
+        )
+
+    def test_a_nested_scenario_the_shape_rejects_writes_nothing(self):
+        # No scenario type: the shape requires at least one.
+        broken = {
+            key: v for key, v in VALID_SCENARIO.items() if key != "scenario_types"
+        }
+
+        response = self.create({**VALID_PAYLOAD, "scenarios": [broken]})
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertFalse(self.store.ask("ASK { ?s ?p ?o }"))
+
+    def test_the_whole_bundle_with_its_scenarios_is_one_write(self):
+        from unittest.mock import patch
+
+        from oekg.graph_store import GraphStore
+
+        real_update, updates = GraphStore.update, []
+
+        def counting(store, *operations):
+            updates.append(operations)
+            return real_update(store, *operations)
+
+        with patch.object(GraphStore, "update", counting):
+            response = self.create({**VALID_PAYLOAD, "scenarios": [VALID_SCENARIO]})
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(len(updates), 1, updates)
+
+    def test_a_read_with_scenarios_can_be_sent_back_to_create_a_copy(self):
+        # The round trip the replace endpoint will depend on: what a read
+        # returns is what a write accepts, sub-resources included.
+        uid, _ = self.created({**VALID_PAYLOAD, "scenarios": [VALID_SCENARIO]})
+        read = self.client.get(self.detail_url(uid)).data
+
+        copy = self.client.post(
+            self.collection_url,
+            data={**read, "acronym": "API-TEST-COPY"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(copy.status_code, 201, copy.data)
+        self.assertEqual(len(copy.data["scenarios"]), 1)
+
+    def test_a_bundle_patch_still_cannot_reach_a_scenario(self):
+        # The asymmetry: nesting on create does not open a door on update.
+        uid, etag = self.created()
+
+        response = self.patch(uid, {"scenarios": [VALID_SCENARIO]}, if_match=etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn("scenarios", response.data)
+
+
+class ScenarioCollectionTest(ScenarioTestCase):
+    def test_a_scenario_is_added_to_an_existing_bundle(self):
+        uid, etag = self.created()
+
+        response = self.add_scenario(uid, etag)
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertEqual(response.data["acronym"], VALID_SCENARIO["acronym"])
+
+    def test_the_response_names_where_the_scenario_now_lives(self):
+        uid, etag = self.created()
+
+        response = self.add_scenario(uid, etag)
+
+        sid = response.data[READ_ONLY_CONTAINER]["uid"]
+        self.assertEqual(response["Location"], self.scenario_url(uid, sid))
+
+    def test_the_collection_lists_what_the_bundle_has(self):
+        uid, _, _ = self.with_one_scenario()
+
+        listing = self.client.get(self.scenarios_url(uid))
+
+        self.assertEqual(listing.status_code, 200)
+        self.assertEqual(listing.data["count"], 1)
+
+    def test_the_collection_is_public(self):
+        uid, _, _ = self.with_one_scenario()
+        self.client.logout()
+
+        self.assertEqual(self.client.get(self.scenarios_url(uid)).status_code, 200)
+
+    def test_it_lists_only_this_bundle_s_scenarios(self):
+        first, _, _ = self.with_one_scenario()
+        second, second_etag = self.created({**VALID_PAYLOAD, "acronym": "OTHER"})
+        self.add_scenario(second, second_etag, {**VALID_SCENARIO, "acronym": "OTHER-S"})
+
+        acronyms = [
+            entry["acronym"]
+            for entry in self.client.get(self.scenarios_url(first)).data["results"]
+        ]
+
+        self.assertEqual(acronyms, [VALID_SCENARIO["acronym"]])
+
+    def test_adding_to_an_unknown_bundle_is_a_404(self):
+        response = self.add_scenario("11111111-2222-3333-4444-555555555555", '"1"')
+
+        self.assertEqual(response.status_code, 404, response.data)
+
+
+class ScenarioItemTest(ScenarioTestCase):
+    def test_a_scenario_reads_back(self):
+        uid, sid, _ = self.with_one_scenario()
+
+        response = self.client.get(self.scenario_url(uid, sid))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["label"], VALID_SCENARIO["label"])
+        self.assertEqual(response.data[READ_ONLY_CONTAINER]["uid"], sid)
+
+    def test_a_read_needs_no_authentication(self):
+        uid, sid, _ = self.with_one_scenario()
+        self.client.logout()
+
+        self.assertEqual(self.client.get(self.scenario_url(uid, sid)).status_code, 200)
+
+    def test_an_unknown_scenario_is_a_404(self):
+        uid, _ = self.created()
+
+        response = self.client.get(self.scenario_url(uid, "no-such-scenario"))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_patching_one_field_leaves_the_others_intact(self):
+        uid, sid, etag = self.with_one_scenario()
+
+        response = self.patch_scenario(uid, sid, {"label": "Renamed"}, etag)
+
+        self.assertEqual(response.status_code, 200, response.data)
+        read = self.client.get(self.scenario_url(uid, sid)).data
+        self.assertEqual(read["label"], "Renamed")
+        self.assertEqual(read["acronym"], VALID_SCENARIO["acronym"])
+        self.assertEqual(read["scenario_types"], VALID_SCENARIO["scenario_types"])
+
+    def test_patching_one_scenario_leaves_its_siblings_alone(self):
+        uid, first, etag = self.with_one_scenario()
+        added = self.add_scenario(uid, etag, {**VALID_SCENARIO, "acronym": "SECOND"})
+        second = added.data[READ_ONLY_CONTAINER]["uid"]
+
+        self.patch_scenario(uid, first, {"label": "Only the first"}, added["ETag"])
+
+        sibling = self.client.get(self.scenario_url(uid, second)).data
+        self.assertEqual(sibling["label"], VALID_SCENARIO["label"])
+        self.assertEqual(sibling["acronym"], "SECOND")
+
+    def test_a_patch_that_breaks_the_shape_writes_nothing(self):
+        uid, sid, etag = self.with_one_scenario()
+
+        response = self.patch_scenario(uid, sid, {"scenario_types": []}, etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertEqual(
+            self.client.get(self.scenario_url(uid, sid)).data["scenario_types"],
+            VALID_SCENARIO["scenario_types"],
+        )
+
+    def test_a_region_is_written_as_a_typed_node(self):
+        uid, sid, etag = self.with_one_scenario()
+
+        response = self.patch_scenario(
+            uid, sid, {"study_regions": [{"label": "Germany"}]}, etag
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertTrue(self.store.ask("ASK { ?node a %s }" % OEO.OEO_00020032.n3()))
+        read = self.client.get(self.scenario_url(uid, sid)).data
+        self.assertEqual(read["study_regions"][0]["label"], "Germany")
+
+    def test_a_scenario_year_round_trips(self):
+        uid, sid, etag = self.with_one_scenario()
+
+        response = self.patch_scenario(
+            uid, sid, {"years": ["2030-01-01T00:00:00+00:00"]}, etag
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(len(response.data["years"]), 1)
+
+    def test_an_unknown_key_is_refused(self):
+        uid, sid, etag = self.with_one_scenario()
+
+        response = self.patch_scenario(uid, sid, {"labelz": "typo"}, etag)
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+    def test_no_identifier_is_accepted_from_a_client(self):
+        uid, etag = self.created()
+
+        response = self.add_scenario(uid, etag, {**VALID_SCENARIO, "uid": "chosen"})
+
+        self.assertEqual(response.status_code, 400, response.data)
+
+
+class ScenarioGuardTest(ScenarioTestCase):
+    """The bundle's version and the bundle's owner guard its parts."""
+
+    def test_a_write_advances_the_bundle_version(self):
+        uid, etag = self.created()
+
+        response = self.add_scenario(uid, etag)
+
+        self.assertEqual(response["ETag"], '"2"')
+        self.assertEqual(self.client.get(self.detail_url(uid))["ETag"], '"2"')
+
+    def test_a_read_carries_the_bundle_entity_tag(self):
+        uid, sid, etag = self.with_one_scenario()
+
+        read = self.client.get(self.scenario_url(uid, sid))
+
+        self.assertEqual(read["ETag"], etag)
+
+    def test_a_missing_precondition_is_refused(self):
+        uid, _ = self.created()
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            self.scenarios_url(uid),
+            data=VALID_SCENARIO,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 428, response.data)
+
+    def test_a_stale_precondition_is_refused(self):
+        uid, etag = self.created()
+        self.add_scenario(uid, etag)
+
+        response = self.add_scenario(uid, etag, {**VALID_SCENARIO, "acronym": "TWO"})
+
+        self.assertEqual(response.status_code, 412, response.data)
+        self.assertEqual(self.client.get(self.scenarios_url(uid)).data["count"], 1)
+
+    def test_a_stale_precondition_on_a_patch_is_refused(self):
+        uid, sid, etag = self.with_one_scenario()
+        self.patch_scenario(uid, sid, {"label": "First"}, etag)
+
+        response = self.patch_scenario(uid, sid, {"label": "Second"}, etag)
+
+        self.assertEqual(response.status_code, 412, response.data)
+        self.assertEqual(
+            self.client.get(self.scenario_url(uid, sid)).data["label"], "First"
+        )
+
+    def test_a_non_owner_is_refused(self):
+        uid, etag = self.created()
+        stranger = myuser.objects.create_user(
+            name="someone-else", email="else@example.org", affiliation=""
+        )
+
+        response = self.add_scenario(uid, etag, as_user=stranger)
+
+        self.assertEqual(response.status_code, 403, response.data)
+
+    def test_an_ownerless_bundle_is_refused(self):
+        uid, etag = self.created()
+        ScenarioBundleAccessControl.objects.filter(bundle_id=uid).delete()
+
+        response = self.add_scenario(uid, etag)
+
+        self.assertEqual(response.status_code, 403, response.data)
+
+    def test_an_unauthenticated_write_is_refused(self):
+        uid, etag = self.created()
+        self.client.logout()
+
+        response = self.client.post(
+            self.scenarios_url(uid),
+            data=VALID_SCENARIO,
+            content_type="application/json",
+            HTTP_IF_MATCH=etag,
+        )
+
+        self.assertIn(response.status_code, (401, 403))
+
+
+class ScenarioHistoryTest(ScenarioTestCase):
+    def entries(self, uid):
+        return list(OEKG_Modifications.objects.filter(bundle_id=uid).order_by("id"))
+
+    def test_adding_a_scenario_records_which_resource_it_was(self):
+        uid, sid, _ = self.with_one_scenario()
+
+        entry = self.entries(uid)[-1]
+
+        self.assertEqual(entry.verb, CREATE)
+        self.assertEqual(entry.resource_type, str(SCENARIO_CLASS))
+        self.assertEqual(entry.resource_uuid, sid)
+
+    def test_patching_a_scenario_records_it_too(self):
+        uid, sid, etag = self.with_one_scenario()
+
+        self.patch_scenario(uid, sid, {"label": "Renamed"}, etag)
+
+        entry = self.entries(uid)[-1]
+        self.assertEqual(entry.verb, UPDATE)
+        self.assertEqual(entry.resource_uuid, sid)
+        self.assertEqual((entry.version_before, entry.version_after), (2, 3))
+
+    def test_a_nested_create_is_one_entry_for_the_bundle(self):
+        # One request, one entry: the diff already carries the scenarios, and
+        # an entry per nested part would multiply rows for a single write.
+        uid, _ = self.created({**VALID_PAYLOAD, "scenarios": [VALID_SCENARIO]})
+
+        entries = self.entries(uid)
+
+        self.assertEqual(len(entries), 1)
+        self.assertIsNone(entries[0].resource_uuid)
+
+    def test_the_history_shows_the_scenario_write(self):
+        uid, sid, _ = self.with_one_scenario()
+
+        results = self.client.get(
+            reverse("api:scenario-bundle-history", kwargs={"uid": uid})
+        ).data["results"]
+
+        self.assertEqual(results[0]["resource"]["uid"], sid)
+        self.assertEqual(results[0]["resource"]["type"], str(SCENARIO_CLASS))
+
+
+class ScenarioShapeTest(ScenarioTestCase):
+    def test_the_bundle_and_its_scenarios_validate_as_one_post_state(self):
+        # A scenario alone is not a unit the shape can judge -- every
+        # constraint in it is bundle-local.
+        uid, etag = self.created()
+
+        response = self.add_scenario(uid, etag)
+
+        self.assertEqual(response.status_code, 201, response.data)
+        self.assertTrue(
+            self.store.ask(
+                "ASK { %s <%s> ?node . ?node a %s }"
+                % (
+                    bundle_iri(uid).n3(),
+                    "http://purl.obolibrary.org/obo/BFO_0000051",
+                    SCENARIO_CLASS.n3(),
+                )
+            )
+        )
+
+    def test_a_pick_outside_the_shapes_list_is_refused(self):
+        uid, etag = self.created()
+
+        response = self.add_scenario(
+            uid, etag, {**VALID_SCENARIO, "scenario_types": [str(OEO.OEO_99999999)]}
+        )
+
+        self.assertEqual(response.status_code, 400, response.data)
+        self.assertIn("scenario_types", response.data)
+
+
+class ScenarioShapeConformanceTest(RequiresShapeArtifactsMixin, SimpleTestCase):
+    """Every property the shape validates on a scenario is accounted for.
+
+    The anti-drift property a generator would have given, without the
+    generator: if the shape gains a property, this fails rather than the API
+    quietly ignoring it.
+    """
+
+    # Two predicates the shape validates that this slice deliberately does not
+    # build: dataset links are the next slice's resource, with their own URLs.
+    # Named here rather than silently passed over, so that slice deletes this
+    # list instead of discovering the gap.
+    DEFERRED = {
+        str(OEO.OEO_00020437),  # has information input -> input dataset
+        str(OEO.OEO_00020436),  # has information output -> output dataset
+    }
+
+    def test_every_scenario_property_in_the_shape_is_covered(self):
+        shape = shape_graph()
+        node = shape.value(predicate=SH.targetClass, object=SCENARIO_CLASS)
+        paths = {
+            str(shape.value(constraint, SH.path))
+            for constraint in shape.objects(node, SH.property)
+            if shape.value(constraint, SH.path) is not None
+        }
+
+        covered = {str(field.predicate) for field in SCENARIO_FIELDS}
+        # The uuid is the server's to mint, so it is an identity rather than a
+        # field -- covered by the builder, absent from the serializer.
+        covered.add(str(HAS_UUID))
+
+        self.assertTrue(paths, "the shape declares no scenario properties")
+        self.assertEqual(paths - covered - self.DEFERRED, set())
+        self.assertEqual(covered - paths, set())
+
+    def test_the_serializer_and_the_builder_agree(self):
+        serializer_fields = set(ScenarioSerializer().fields)
+        builder_fields = {field.name for field in SCENARIO_FIELDS}
+
+        self.assertEqual(serializer_fields, builder_fields)
+
+    def test_a_client_cannot_supply_the_identifier(self):
+        # The uuid is in the shape and therefore in the builder, but it must
+        # never be in the serializer: no client supplies an identifier here.
+        self.assertNotIn("uid", ScenarioSerializer().fields)
+        self.assertNotIn("uuid", ScenarioSerializer().fields)

--- a/oekg/writes.py
+++ b/oekg/writes.py
@@ -1,0 +1,186 @@
+"""One write to a bundle, whatever part of it the request names.
+
+Every mutating endpoint in this API does the same five things in the same
+order, and gets them wrong in the same ways if it does them itself:
+
+1. the bundle has to exist, or there is nothing to write to;
+2. the caller has to own it;
+3. the caller has to say which version it is editing;
+4. the **whole bundle** with the change in it has to satisfy the shape --
+   every constraint in the shape is bundle-local, so a part on its own is not
+   a unit the shape can judge;
+5. the write has to be guarded on that version from inside, and read back,
+   because the store answers `200` whether or not the guard held.
+
+So the sequence lives here once rather than in each view. `open_write` does
+1-3 and hands back a bundle already read; `apply` does 4 and 5 and records the
+history. A view is then only the part that differs: which triples change.
+
+**Refusals travel as exceptions.** A helper that returns either a value or a
+refusal makes every call site test which it got, and one forgotten test is a
+refusal silently ignored -- so a refusal is raised and a view catches it in the
+same place it already catches the store's failures.
+
+SPDX-FileCopyrightText: 2026 Jonas Huber <https://github.com/jh-RLI> © Reiner Lemoine Institut
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""  # noqa: 501
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from rdflib import Graph, URIRef
+from rest_framework import status
+from rest_framework.response import Response
+
+from oekg.api_support import bundle_exists, no_such_bundle
+from oekg.bundles import BUNDLE_CLASS, bundle_subgraph
+from oekg.graph_store import GraphStore
+from oekg.history import record_write
+from oekg.permissions import may_write_bundle
+from oekg.preconditions import precondition_refusal
+from oekg.reads import labels_of, read_bundle
+from oekg.validation import validate_post_state
+from oekg.versioning import (
+    BundleVersion,
+    guarded_operation,
+    mint_write_token,
+    read_version,
+    write_applied,
+)
+
+
+class Refused(Exception):
+    """A refusal a view should return as it stands."""
+
+    def __init__(self, response: Response):
+        super().__init__(getattr(response, "status_code", "refused"))
+        self.response = response
+
+
+@dataclass
+class BundleWrite:
+    """A bundle read, checked, and ready to be changed."""
+
+    uid: str
+    store: GraphStore
+    pre_state: Graph
+    version: BundleVersion
+    actor: object = None
+    post_state: Optional[Graph] = field(default=None)
+    history_recorded: bool = True
+
+    def labels_of(self, iris: list) -> dict:
+        """Labels for referenced nodes, answered from the bundle where possible."""
+        return labels_of(self.store, iris, self.pre_state)
+
+    def apply(
+        self,
+        *,
+        removed: Graph,
+        added: Graph,
+        verb: str,
+        resource_type: URIRef = BUNDLE_CLASS,
+        resource_uuid: Optional[str] = None,
+    ) -> None:
+        """Validate the post-state, write it under the guard, record it.
+
+        Raises ``Refused`` with a `400` if the shape objects and with a `409`
+        if the guard did not hold. Nothing is written in either case.
+        """
+        self.post_state = bundle_subgraph(self.pre_state - removed + added, self.uid)
+        violations = validate_post_state(self.post_state)
+        if violations:
+            raise Refused(
+                Response(
+                    {
+                        "detail": "The bundle does not conform to the OEKG shape.",
+                        "violations": [v.as_dict() for v in violations],
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            )
+
+        token = mint_write_token()
+        self.store.update(
+            guarded_operation(
+                self.store,
+                self.uid,
+                self.version,
+                token,
+                delete=removed,
+                insert=added,
+            )
+        )
+        if not write_applied(self.store, self.uid, token):
+            raise Refused(
+                Response(
+                    {
+                        "detail": (
+                            "The bundle changed while this request was being "
+                            "prepared, so nothing was written. Read it again, "
+                            "apply the change to what you get back, and retry."
+                        )
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+            )
+
+        before = self.version.number
+        self.version = BundleVersion(before + 1, token)
+        # The graph has committed. Nothing from here may turn a successful
+        # write into an error; a lost history entry is reported beside the
+        # success it qualifies, never instead of it.
+        self.history_recorded = record_write(
+            bundle_uid=self.uid,
+            verb=verb,
+            actor=self.actor,
+            version_before=before,
+            version_after=self.version.number,
+            removed=removed,
+            added=added,
+            resource_type=resource_type,
+            resource_uuid=resource_uuid,
+        )
+
+
+def open_write(request, uid: str, read_only: bool = False) -> BundleWrite:
+    """Read the bundle and check what a write to it needs. Raises ``Refused``.
+
+    Existence first, as it is for the two-step delete: one order for the whole
+    API rather than one per endpoint. Reads are public, so answering 404 before
+    authorisation reveals nothing a `GET` would not.
+    """
+    if not bundle_exists(uid):
+        raise Refused(no_such_bundle(uid))
+
+    store = GraphStore.from_settings()
+    pre_state = read_bundle(store, uid)
+    if pre_state is None:
+        raise Refused(no_such_bundle(uid))
+    version = read_version(store, uid)
+
+    if not read_only:
+        if not may_write_bundle(request.user, uid):
+            raise Refused(
+                Response(
+                    {
+                        "detail": (
+                            "Only an owner of this scenario bundle may change "
+                            "it. A bundle with no recorded owner can be "
+                            "changed by an administrator only."
+                        )
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            )
+        refusal = precondition_refusal(request, version)
+        if refusal is not None:
+            raise Refused(refusal)
+
+    return BundleWrite(
+        uid=uid,
+        store=store,
+        pre_state=pre_state,
+        version=version,
+        actor=getattr(request, "user", None),
+    )

--- a/oekg/writes.py
+++ b/oekg/writes.py
@@ -12,9 +12,11 @@ order, and gets them wrong in the same ways if it does them itself:
 5. the write has to be guarded on that version from inside, and read back,
    because the store answers `200` whether or not the guard held.
 
-So the sequence lives here once rather than in each view. `open_write` does
-1-3 and hands back a bundle already read; `apply` does 4 and 5 and records the
-history. A view is then only the part that differs: which triples change.
+So the sequence lives here once rather than in each view. `open_bundle` does 1,
+`require_write` does 2 and 3, and `apply` does 4 and 5 and records the history.
+They are three calls rather than one so a sub-resource view can check that
+*its* part exists between the first and the second, and keep the same order
+one level down. A view is then only the part that differs: which triples change.
 
 **Refusals travel as exceptions.** A helper that returns either a value or a
 refusal makes every call site test which it got, and one forgotten test is a
@@ -30,10 +32,10 @@ from typing import Optional
 
 from rdflib import Graph, URIRef
 from rest_framework import status
-from rest_framework.response import Response
+from rest_framework.exceptions import APIException
 
-from oekg.api_support import bundle_exists, no_such_bundle
-from oekg.bundles import BUNDLE_CLASS, bundle_subgraph
+from oekg.api_support import bundle_exists
+from oekg.bundles import BUNDLE_CLASS, NODE, bundle_subgraph
 from oekg.graph_store import GraphStore
 from oekg.history import record_write
 from oekg.permissions import may_write_bundle
@@ -49,12 +51,19 @@ from oekg.versioning import (
 )
 
 
-class Refused(Exception):
-    """A refusal a view should return as it stands."""
+class Refused(APIException):
+    """A refusal, raised where it is decided and rendered by the framework.
 
-    def __init__(self, response: Response):
-        super().__init__(getattr(response, "status_code", "refused"))
-        self.response = response
+    An ``APIException`` rather than a plain one so that no view needs a clause
+    to catch it: the framework turns it into the response it already carries.
+    A helper that *returned* a refusal would make every call site test which of
+    the two things it got, and one forgotten test is a refusal silently
+    ignored.
+    """
+
+    def __init__(self, detail, status_code: int):
+        self.status_code = status_code
+        super().__init__(detail)
 
 
 @dataclass
@@ -68,6 +77,26 @@ class BundleWrite:
     actor: object = None
     post_state: Optional[Graph] = field(default=None)
     history_recorded: bool = True
+
+    def require_write(self, request) -> None:
+        """Refuse unless this caller may write, and said which version.
+
+        Raises ``Refused`` with a `403`, a `428` or a `412`.
+        """
+        if not may_write_bundle(request.user, self.uid):
+            raise Refused(
+                {
+                    "detail": (
+                        "Only an owner of this scenario bundle may change it. "
+                        "A bundle with no recorded owner can be changed by an "
+                        "administrator only."
+                    )
+                },
+                status.HTTP_403_FORBIDDEN,
+            )
+        refusal = precondition_refusal(request, self.version)
+        if refusal is not None:
+            raise Refused(refusal.data, refusal.status_code)
 
     def labels_of(self, iris: list) -> dict:
         """Labels for referenced nodes, answered from the bundle where possible."""
@@ -85,19 +114,27 @@ class BundleWrite:
         """Validate the post-state, write it under the guard, record it.
 
         Raises ``Refused`` with a `400` if the shape objects and with a `409`
-        if the guard did not hold. Nothing is written in either case.
+        if the guard did not hold. Nothing is written in either case, and
+        nothing on this object is updated either -- a caller that catches a
+        refusal must not find a post-state describing a write that did not
+        happen.
         """
-        self.post_state = bundle_subgraph(self.pre_state - removed + added, self.uid)
-        violations = validate_post_state(self.post_state)
+        if self.post_state is not None:
+            raise RuntimeError(
+                "This bundle has already been written. A second write needs a "
+                "fresh read: this one still holds the state from before the "
+                "first, and would silently undo it."
+            )
+
+        post_state = bundle_subgraph(self.pre_state - removed + added, self.uid)
+        violations = validate_post_state(post_state)
         if violations:
             raise Refused(
-                Response(
-                    {
-                        "detail": "The bundle does not conform to the OEKG shape.",
-                        "violations": [v.as_dict() for v in violations],
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+                {
+                    "detail": "The bundle does not conform to the OEKG shape.",
+                    "violations": [v.as_dict() for v in violations],
+                },
+                status.HTTP_400_BAD_REQUEST,
             )
 
         token = mint_write_token()
@@ -113,18 +150,19 @@ class BundleWrite:
         )
         if not write_applied(self.store, self.uid, token):
             raise Refused(
-                Response(
-                    {
-                        "detail": (
-                            "The bundle changed while this request was being "
-                            "prepared, so nothing was written. Read it again, "
-                            "apply the change to what you get back, and retry."
-                        )
-                    },
-                    status=status.HTTP_409_CONFLICT,
-                )
+                {
+                    "detail": (
+                        "The bundle changed while this request was being "
+                        "prepared, so nothing was written. Read it again, "
+                        "apply the change to what you get back, and retry."
+                    )
+                },
+                status.HTTP_409_CONFLICT,
             )
 
+        # Only now: everything above could still have refused, and a refusal
+        # must leave this object describing the bundle as it still is.
+        self.post_state = post_state
         before = self.version.number
         self.version = BundleVersion(before + 1, token)
         # The graph has committed. Nothing from here may turn a successful
@@ -143,44 +181,73 @@ class BundleWrite:
         )
 
 
-def open_write(request, uid: str, read_only: bool = False) -> BundleWrite:
-    """Read the bundle and check what a write to it needs. Raises ``Refused``.
+def open_bundle(request, uid: str) -> BundleWrite:
+    """Read a bundle, or refuse with a `404`. Raises ``Refused``.
 
-    Existence first, as it is for the two-step delete: one order for the whole
-    API rather than one per endpoint. Reads are public, so answering 404 before
-    authorisation reveals nothing a `GET` would not.
+    **Existence first**, as it is for the two-step delete: one order for the
+    whole API rather than one per endpoint. Reads are public, so answering 404
+    before authorisation reveals nothing a `GET` would not -- and a request for
+    something that is not there should hear that, rather than being told its
+    precondition is missing for a resource that does not exist.
+
+    Separate from ``require_write`` so a sub-resource view can check that *its*
+    part exists in between, and keep the same order one level down.
     """
     if not bundle_exists(uid):
-        raise Refused(no_such_bundle(uid))
+        raise Refused(
+            {"detail": f"No scenario bundle {uid}."}, status.HTTP_404_NOT_FOUND
+        )
 
     store = GraphStore.from_settings()
     pre_state = read_bundle(store, uid)
     if pre_state is None:
-        raise Refused(no_such_bundle(uid))
-    version = read_version(store, uid)
-
-    if not read_only:
-        if not may_write_bundle(request.user, uid):
-            raise Refused(
-                Response(
-                    {
-                        "detail": (
-                            "Only an owner of this scenario bundle may change "
-                            "it. A bundle with no recorded owner can be "
-                            "changed by an administrator only."
-                        )
-                    },
-                    status=status.HTTP_403_FORBIDDEN,
-                )
-            )
-        refusal = precondition_refusal(request, version)
-        if refusal is not None:
-            raise Refused(refusal)
+        raise Refused(
+            {"detail": f"No scenario bundle {uid}."}, status.HTTP_404_NOT_FOUND
+        )
 
     return BundleWrite(
         uid=uid,
         store=store,
         pre_state=pre_state,
-        version=version,
+        version=read_version(store, uid),
         actor=getattr(request, "user", None),
     )
+
+
+def refuse_renames(payload: dict, known_labels: dict, fields: tuple) -> None:
+    """Refuse a payload that gives an existing node a different label.
+
+    **The API offers no rename.** Shared IRIs stay shared -- that is the point
+    of a graph -- but a shared contact, organisation, funder or region is cited
+    by other bundles, so letting one payload rewrite its label would change
+    every one of them. Referencing such a node is allowed; renaming it is not,
+    and the difference is the label sent alongside the iri.
+
+    Driven by the field table rather than by a list of field names, because a
+    list stops covering a table the moment that table gains a node field, and
+    the refusal then quietly passes writes it should refuse.
+    """
+    conflicts = [
+        {
+            "iri": entry["iri"],
+            "stored_label": known_labels[entry["iri"]],
+            "sent_label": entry["label"],
+        }
+        for field in fields
+        if field.kind == NODE
+        for entry in (payload.get(field.name) or [])
+        if entry.get("iri") in known_labels
+        and entry["label"] != known_labels[entry["iri"]]
+    ]
+    if conflicts:
+        raise Refused(
+            {
+                "detail": (
+                    "A shared node cannot be renamed through this API. "
+                    "Reference it by iri and send the label it already has, or "
+                    "omit the iri to mint a new node."
+                ),
+                "conflicts": conflicts,
+            },
+            status.HTTP_400_BAD_REQUEST,
+        )

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -129,6 +129,11 @@ SPDX-License-Identifier: CC0-1.0
   pipeline needs; a bundle `PATCH` still cannot reach into one, so no call can
   drop a scenario by leaving it out. Writes use the containing bundle's version
   and ownership, and a read of a scenario carries the bundle's `ETag`
+  [(#2444)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2444)
+
+- A read of a scenario bundle now includes its scenarios, so what you read is
+  what a create accepts back
+  [(#2444)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2444)
 
 - New management command `repair_factsheet_tags` repairs the factsheets the old
   tag editor damaged - on production 23 of 339 carry a copy of the whole tag

--- a/versions/changelogs/current.md
+++ b/versions/changelogs/current.md
@@ -123,6 +123,13 @@ SPDX-License-Identifier: CC0-1.0
   and read as coming from before the API
   [(#2441)](https://github.com/OpenEnergyPlatform/oeplatform/pull/2441)
 
+- Scenario factsheets are now addressable through the REST API: `POST`, `GET`
+  and `PATCH` under `/api/v0/scenario-bundles/<uid>/scenarios/`. A bundle can
+  also be created with its scenarios in a single call, which is what a modelling
+  pipeline needs; a bundle `PATCH` still cannot reach into one, so no call can
+  drop a scenario by leaving it out. Writes use the containing bundle's version
+  and ownership, and a read of a scenario carries the bundle's `ETag`
+
 - New management command `repair_factsheet_tags` repairs the factsheets the old
   tag editor damaged - on production 23 of 339 carry a copy of the whole tag
   table, holding 95% of all factsheet tag assignments. It reports by default and


### PR DESCRIPTION
## Summary of the discussion

Sixth of the twelve OEKG REST API slices, and the last linear one — after it the work
fans into three independent strands. It gives scenario factsheets their own URLs and
lets a bundle be created with its scenarios in one call.

**Why a scenario gets a URL and a framework does not** is decided by the shape rather
than per class: a list of objects carrying its own `oeo:OEO_00390095` (*has uuid*)
becomes a sub-resource; a set of IRIs with labels stays a field. `ex:ScenarioShape`
requires that uuid, `ex:FrameworkShape` does not.

**Two asymmetries carry the slice.**

A bundle `POST` builds its scenarios with it while a bundle `PATCH` cannot reach one.
That is what lets a pipeline create a whole bundle in one call *without* giving any call
the power to drop its parts by omitting them — in a graph an omitted field is
indistinguishable from a deleted one, which is today's data-loss mechanism. The
difference is structural, a serializer subclass for create, not a flag.

And the bundle owns the version, the ownership and the entity tag, because a scenario has
no independent existence to guard. A sub-resource read returns the **bundle's** `ETag`:
anything else would guarantee a `412` on the client's very next call. The accepted cost,
following from one version per bundle, is that two clients editing two *different*
scenarios of one bundle conflict — conflict granularity follows the aggregate root.

## The two things underneath that had to change

**The read went one hop deep.** A scenario is one hop away, but its study region is two
and that region's reference is three. A one-hop read would have returned no regions **and
hidden them from the validator** — so the slice that introduces regions would have shipped
with a post-state check blind to exactly the nodes it adds. It is bounded at three now,
the longest chain the shape permits. Deliberately not a transitive closure: that would be
an unbounded walk on a public endpoint, reachable by anyone who can put a triple in the
graph. A test pins the read and the post-state pruner to the same depth, which is the
diff's subtlest claim.

**The field machinery was wired to the bundle as its subject.** A scenario is the same
problem one level down — a closed set of fields, some literal, some picked from the
shape's own lists, some minted nodes — so `field_triples`, `linked_field_triples`,
`resource_payload` and `resource_delta` now work against a subject and a table. Without
that a scenario would have needed a second copy of the same logic, and the two would have
drifted. Two tables today; at four the machinery should move to a module of its own,
which the docstring says.

Three modules come out of it, because every sub-resource write does the same things in the
same order and gets them wrong the same ways: `writes.py` holds the sequence once,
`reads.py` the bounded read and the label lookup, `preconditions.py` the `If-Match` rules.
The bundle `PATCH` from #2438 rides the same spine rather than keeping a second copy.

## Two defects the review found, both real

Both were reverted and watched failing before the fix was kept.

- **The rename refusal did not see regions.** It was driven by a hardcoded list of bundle
  field names, so a payload could cite an existing region with a different label and be
  accepted — and the response then carried the *stored* label rather than the one sent, so
  the client was quietly told something other than what it asked for. It is driven by the
  field tables now: a list stops covering a table the moment that table gains a node
  field, which is exactly what happened, while the table cannot.
- **An unknown scenario answered `428`/`412` instead of `404`**, because the precondition
  was checked before the part's existence — sending a client to look for a version it
  could not use, for something that is not there. `open_write` is split into `open_bundle`
  and `require_write` so a sub-resource view can put its own existence check between them.

Also from the review: `BundleWrite` no longer describes a write that did not happen
(`post_state` is assigned only after the guard is confirmed, and a second `apply()`
refuses rather than recomputing from a stale pre-state); `Refused` became a DRF exception,
so five views stopped repeating a clause; and the scenario collection is paginated.

## What this slice deliberately does not do

**No `DELETE`.** The spec's endpoint table lists one, but the slice ticket says
`POST`, `GET`, `PATCH` — and removing a part safely is a typed containment walk with a
guard clause whose allowlist *"was already wrong once while it was being drafted"*. It
belongs to its own slice, built once rather than twice.

**No dataset links.** `ex:ScenarioShape` validates *has information input/output*; those
are the next slice's resource. The conformance test **names them as deferred** rather than
passing over them, so that slice deletes a list instead of discovering a gap.

## One consequence worth reading before merging

Validating the post-state now reaches three hops, so **a bundle carrying a pre-existing
shape violation two or three hops out will refuse an otherwise valid `PATCH`**, naming
violations the client did not cause. The live graph is known to carry such violations —
the user interface never types organisations, funders or contact persons.

This follows from WF-05's "validate the post-state, not the diff" and is not this slice's
to overturn. It does change what a deploy feels like: a bundle written only through this
API always conforms and is always patchable; one written through the browser may not be.
Three ways out are written down in the map and **none is decided** — that choice belongs
with whoever owns the live-data cleanup.

## Type of change (CHANGELOG.md)

### Features

- Scenario factsheets are now addressable through the REST API: `POST`, `GET`
  and `PATCH` under `/api/v0/scenario-bundles/<uid>/scenarios/`. A bundle can
  also be created with its scenarios in a single call, which is what a modelling
  pipeline needs; a bundle `PATCH` still cannot reach into one, so no call can
  drop a scenario by leaving it out. Writes use the containing bundle's version
  and ownership, and a read of a scenario carries the bundle's `ETag`

### Changes

- `GET /api/v0/scenario-bundles/<uid>/` now returns its scenarios nested under a
  `scenarios` key. Additive for a reader, and it is what lets a client send back what it
  read — the property the replace endpoint will depend on.

### Bugs

None as a separate entry. Both defects fixed here were introduced and fixed inside this
PR, so recording them would tell a reader of the release notes that something they were
running had failed.

### Removed

None.

### Documentation updates

None, for the third slice running, and the gap is now the map's actual frontier. WF-13
(where the API description comes from) has been the next unblocked ticket since
2026-09-08 and blocks WF-14 and WF-15, while each slice adds endpoints that will have to
be described afterwards and `drf-spectacular` sits on an unmerged branch drifting further
from develop. Worth taking before slice 7.

## Workflow checklist

### Automation

Closes #2443

### PR-Assignee

- [x] 🐙 Follow the workflow in
      [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the
      [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oeplatform/blob/develop/versions/changelogs/current.md)
- [ ] 📙 Update the documentation on
      [mkdocs](https://openenergyplatform.github.io/oeplatform/) — deliberately not done,
      see *Documentation updates* above

### Reviewer

- [x] 🐙 Follow the
      [Reviewer Guidelines](https://github.com/rl-institut/super-repo/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done

---

## Deployment

**No migration, no new dependency, no configuration change.** Unlike #2441, which needed
`factsheet.0012`, this slice adds endpoints only. The standing requirement from #2428 is
unchanged: `python manage.py fetch_oekg_shapes` must have run, or the bundle endpoints
answer `503`.

**Verifying the deploy** — reads are public, so this needs no token:

```
curl -s https://openenergyplatform.org/api/v0/scenario-bundles/<uid>/scenarios/
```

A paginated body with `count`, `next` and `results` means it is live. An empty `results`
on a bundle the browser wrote is correct rather than a fault.

## Reviewer's guide to the diff

Two commits: the slice, then the review's yield.

| File | What to look at |
|---|---|
| `oekg/bundles.py` | The generalisation onto subject + table, and `SCENARIO_FIELDS` beside `BUNDLE_FIELDS`. `BUNDLE_DEPTH` and why it is 3. |
| `oekg/writes.py` | The sequence every mutating endpoint shares: exist, own, precondition, validate the whole bundle, guard, read back, record. `refuse_renames` is table-driven for the reason above. |
| `oekg/reads.py` | The bounded read. `_query` builds one UNION per depth; a test asserts it agrees with the pruner. |
| `oekg/scenario_views.py` | The order in `patch`: bundle exists, **then** the scenario exists, then the precondition. |
| `oekg/serializers.py` | `ScenarioBundleCreateSerializer` is where the create/patch asymmetry lives — a subclass, not a flag. |
| `oekg/tests/test_scenario_api.py` | `SharedRegionTest` and `ScenarioNotFoundTest` are the two defects. `ReadDepthTest` is the depth claim. |

**Tests: 900 green** (850 before this branch), against a real Fuseki and the fetched shape
artifacts. Without a store or artifacts the graph tests skip with a stated reason.
